### PR TITLE
ci(ci-cd): sync Worker secrets on auto-deploy — close #5

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -229,6 +229,8 @@ jobs:
             SENTRY_DSN=${{ secrets.SENTRY_DSN }}
             AXIOM_TOKEN=${{ secrets.AXIOM_TOKEN }}
             CLOUDFLARE_API_TOKEN=${{ secrets.CLOUDFLARE_API_TOKEN }}
+            UPSTASH_REDIS_REST_URL=${{ secrets.UPSTASH_REDIS_REST_URL }}
+            UPSTASH_REDIS_REST_TOKEN=${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
       - name: 🏗️ Build frontend
         working-directory: ${{ env.FRONTEND_DIR }}
@@ -245,6 +247,18 @@ jobs:
           npx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: 🔐 Sync Worker secrets
+        run: |
+          echo "${{ secrets.NEON_DATABASE_URL }}" | npx wrangler secret put DATABASE_URL
+          echo "${{ secrets.JWT_SECRET }}" | npx wrangler secret put JWT_SECRET
+          echo "${{ secrets.UPSTASH_REDIS_REST_URL }}" | npx wrangler secret put UPSTASH_REDIS_REST_URL
+          echo "${{ secrets.UPSTASH_REDIS_REST_TOKEN }}" | npx wrangler secret put UPSTASH_REDIS_REST_TOKEN
+          echo "${{ secrets.SENTRY_DSN }}" | npx wrangler secret put SENTRY_DSN
+          echo "${{ secrets.AXIOM_TOKEN }}" | npx wrangler secret put AXIOM_TOKEN
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: 🚀 Deploy Frontend to production
         working-directory: ${{ env.FRONTEND_DIR }}


### PR DESCRIPTION
## Summary

Closes #5 (filed during PR #4 review). Fixes the one asymmetry left between `ci-cd.yml` and `deploy-production.yml` after the preflight consolidation: rotatable Worker secrets now propagate on the push-to-main auto-deploy the same way they already did on the manual dispatch path.

## Changes

1. **Preflight required-secrets** — added `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` to the `required-secrets` input on `ci-cd.yml`'s `deploy-production` job. Now matches the set that `deploy-production.yml` already enforces.
2. **New `🔐 Sync Worker secrets` step** — runs after `wrangler deploy`, mirrors `deploy-production.yml:99-109` exactly. Pushes `DATABASE_URL`, `JWT_SECRET`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `SENTRY_DSN`, `AXIOM_TOKEN` to the Worker.

Deliberately kept the `echo "..."` pattern from the manual path rather than switching to `printf '%s'` — changing the trailing-newline behavior on a secret that's been working in prod could surprise downstream consumers, and if it's a bug it's a bug in both paths. Out of scope for this PR.

## Why this matters

Before: someone rotates Upstash creds in GitHub Secrets → next auto-deploy runs but Worker keeps bound to stale tokens → Redis failures until someone notices and manually dispatches `deploy-production.yml`.

After: next auto-deploy propagates rotated secrets. Auto-deploy and manual dispatch are now genuinely equivalent — fulfilling the claim PR #4's description made about the composite action.

## Test plan

- [ ] CI green on this branch
- [ ] Confirm step ordering: preflight → build → deploy worker → sync secrets → deploy frontend → source maps
- [ ] (Deferred) First push-to-main after merge will exercise the new step. Watch the run for any `wrangler secret put` failures; Upstash is not on the critical path for most endpoints so a failure here won't immediately break user-facing functionality, but it would warrant a quick rollback of this PR.

## Risk

Low. New step is additive. Worst case: `wrangler secret put` fails and the deploy job errors after `wrangler deploy` has already succeeded — the Worker code is live but with whatever secrets were already bound. Not worse than the current state (where rotated secrets silently don't propagate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)