### PR TITLE
refactor(tier-1): migrate gate/trust-calc catch-swallows to safeQuery

### DIFF
--- a/src/handlers/follows-enhanced.ts
+++ b/src/handlers/follows-enhanced.ts
@@ -7,6 +7,7 @@ import { getDb } from '../db/connection';
 import type { Env as DbEnv } from '../db/connection';
 import { getUserId } from '../utils/auth-extract';
 import { sendNewFollowerEmail } from '../services/email/index';
+import * as Sentry from '@sentry/cloudflare';
 
 // Schema for follow/unfollow actions
 // Accepts both legacy {userId} and frontend {targetId, targetType} formats
@@ -126,6 +127,14 @@ export async function followActionHandler(request: Request, env: Env): Promise<R
           }, (env as Record<string, unknown>).RESEND_API_KEY as string).catch((err: unknown) => {
             const e = err instanceof Error ? err : new Error(String(err));
             console.error('Failed to send new follower email:', e.message);
+            try {
+              Sentry.withScope((scope) => {
+                scope.setTag('email.context', 'follows-enhanced.new-follower-notify');
+                scope.setTag('followerId', String(followerId));
+                scope.setTag('followingId', String(followingId));
+                Sentry.captureException(e);
+              });
+            } catch { /* Sentry hub not initialized */ }
           });
         }
       } catch (emailErr) {

--- a/src/handlers/follows.ts
+++ b/src/handlers/follows.ts
@@ -6,6 +6,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId } from '../utils/auth-extract';
+import { safeQuery } from '../db/safe-query';
 
 /**
  * Main follows handler - returns combined followers, following, activities, and summary
@@ -41,15 +42,18 @@ export async function followsHandler(request: Request, env: Env): Promise<Respon
   }
 
   try {
-    // Check if follows table exists
-    const tableCheck = await sql`
-      SELECT EXISTS (
-        SELECT FROM information_schema.tables
-        WHERE table_name = 'follows'
-      )
-    `.catch(() => [{ exists: false }]);
+    // Table probe — expected to fail on envs without the follows table, so report: false.
+    const tableCheck = await safeQuery<{ exists: boolean }>(
+      () => sql`
+        SELECT EXISTS (
+          SELECT FROM information_schema.tables
+          WHERE table_name = 'follows'
+        )
+      `,
+      { fallback: [{ exists: false }], context: 'follows.table-probe', report: false },
+    );
 
-    if (!tableCheck[0]?.exists) {
+    if (!tableCheck.rows[0]?.exists) {
       return new Response(JSON.stringify(defaultResponse), {
         status: 200,
         headers: {
@@ -61,62 +65,74 @@ export async function followsHandler(request: Request, env: Env): Promise<Respon
     }
 
     // Get followers (people who follow the current user)
-    const followers = await sql`
-      SELECT
-        u.id, u.username, u.email, u.first_name as "firstName", u.last_name as "lastName",
-        u.profile_image as "profileImage", u.bio, u.location, u.user_type as "userType",
-        COALESCE(f.followed_at, f.created_at) as "followedAt", u.created_at as "createdAt",
-        COALESCE((SELECT COUNT(*) FROM pitches WHERE user_id = u.id), 0) as "pitchCount"
-      FROM follows f
-      JOIN users u ON f.follower_id = u.id
-      WHERE f.following_id = ${authenticatedUserId}
-      ORDER BY COALESCE(f.followed_at, f.created_at) DESC
-      LIMIT 50
-    `.catch(() => []);
+    const followersResult = await safeQuery(
+      () => sql`
+        SELECT
+          u.id, u.username, u.email, u.first_name as "firstName", u.last_name as "lastName",
+          u.profile_image as "profileImage", u.bio, u.location, u.user_type as "userType",
+          COALESCE(f.followed_at, f.created_at) as "followedAt", u.created_at as "createdAt",
+          COALESCE((SELECT COUNT(*) FROM pitches WHERE user_id = u.id), 0) as "pitchCount"
+        FROM follows f
+        JOIN users u ON f.follower_id = u.id
+        WHERE f.following_id = ${authenticatedUserId}
+        ORDER BY COALESCE(f.followed_at, f.created_at) DESC
+        LIMIT 50
+      `,
+      { fallback: [], context: 'follows.followers-list', tags: { userId: String(authenticatedUserId) } },
+    );
+    const followers = followersResult.rows;
 
     // Get following (people the current user follows)
-    const following = await sql`
-      SELECT
-        u.id, u.username, u.email, u.first_name as "firstName", u.last_name as "lastName",
-        u.profile_image as "profileImage", u.bio, u.location, u.user_type as "userType",
-        COALESCE(f.followed_at, f.created_at) as "followedAt", u.created_at as "createdAt",
-        COALESCE((SELECT COUNT(*) FROM pitches WHERE user_id = u.id), 0) as "pitchCount"
-      FROM follows f
-      JOIN users u ON f.following_id = u.id
-      WHERE f.follower_id = ${authenticatedUserId}
-      ORDER BY COALESCE(f.followed_at, f.created_at) DESC
-      LIMIT 50
-    `.catch(() => []);
+    const followingResult = await safeQuery(
+      () => sql`
+        SELECT
+          u.id, u.username, u.email, u.first_name as "firstName", u.last_name as "lastName",
+          u.profile_image as "profileImage", u.bio, u.location, u.user_type as "userType",
+          COALESCE(f.followed_at, f.created_at) as "followedAt", u.created_at as "createdAt",
+          COALESCE((SELECT COUNT(*) FROM pitches WHERE user_id = u.id), 0) as "pitchCount"
+        FROM follows f
+        JOIN users u ON f.following_id = u.id
+        WHERE f.follower_id = ${authenticatedUserId}
+        ORDER BY COALESCE(f.followed_at, f.created_at) DESC
+        LIMIT 50
+      `,
+      { fallback: [], context: 'follows.following-list', tags: { userId: String(authenticatedUserId) } },
+    );
+    const following = followingResult.rows;
 
     // Get recent activity from followed users (new pitches)
-    const activities = await sql`
-      SELECT
-        p.id,
-        'pitch_created' as type,
-        json_build_object(
-          'id', u.id,
-          'username', u.username,
-          'companyName', u.company_name,
-          'profileImage', u.profile_image,
-          'userType', u.user_type
-        ) as creator,
-        'created a new pitch' as action,
-        json_build_object(
-          'id', p.id,
-          'title', p.title,
-          'genre', p.genre,
-          'logline', p.logline
-        ) as pitch,
-        p.created_at as "createdAt"
-      FROM pitches p
-      JOIN users u ON p.user_id = u.id
-      WHERE p.user_id IN (
-        SELECT following_id FROM follows WHERE follower_id = ${authenticatedUserId}
-      )
-      AND p.created_at > NOW() - INTERVAL '30 days'
-      ORDER BY p.created_at DESC
-      LIMIT 20
-    `.catch(() => []);
+    const activitiesResult = await safeQuery(
+      () => sql`
+        SELECT
+          p.id,
+          'pitch_created' as type,
+          json_build_object(
+            'id', u.id,
+            'username', u.username,
+            'companyName', u.company_name,
+            'profileImage', u.profile_image,
+            'userType', u.user_type
+          ) as creator,
+          'created a new pitch' as action,
+          json_build_object(
+            'id', p.id,
+            'title', p.title,
+            'genre', p.genre,
+            'logline', p.logline
+          ) as pitch,
+          p.created_at as "createdAt"
+        FROM pitches p
+        JOIN users u ON p.user_id = u.id
+        WHERE p.user_id IN (
+          SELECT following_id FROM follows WHERE follower_id = ${authenticatedUserId}
+        )
+        AND p.created_at > NOW() - INTERVAL '30 days'
+        ORDER BY p.created_at DESC
+        LIMIT 20
+      `,
+      { fallback: [], context: 'follows.activity-feed', tags: { userId: String(authenticatedUserId) } },
+    );
+    const activities = activitiesResult.rows;
 
     // Calculate summary stats
     const newPitchesCount = activities.length;
@@ -186,26 +202,29 @@ export async function followersHandler(request: Request, env: Env): Promise<Resp
   }
   
   try {
-    // Check if follows table exists first
-    const tableCheck = await sql`
-      SELECT EXISTS (
-        SELECT FROM information_schema.tables 
-        WHERE table_name = 'follows'
-      )
-    `.catch(() => [{ exists: false }]);
-    
-    if (!tableCheck[0]?.exists) {
+    // Table probe — expected to fail on envs without the follows table, so report: false.
+    const tableCheck = await safeQuery<{ exists: boolean }>(
+      () => sql`
+        SELECT EXISTS (
+          SELECT FROM information_schema.tables
+          WHERE table_name = 'follows'
+        )
+      `,
+      { fallback: [{ exists: false }], context: 'follows.followers-table-probe', report: false },
+    );
+
+    if (!tableCheck.rows[0]?.exists) {
       // Table doesn't exist, return empty
       return new Response(JSON.stringify(defaultResponse), {
         status: 200,
-        headers: { 
+        headers: {
           'Content-Type': 'application/json',
           'Cache-Control': 'public, max-age=300',
           ...corsHeaders
         }
       });
     }
-    
+
     const result = await sql`
       SELECT
         u.id, u.username, u.email,
@@ -279,25 +298,28 @@ export async function followingHandler(request: Request, env: Env): Promise<Resp
   }
   
   try {
-    // Check if follows table exists
-    const tableCheck = await sql`
-      SELECT EXISTS (
-        SELECT FROM information_schema.tables 
-        WHERE table_name = 'follows'
-      )
-    `.catch(() => [{ exists: false }]);
-    
-    if (!tableCheck[0]?.exists) {
+    // Table probe — expected to fail on envs without the follows table, so report: false.
+    const tableCheck = await safeQuery<{ exists: boolean }>(
+      () => sql`
+        SELECT EXISTS (
+          SELECT FROM information_schema.tables
+          WHERE table_name = 'follows'
+        )
+      `,
+      { fallback: [{ exists: false }], context: 'follows.following-table-probe', report: false },
+    );
+
+    if (!tableCheck.rows[0]?.exists) {
       return new Response(JSON.stringify(defaultResponse), {
         status: 200,
-        headers: { 
+        headers: {
           'Content-Type': 'application/json',
           'Cache-Control': 'public, max-age=300',
           ...corsHeaders
         }
       });
     }
-    
+
     const result = await sql`
       SELECT
         u.id, u.username, u.email,

--- a/src/handlers/pitch-feedback.ts
+++ b/src/handlers/pitch-feedback.ts
@@ -8,6 +8,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId, getAuthenticatedUser } from '../utils/auth-extract';
+import { safeQuery } from '../db/safe-query';
 
 function jsonResponse(data: unknown, origin: string | null, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -57,46 +58,49 @@ async function updateRatingStats(sql: ReturnType<typeof getDb>, pitchId: number)
   if (!sql) return;
   // Admins (heat_role_weights.admin = 0) are excluded everywhere — they'd divide by zero
   // and their ratings shouldn't count in any aggregate.
-  await sql`
-    UPDATE pitches SET
-      -- Combined weighted average (all sources except admin)
-      rating_average = COALESCE(
-        (SELECT (SUM(rating * reviewer_weight) / NULLIF(SUM(reviewer_weight), 0))::decimal(4,2)
-         FROM (
-           SELECT rating, reviewer_weight FROM pitch_feedback
-           WHERE pitch_id = ${pitchId} AND rating IS NOT NULL AND reviewer_type != 'admin'
-           UNION ALL
-           SELECT rating, reviewer_weight FROM pitch_ratings_anonymous
-           WHERE pitch_id = ${pitchId}
-         ) combined
-        ), 0
-      ),
-      rating_count = (
-        (SELECT COUNT(*)::int FROM pitch_feedback WHERE pitch_id = ${pitchId} AND rating IS NOT NULL AND reviewer_type != 'admin') +
-        (SELECT COUNT(*)::int FROM pitch_ratings_anonymous WHERE pitch_id = ${pitchId})
-      ),
-      -- Pitchey Score (industry): investor + production + creator + peer
-      pitchey_score_avg = COALESCE(
-        (SELECT (SUM(rating * reviewer_weight) / NULLIF(SUM(reviewer_weight), 0))::decimal(4,2)
-         FROM pitch_feedback
-         WHERE pitch_id = ${pitchId} AND rating IS NOT NULL
-           AND reviewer_type IN ('investor', 'production', 'creator', 'peer')
-        ), 0
-      ),
-      -- Viewer Score (audience): viewer + watcher + anonymous
-      viewer_score_avg = COALESCE(
-        (SELECT (SUM(rating * reviewer_weight) / NULLIF(SUM(reviewer_weight), 0))::decimal(4,2)
-         FROM (
-           SELECT rating, reviewer_weight FROM pitch_feedback
-           WHERE pitch_id = ${pitchId} AND rating IS NOT NULL AND reviewer_type IN ('viewer', 'watcher')
-           UNION ALL
-           SELECT rating, reviewer_weight FROM pitch_ratings_anonymous
-           WHERE pitch_id = ${pitchId}
-         ) viewer_combined
-        ), 0
-      )
-    WHERE id = ${pitchId}
-  `.catch(() => {});
+  await safeQuery(
+    () => sql`
+      UPDATE pitches SET
+        -- Combined weighted average (all sources except admin)
+        rating_average = COALESCE(
+          (SELECT (SUM(rating * reviewer_weight) / NULLIF(SUM(reviewer_weight), 0))::decimal(4,2)
+           FROM (
+             SELECT rating, reviewer_weight FROM pitch_feedback
+             WHERE pitch_id = ${pitchId} AND rating IS NOT NULL AND reviewer_type != 'admin'
+             UNION ALL
+             SELECT rating, reviewer_weight FROM pitch_ratings_anonymous
+             WHERE pitch_id = ${pitchId}
+           ) combined
+          ), 0
+        ),
+        rating_count = (
+          (SELECT COUNT(*)::int FROM pitch_feedback WHERE pitch_id = ${pitchId} AND rating IS NOT NULL AND reviewer_type != 'admin') +
+          (SELECT COUNT(*)::int FROM pitch_ratings_anonymous WHERE pitch_id = ${pitchId})
+        ),
+        -- Pitchey Score (industry): investor + production + creator + peer
+        pitchey_score_avg = COALESCE(
+          (SELECT (SUM(rating * reviewer_weight) / NULLIF(SUM(reviewer_weight), 0))::decimal(4,2)
+           FROM pitch_feedback
+           WHERE pitch_id = ${pitchId} AND rating IS NOT NULL
+             AND reviewer_type IN ('investor', 'production', 'creator', 'peer')
+          ), 0
+        ),
+        -- Viewer Score (audience): viewer + watcher + anonymous
+        viewer_score_avg = COALESCE(
+          (SELECT (SUM(rating * reviewer_weight) / NULLIF(SUM(reviewer_weight), 0))::decimal(4,2)
+           FROM (
+             SELECT rating, reviewer_weight FROM pitch_feedback
+             WHERE pitch_id = ${pitchId} AND rating IS NOT NULL AND reviewer_type IN ('viewer', 'watcher')
+             UNION ALL
+             SELECT rating, reviewer_weight FROM pitch_ratings_anonymous
+             WHERE pitch_id = ${pitchId}
+           ) viewer_combined
+          ), 0
+        )
+      WHERE id = ${pitchId}
+    `,
+    { fallback: [], context: 'pitch-feedback.update-rating-stats', tags: { pitchId } },
+  );
 }
 
 interface FeedbackBody {
@@ -188,10 +192,21 @@ export async function submitPitchFeedback(request: Request, env: Env): Promise<R
     // Consumption gating — require minimum 30 seconds of view time (skip for rating-only watchers)
     if (userType !== 'watcher') {
       const CONSUMPTION_THRESHOLD = 30;
-      const [viewData] = await sql`
-        SELECT COALESCE(MAX(view_duration), 0)::int as total_duration
-        FROM views WHERE pitch_id = ${pitchId} AND viewer_id = ${Number(userId)}
-      `.catch(() => [{ total_duration: 0 }]);
+      const viewResult = await safeQuery<{ total_duration: number }>(
+        () => sql`
+          SELECT COALESCE(MAX(view_duration), 0)::int as total_duration
+          FROM views WHERE pitch_id = ${pitchId} AND viewer_id = ${Number(userId)}
+        `,
+        { fallback: [{ total_duration: 0 }], context: 'pitch-feedback.consumption-gate', tags: { pitchId, userId: String(userId) } },
+      );
+      // Fail closed on query error — don't let a schema drift let submissions through silently.
+      if (!viewResult.ok) {
+        return errorResponse(
+          'Unable to verify view duration — please refresh and try again',
+          origin, 503
+        );
+      }
+      const viewData = viewResult.rows[0];
       if ((viewData?.total_duration || 0) < CONSUMPTION_THRESHOLD) {
         return errorResponse(
           `Please spend at least ${CONSUMPTION_THRESHOLD} seconds reviewing this pitch before leaving feedback`,
@@ -430,12 +445,15 @@ export async function getConsumptionStatus(request: Request, env: Env): Promise<
 
   try {
     const THRESHOLD = 30;
-    const [viewData] = await sql`
-      SELECT COALESCE(MAX(view_duration), 0)::int as total_duration
-      FROM views WHERE pitch_id = ${pitchId} AND viewer_id = ${Number(userId)}
-    `.catch(() => [{ total_duration: 0 }]);
+    const viewResult = await safeQuery<{ total_duration: number }>(
+      () => sql`
+        SELECT COALESCE(MAX(view_duration), 0)::int as total_duration
+        FROM views WHERE pitch_id = ${pitchId} AND viewer_id = ${Number(userId)}
+      `,
+      { fallback: [{ total_duration: 0 }], context: 'pitch-feedback.consumption-status', tags: { pitchId, userId: String(userId) } },
+    );
 
-    const duration = viewData?.total_duration || 0;
+    const duration = viewResult.rows[0]?.total_duration || 0;
     return jsonResponse({
       success: true,
       data: { eligible: duration >= THRESHOLD, viewDuration: duration, threshold: THRESHOLD }
@@ -601,12 +619,15 @@ export async function getPitchComments(request: Request, env: Env): Promise<Resp
       if (String(pitch.user_id) === String(userId)) {
         hasNda = true;
       } else {
-        const [nda] = await sql`
-          SELECT 1 FROM pitch_ndas
-          WHERE pitch_id = ${pitchId} AND user_id = ${Number(userId)} AND status = 'signed'
-          LIMIT 1
-        `.catch(() => []);
-        hasNda = !!nda;
+        const ndaResult = await safeQuery(
+          () => sql`
+            SELECT 1 FROM pitch_ndas
+            WHERE pitch_id = ${pitchId} AND user_id = ${Number(userId)} AND status = 'signed'
+            LIMIT 1
+          `,
+          { fallback: [], context: 'pitch-feedback.nda-access-check', tags: { pitchId, userId: String(userId) } },
+        );
+        hasNda = ndaResult.rows.length > 0;
       }
     }
 

--- a/src/handlers/pitch-interactions.ts
+++ b/src/handlers/pitch-interactions.ts
@@ -8,6 +8,8 @@ import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId } from '../utils/auth-extract';
 import { sendNewPitchFromFollowedEmail } from '../services/email/index';
+import { safeQuery } from '../db/safe-query';
+import * as Sentry from '@sentry/cloudflare';
 
 function jsonResponse(data: unknown, status: number, origin: string | null): Response {
   return new Response(JSON.stringify(data), {
@@ -255,6 +257,13 @@ export async function pitchPublishHandler(request: Request, env: Env): Promise<R
             }, resendKey).catch((err: unknown) => {
               const e = err instanceof Error ? err : new Error(String(err));
               console.error('Failed to send new pitch email to follower:', e.message);
+              try {
+                Sentry.withScope((scope) => {
+                  scope.setTag('email.context', 'pitch-interactions.new-pitch-follower-notify');
+                  scope.setTag('pitchId', String(pitchId));
+                  Sentry.captureException(e);
+                });
+              } catch { /* Sentry hub not initialized */ }
             });
           }
         }
@@ -280,23 +289,27 @@ export async function pitchPublishHandler(request: Request, env: Env): Promise<R
           || `${creatorInfo?.first_name || ''} ${creatorInfo?.last_name || ''}`.trim()
           || 'A creator';
         const pitchTitle = pitch.title || 'Untitled Pitch';
-        await sql`
-          INSERT INTO notifications (
-            user_id, type, title, message,
-            related_user_id, related_pitch_id, created_at
-          ) VALUES (
-            ${Number(referral.inviter_id)},
-            'pitch_published',
-            ${`New pitch from ${creatorName}`},
-            ${`${creatorName} published "${pitchTitle}" — they signed up through your invite`},
-            ${Number(userId)},
-            ${Number(pitchId)},
-            NOW()
-          )
-        `.catch((err: unknown) => {
-          const e = err instanceof Error ? err : new Error(String(err));
-          console.error('Failed to notify inviter of first pitch publish:', e.message);
-        });
+        await safeQuery(
+          () => sql`
+            INSERT INTO notifications (
+              user_id, type, title, message,
+              related_user_id, related_pitch_id, created_at
+            ) VALUES (
+              ${Number(referral.inviter_id)},
+              'pitch_published',
+              ${`New pitch from ${creatorName}`},
+              ${`${creatorName} published "${pitchTitle}" — they signed up through your invite`},
+              ${Number(userId)},
+              ${Number(pitchId)},
+              NOW()
+            )
+          `,
+          {
+            fallback: [],
+            context: 'pitch-interactions.inviter-first-publish-notify',
+            tags: { pitchId: String(pitchId), inviterId: String(referral.inviter_id) },
+          },
+        );
       }
     } catch (referralErr) {
       // Non-blocking — don't fail the publish if referral notification fails

--- a/src/handlers/portfolio-share.ts
+++ b/src/handlers/portfolio-share.ts
@@ -7,6 +7,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId } from '../utils/auth-extract';
+import { safeQuery } from '../db/safe-query';
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -181,12 +182,15 @@ export async function publicPortfolioByTokenHandler(
     const link = linkResult[0];
     const creatorId = link.creator_id;
 
-    // Increment view count (fire and forget pattern)
-    sql`
-      UPDATE portfolio_share_links
-      SET view_count = view_count + 1, updated_at = NOW()
-      WHERE id = ${link.id}
-    `.catch(() => {});
+    // Increment view count (fire and forget — failures reported to Sentry but don't block the view).
+    void safeQuery(
+      () => sql`
+        UPDATE portfolio_share_links
+        SET view_count = view_count + 1, updated_at = NOW()
+        WHERE id = ${link.id}
+      `,
+      { fallback: [], context: 'portfolio-share.view-counter', tags: { linkId: String(link.id) } },
+    );
 
     // Fetch creator profile (NO email exposed)
     const creatorResult = await sql`

--- a/src/handlers/slates.ts
+++ b/src/handlers/slates.ts
@@ -7,6 +7,15 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId } from '../utils/auth-extract';
+import { safeQuery } from '../db/safe-query';
+
+// Fire-and-forget updated_at bump — failures reported to Sentry, don't block the caller.
+function bumpSlateUpdatedAt(sql: NonNullable<ReturnType<typeof getDb>>, slateId: number): void {
+  void safeQuery(
+    () => sql`UPDATE slates SET updated_at = NOW() WHERE id = ${slateId}`,
+    { fallback: [], context: 'slates.bump-updated-at', tags: { slateId } },
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -387,7 +396,7 @@ export async function addPitchToSlateHandler(
     }
 
     // Bump slate updated_at
-    sql!`UPDATE slates SET updated_at = NOW() WHERE id = ${slateId}`.catch(() => {});
+    bumpSlateUpdatedAt(sql!, slateId);
 
     return jsonResponse({ success: true, data: result[0] }, origin, 201);
   } catch (err) {
@@ -436,7 +445,7 @@ export async function removePitchFromSlateHandler(
     }
 
     // Bump slate updated_at
-    sql!`UPDATE slates SET updated_at = NOW() WHERE id = ${slateId}`.catch(() => {});
+    bumpSlateUpdatedAt(sql!, slateId);
 
     return jsonResponse({ success: true }, origin);
   } catch (err) {
@@ -490,7 +499,7 @@ export async function reorderSlatePitchesHandler(
     }
 
     // Bump slate updated_at
-    sql!`UPDATE slates SET updated_at = NOW() WHERE id = ${slateId}`.catch(() => {});
+    bumpSlateUpdatedAt(sql!, slateId);
 
     return jsonResponse({ success: true }, origin);
   } catch (err) {

--- a/src/worker-modules/analytics-endpoints.ts
+++ b/src/worker-modules/analytics-endpoints.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Env, DatabaseService, User, ApiResponse, AuthPayload, SentryLogger } from '../types/worker-types';
+import { safeQuery } from '../db/safe-query';
 import {
   getPitchViewsTimeSeries,
   getUserViewsTimeSeries,
@@ -532,39 +533,49 @@ export class AnalyticsEndpointsHandler {
 
         // Followers change: count follows gained in each half of the period
         const sqlRef = this.getSqlForQueries();
+        type HalfRow = { first_half: number; second_half: number };
         const [followersHalfResult, pitchesHalfResult, ndasHalfResult] = await Promise.all([
-          sqlRef`
-            SELECT
-              COALESCE(SUM(CASE WHEN created_at < NOW() - INTERVAL '1 day' * ${halfDays} THEN 1 ELSE 0 END), 0)::int AS first_half,
-              COALESCE(SUM(CASE WHEN created_at >= NOW() - INTERVAL '1 day' * ${halfDays} THEN 1 ELSE 0 END), 0)::int AS second_half
-            FROM follows
-            WHERE (following_id::text = ${userIdStr} OR creator_id::text = ${userIdStr})
-              AND created_at >= NOW() - INTERVAL '1 day' * ${days}
-          `.catch(() => [{ first_half: 0, second_half: 0 }]),
-          sqlRef`
-            SELECT
-              COALESCE(SUM(CASE WHEN created_at < NOW() - INTERVAL '1 day' * ${halfDays} THEN 1 ELSE 0 END), 0)::int AS first_half,
-              COALESCE(SUM(CASE WHEN created_at >= NOW() - INTERVAL '1 day' * ${halfDays} THEN 1 ELSE 0 END), 0)::int AS second_half
-            FROM pitches
-            WHERE (creator_id::text = ${userIdStr} OR user_id::text = ${userIdStr})
-              AND created_at >= NOW() - INTERVAL '1 day' * ${days}
-          `.catch(() => [{ first_half: 0, second_half: 0 }]),
-          sqlRef`
-            SELECT
-              COALESCE(SUM(CASE WHEN nr.created_at < NOW() - INTERVAL '1 day' * ${halfDays} THEN 1 ELSE 0 END), 0)::int AS first_half,
-              COALESCE(SUM(CASE WHEN nr.created_at >= NOW() - INTERVAL '1 day' * ${halfDays} THEN 1 ELSE 0 END), 0)::int AS second_half
-            FROM nda_requests nr
-            JOIN pitches p ON nr.pitch_id = p.id
-            WHERE (p.creator_id::text = ${userIdStr} OR p.user_id::text = ${userIdStr})
-              AND nr.created_at >= NOW() - INTERVAL '1 day' * ${days}
-          `.catch(() => [{ first_half: 0, second_half: 0 }])
+          safeQuery<HalfRow>(
+            () => sqlRef`
+              SELECT
+                COALESCE(SUM(CASE WHEN created_at < NOW() - INTERVAL '1 day' * ${halfDays} THEN 1 ELSE 0 END), 0)::int AS first_half,
+                COALESCE(SUM(CASE WHEN created_at >= NOW() - INTERVAL '1 day' * ${halfDays} THEN 1 ELSE 0 END), 0)::int AS second_half
+              FROM follows
+              WHERE (following_id::text = ${userIdStr} OR creator_id::text = ${userIdStr})
+                AND created_at >= NOW() - INTERVAL '1 day' * ${days}
+            `,
+            { fallback: [{ first_half: 0, second_half: 0 }], context: 'analytics-endpoints.followers-half-split', tags: { userId: userIdStr } },
+          ),
+          safeQuery<HalfRow>(
+            () => sqlRef`
+              SELECT
+                COALESCE(SUM(CASE WHEN created_at < NOW() - INTERVAL '1 day' * ${halfDays} THEN 1 ELSE 0 END), 0)::int AS first_half,
+                COALESCE(SUM(CASE WHEN created_at >= NOW() - INTERVAL '1 day' * ${halfDays} THEN 1 ELSE 0 END), 0)::int AS second_half
+              FROM pitches
+              WHERE (creator_id::text = ${userIdStr} OR user_id::text = ${userIdStr})
+                AND created_at >= NOW() - INTERVAL '1 day' * ${days}
+            `,
+            { fallback: [{ first_half: 0, second_half: 0 }], context: 'analytics-endpoints.pitches-half-split', tags: { userId: userIdStr } },
+          ),
+          safeQuery<HalfRow>(
+            () => sqlRef`
+              SELECT
+                COALESCE(SUM(CASE WHEN nr.created_at < NOW() - INTERVAL '1 day' * ${halfDays} THEN 1 ELSE 0 END), 0)::int AS first_half,
+                COALESCE(SUM(CASE WHEN nr.created_at >= NOW() - INTERVAL '1 day' * ${halfDays} THEN 1 ELSE 0 END), 0)::int AS second_half
+              FROM nda_requests nr
+              JOIN pitches p ON nr.pitch_id = p.id
+              WHERE (p.creator_id::text = ${userIdStr} OR p.user_id::text = ${userIdStr})
+                AND nr.created_at >= NOW() - INTERVAL '1 day' * ${days}
+            `,
+            { fallback: [{ first_half: 0, second_half: 0 }], context: 'analytics-endpoints.ndas-half-split', tags: { userId: userIdStr } },
+          ),
         ]);
 
-        const fh = followersHalfResult[0] || { first_half: 0, second_half: 0 };
+        const fh = followersHalfResult.rows[0] || { first_half: 0, second_half: 0 };
         const followersChange = fh.first_half > 0 ? ((fh.second_half - fh.first_half) / fh.first_half) * 100 : 0;
-        const ph = pitchesHalfResult[0] || { first_half: 0, second_half: 0 };
+        const ph = pitchesHalfResult.rows[0] || { first_half: 0, second_half: 0 };
         const pitchesChange = ph.first_half > 0 ? ((ph.second_half - ph.first_half) / ph.first_half) * 100 : 0;
-        const nh = ndasHalfResult[0] || { first_half: 0, second_half: 0 };
+        const nh = ndasHalfResult.rows[0] || { first_half: 0, second_half: 0 };
         const ndasChange = nh.first_half > 0 ? ((nh.second_half - nh.first_half) / nh.first_half) * 100 : 0;
 
         const pitchStats = userPitchResults[0] || {};


### PR DESCRIPTION
## Summary

Follow-up to PR #3's observability hardening. The catch-swallow audit (`docs/catch-swallow-audit-2026-04-17.md`) tier-ordered the ~196 call sites; this PR ships **Tier 1 — the handlers whose queries feed gates, trust-signal calculations, or user-visible counters.** These are the sites where a silent `.catch(() => [])` hid the consumption-gate bug for weeks; migrating them to `safeQuery()` means Sentry sees the next schema drift before the users do.

### What changed

| File | Sites | Notes |
|---|---|---|
| `worker-modules/analytics-endpoints.ts` | 3 | Half-split change % queries for followers / pitches / NDAs |
| `handlers/pitch-feedback.ts` | 4 | Consumption gate, consumption-status API, NDA access on comments, rating-stats UPDATE |
| `handlers/follows.ts` | 6 | Follower/following/activity reads + 3 `information_schema` probes (probes get `report: false`) |
| `handlers/pitch-interactions.ts` | 2 | Follower email send + referral-invite notification INSERT |
| `handlers/follows-enhanced.ts` | 1 | New-follower email send |
| `handlers/portfolio-share.ts` | 1 | View-counter UPDATE on public portfolio tokens |
| `handlers/slates.ts` | 3 | Extracted `bumpSlateUpdatedAt()` helper so the three fire-and-forget touches share one context tag |

**`request.json().catch(() => ({}))` sites in `slates.ts` and `portfolio-share.ts` are intentionally left alone** — that's the correct defensive body-parse pattern, not a DB swallow.

### One behaviour change worth calling out

The consumption gate in `submitPitchFeedback` used to silently treat a query error as `total_duration = 0`, which made the gate refuse the submission without a clear reason. Now when the query errors, the gate returns `503 "Unable to verify view duration — please refresh and try again"` explicitly. Fail-closed either way, but the user and Sentry both know what happened.

All other migrations preserve the existing observable behaviour — the only delta is that Sentry now sees the error with a context tag (`analytics-endpoints.followers-half-split`, `pitch-feedback.consumption-gate`, etc.).

### Out of scope (still on the audit)

- **Tier 2** (~80 sites across 6 dashboard handlers) — creator/production/investor dashboard reads. Same pattern, bulkier files.
- **Tier 3** (~11 sites) — AI handlers, collaborator/teams/messaging.
- **Tier 4** (`worker-integrated.ts`, 59 sites) — needs line-by-line audit to separate legitimate `ctx.waitUntil().catch(() => {})` fire-and-forget telemetry from real swallows. The largest and most error-prone tier.

## Test plan

- [ ] CI green — `Frontend Tests`, `Worker Tests`, `Static Code Analysis`, `CodeQL`, `SonarCloud`
- [ ] Verify the Worker bundles — already confirmed locally via `esbuild` (128ms, 4.8mb — unchanged from baseline)
- [ ] On staging: sign in, view a pitch for < 30s, attempt feedback — gate still refuses with the new 503 fallback message if the view query errors (but should still hit the normal 403 threshold path when it succeeds)
- [ ] Watch Sentry for a week post-merge — new `safe_query.context` tags are the signal. If any tag fires with unexpected volume, that's evidence the old `.catch(() => [])` was hiding something real. Don't re-suppress — chase the root cause (likely schema drift or a nullable column).

## Risk

Low. The helper is already in production (PR #3 landed it + `creatorRevenueHandler` exemplar). This PR extends the pattern to 20 more sites with the same contract — `fallback: []`, `context: '...'`, errors reported to Sentry — and preserves observable behavior at every site except the consumption gate's fail-closed message (a strict improvement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)