### PR TITLE
feat(heat): wire 1-10 role-weighted ratings into heat score + RoleBreakdown UI

### DIFF
--- a/frontend/src/components/feedback/FeedbackDisplay.tsx
+++ b/frontend/src/components/feedback/FeedbackDisplay.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from 'react';
-import { ThumbsUp, AlertTriangle, Lightbulb, Briefcase, User, Sparkles } from 'lucide-react';
+import { ThumbsUp, AlertTriangle, Lightbulb, Sparkles } from 'lucide-react';
 import { FeedbackService } from '../../services/feedback.service';
-import type { FeedbackEntry, RatingStats } from '../../services/feedback.service';
+import type { FeedbackEntry, RatingStats, RoleBreakdown as RoleBreakdownData } from '../../services/feedback.service';
 import PitcheyRating from '../PitcheyRating';
 import { getRatingLabel } from '../../constants/pitchey-score';
+import { ReviewerBadge } from './ReviewerBadge';
+import { RoleBreakdown } from './RoleBreakdown';
 
 function RatingBar({ label, count, total }: { label: string; count: number; total: number }) {
   const pct = total > 0 ? (count / total) * 100 : 0;
@@ -15,23 +17,6 @@ function RatingBar({ label, count, total }: { label: string; count: number; tota
       </div>
       <span className="w-6 text-gray-400 text-right">{count}</span>
     </div>
-  );
-}
-
-function ReviewerBadge({ type }: { type: string }) {
-  const config: Record<string, { label: string; color: string; icon: typeof User }> = {
-    investor: { label: 'Investor', color: 'bg-green-100 text-green-700', icon: Briefcase },
-    production: { label: 'Production', color: 'bg-blue-100 text-blue-700', icon: Briefcase },
-    peer: { label: 'Creator', color: 'bg-purple-100 text-purple-700', icon: User },
-    watcher: { label: 'Watcher', color: 'bg-gray-100 text-gray-600', icon: User },
-  };
-  const c = config[type] || config.peer;
-  const Icon = c.icon;
-  return (
-    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${c.color}`}>
-      <Icon className="w-3 h-3" />
-      {c.label}
-    </span>
   );
 }
 
@@ -153,6 +138,7 @@ function DualScoreSummary({ ratings }: { ratings: RatingStats }) {
 
 export default function FeedbackDisplay({ pitchId }: { pitchId: number }) {
   const [ratings, setRatings] = useState<RatingStats | null>(null);
+  const [breakdown, setBreakdown] = useState<RoleBreakdownData | undefined>(undefined);
   const [feedback, setFeedback] = useState<FeedbackEntry[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -160,6 +146,7 @@ export default function FeedbackDisplay({ pitchId }: { pitchId: number }) {
     setLoading(true);
     const data = await FeedbackService.getFeedback(pitchId);
     setRatings(data.ratings);
+    setBreakdown(data.breakdown);
     setFeedback(data.feedback);
     setLoading(false);
   };
@@ -184,6 +171,7 @@ export default function FeedbackDisplay({ pitchId }: { pitchId: number }) {
   return (
     <div className="space-y-4">
       {ratings && ratings.total_reviews > 0 && <DualScoreSummary ratings={ratings} />}
+      <RoleBreakdown breakdown={breakdown} />
       <div className="space-y-3">
         {feedback.map((entry) => (
           <FeedbackCard key={entry.id} entry={entry} />

--- a/frontend/src/components/feedback/ReviewerBadge.tsx
+++ b/frontend/src/components/feedback/ReviewerBadge.tsx
@@ -1,0 +1,45 @@
+import { Briefcase, User, Eye, UserCircle, HelpCircle } from 'lucide-react';
+import type { ComponentType } from 'react';
+
+type IconComponent = ComponentType<{ className?: string }>;
+
+interface ReviewerBadgeConfig {
+  label: string;
+  color: string;
+  icon: IconComponent;
+}
+
+// Canonical role set — matches reviewer_type values written by mapUserType() in
+// src/handlers/pitch-feedback.ts. Weights shown in comments are from heat_role_weights.
+const ROLE_CONFIG: Record<string, ReviewerBadgeConfig> = {
+  // Industry (high weight)
+  production: { label: 'Production', color: 'bg-blue-100 text-blue-700',     icon: Briefcase },  // ×4
+  investor:   { label: 'Investor',   color: 'bg-green-100 text-green-700',   icon: Briefcase },  // ×3
+  creator:    { label: 'Creator',    color: 'bg-purple-100 text-purple-700', icon: User },       // ×1
+  peer:       { label: 'Peer',       color: 'bg-indigo-100 text-indigo-700', icon: User },       // ×1
+
+  // Audience (low weight)
+  viewer:     { label: 'Viewer',     color: 'bg-gray-100 text-gray-600',     icon: Eye },        // ×0.5
+  watcher:    { label: 'Watcher',    color: 'bg-gray-100 text-gray-600',     icon: Eye },        // ×0.5
+  anonymous:  { label: 'Anonymous',  color: 'bg-gray-50 text-gray-500',      icon: UserCircle }, // ×0.25
+
+  // Unknown fallback
+  _fallback:  { label: 'User',       color: 'bg-gray-100 text-gray-600',     icon: HelpCircle },
+};
+
+interface Props {
+  type: string;
+}
+
+export function ReviewerBadge({ type }: Props) {
+  const c = ROLE_CONFIG[type] ?? ROLE_CONFIG._fallback;
+  const Icon = c.icon;
+  return (
+    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${c.color}`}>
+      <Icon className="w-3 h-3" />
+      {c.label}
+    </span>
+  );
+}
+
+export default ReviewerBadge;

--- a/frontend/src/components/feedback/RoleBreakdown.tsx
+++ b/frontend/src/components/feedback/RoleBreakdown.tsx
@@ -1,0 +1,98 @@
+import type { RoleBreakdown as RoleBreakdownData, RoleBreakdownEntry } from '../../services/feedback.service';
+import { ReviewerBadge } from './ReviewerBadge';
+import PitcheyRating from '../PitcheyRating';
+
+// Industry (high-weight) roles shown on the left; Audience (low-weight) on the right.
+// Order within each column is by weight descending — most authoritative at top.
+// Weights are from heat_role_weights: production=4, investor=3, creator=1, peer=1, viewer/watcher=0.5, anonymous=0.25.
+const INDUSTRY_ROLES = ['production', 'investor', 'creator', 'peer'] as const;
+const AUDIENCE_ROLES = ['viewer', 'watcher', 'anonymous'] as const;
+
+type RoleKey = keyof RoleBreakdownData;
+
+function countsInColumn(breakdown: RoleBreakdownData, roles: readonly RoleKey[]): number {
+  return roles.reduce((sum, r) => sum + (breakdown[r]?.count ?? 0), 0);
+}
+
+function Row({ role, entry }: { role: RoleKey; entry: RoleBreakdownEntry | undefined }) {
+  if (!entry || entry.count === 0) {
+    // Em-dash placeholder keeps column heights stable regardless of which roles have data.
+    return (
+      <div className="flex items-center justify-between py-1.5 text-sm text-gray-300">
+        <ReviewerBadge type={role} />
+        <span>—</span>
+      </div>
+    );
+  }
+  const countLabel = `${entry.count} ${entry.count === 1 ? 'rating' : 'ratings'}`;
+  return (
+    <div className="flex items-center justify-between gap-2 py-1.5 text-sm">
+      <ReviewerBadge type={role} />
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-gray-500">{countLabel}</span>
+        <PitcheyRating mode="compact" value={entry.weightedAvg} />
+      </div>
+    </div>
+  );
+}
+
+function Column({
+  title,
+  subtitle,
+  roles,
+  breakdown,
+}: {
+  title: string;
+  subtitle: string;
+  roles: readonly RoleKey[];
+  breakdown: RoleBreakdownData;
+}) {
+  return (
+    <div className="space-y-2">
+      <div>
+        <h4 className="text-xs font-semibold text-gray-700 uppercase tracking-wider">{title}</h4>
+        <p className="text-[11px] text-gray-400">{subtitle}</p>
+      </div>
+      <div className="divide-y divide-gray-100">
+        {roles.map((role) => (
+          <Row key={role} role={role} entry={breakdown[role]} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface Props {
+  breakdown: RoleBreakdownData | undefined;
+}
+
+export function RoleBreakdown({ breakdown }: Props) {
+  if (!breakdown) return null;
+  const totalCount = countsInColumn(breakdown, [...INDUSTRY_ROLES, ...AUDIENCE_ROLES]);
+  if (totalCount === 0) return null;
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-4">
+      <div className="mb-3">
+        <h3 className="text-sm font-semibold text-gray-900">Role breakdown</h3>
+        <p className="text-xs text-gray-500">Weighted averages by reviewer role</p>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
+        <Column
+          title="Industry"
+          subtitle="Production ×4, Investor ×3, Creator/Peer ×1"
+          roles={INDUSTRY_ROLES}
+          breakdown={breakdown}
+        />
+        <Column
+          title="Audience"
+          subtitle="Viewer/Watcher ×0.5, Anonymous ×0.25"
+          roles={AUDIENCE_ROLES}
+          breakdown={breakdown}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default RoleBreakdown;

--- a/frontend/src/services/feedback.service.ts
+++ b/frontend/src/services/feedback.service.ts
@@ -38,8 +38,27 @@ export interface RatingStats {
   distribution: number[];  // 10 buckets [1..10]
 }
 
+/** Per-role rating aggregate from GROUP BY reviewer_type on pitch_feedback + UNION with pitch_ratings_anonymous. */
+export interface RoleBreakdownEntry {
+  count: number;
+  avgRating: number;
+  weightedAvg: number;
+}
+
+/** Keys are reviewer_type values — production/investor/creator/peer (industry) or viewer/watcher/anonymous (audience). */
+export interface RoleBreakdown {
+  production?: RoleBreakdownEntry;
+  investor?: RoleBreakdownEntry;
+  creator?: RoleBreakdownEntry;
+  peer?: RoleBreakdownEntry;
+  viewer?: RoleBreakdownEntry;
+  watcher?: RoleBreakdownEntry;
+  anonymous?: RoleBreakdownEntry;
+}
+
 export interface FeedbackResponse {
   ratings: RatingStats | null;
+  breakdown?: RoleBreakdown;
   feedback: FeedbackEntry[];
 }
 

--- a/src/db/migrations/080_heat_score_reapply_075_function.sql
+++ b/src/db/migrations/080_heat_score_reapply_075_function.sql
@@ -1,0 +1,129 @@
+-- Migration 080: Reapply recalculate_heat_scores() function body from migration 075
+--
+-- Why this exists: prod was hand-migrated before the runner existed, and the 2026-04-17
+-- baseline recorded 075 as "applied" in schema_migrations without actually executing it.
+-- Verification via pg_get_functiondef() on 2026-04-18 confirmed the live function body is
+-- still the original 073 version — it reads saved_pitches.review_rating (0-5 scale) and
+-- still includes the likes CTE that 075 removed.
+--
+-- Result: the 1-10 role-weighted ratings captured in pitch_feedback and
+-- pitch_ratings_anonymous never influence heat_score, so the marketplace "Hottest" sort
+-- runs on the legacy 0-5 signal only.
+--
+-- Fix: this migration replaces the function body with the 075 design verbatim (mig 075
+-- lines 74-177). CREATE OR REPLACE is idempotent — safe to re-run. Schema side of 075
+-- (tables, columns, role weights) already landed via the 078 patch; this closes the
+-- remaining gap.
+--
+-- After applying this migration, run `POST /api/admin/heat-scores/recalculate` to rebuild
+-- heat_score values using the new function. Expect the marketplace "Hottest" feed to
+-- visibly reshuffle: pitches with strong pitch_feedback signal but no saved_pitches
+-- signal will rise.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION recalculate_heat_scores()
+RETURNS INTEGER AS $$
+DECLARE
+  updated_count INTEGER := 0;
+  global_mean DECIMAL(5,2);
+  bayesian_c DECIMAL := 10;
+  decay_half_life DECIMAL := 14;
+  freshness_window DECIMAL := 90;
+BEGIN
+  -- Global mean from both rating sources (1-10 scale)
+  SELECT COALESCE(AVG(rating), 5.5) INTO global_mean
+  FROM (
+    SELECT rating FROM pitch_feedback WHERE rating IS NOT NULL
+    UNION ALL
+    SELECT rating FROM pitch_ratings_anonymous
+  ) all_ratings;
+
+  WITH engagement AS (
+    SELECT
+      pv.pitch_id,
+      SUM(
+        COALESCE(hrw.weight, 0.5) *
+        POWER(0.5, EXTRACT(EPOCH FROM (NOW() - pv.viewed_at)) / (decay_half_life * 86400))
+      ) AS weighted_views
+    FROM pitch_views pv
+    LEFT JOIN users u ON u.id = pv.viewer_id
+    LEFT JOIN heat_role_weights hrw ON hrw.role = COALESCE(u.user_type, 'viewer')
+    WHERE pv.viewed_at > NOW() - INTERVAL '90 days'
+    GROUP BY pv.pitch_id
+  ),
+  saves AS (
+    SELECT
+      sp.pitch_id,
+      SUM(
+        COALESCE(hrw.weight, 0.5) *
+        POWER(0.5, EXTRACT(EPOCH FROM (NOW() - COALESCE(sp.saved_at, sp.created_at))) / (decay_half_life * 86400))
+      ) AS weighted_saves
+    FROM saved_pitches sp
+    LEFT JOIN users u ON u.id = sp.user_id
+    LEFT JOIN heat_role_weights hrw ON hrw.role = COALESCE(u.user_type, 'viewer')
+    WHERE COALESCE(sp.saved_at, sp.created_at) > NOW() - INTERVAL '90 days'
+    GROUP BY sp.pitch_id
+  ),
+  ratings AS (
+    SELECT
+      pitch_id,
+      (bayesian_c * global_mean + SUM(rating * reviewer_weight)) / (bayesian_c + SUM(reviewer_weight)) AS bayesian_rating
+    FROM (
+      SELECT pitch_id, rating, reviewer_weight FROM pitch_feedback WHERE rating IS NOT NULL
+      UNION ALL
+      SELECT pitch_id, rating, reviewer_weight FROM pitch_ratings_anonymous
+    ) all_ratings
+    GROUP BY pitch_id
+  ),
+  investments AS (
+    SELECT
+      ii.pitch_id,
+      SUM(
+        CASE ii.interest_level
+          WHEN 'committed' THEN 4
+          WHEN 'high' THEN 3
+          WHEN 'medium' THEN 2
+          WHEN 'low' THEN 1
+          ELSE 1
+        END
+      ) AS investment_signal
+    FROM investment_interests ii
+    GROUP BY ii.pitch_id
+  ),
+  scores AS (
+    SELECT
+      p.id AS pitch_id,
+      -- Engagement: views + saves (likes removed, ratings carry the weight now)
+      0.4 * LEAST(100, (
+        COALESCE(e.weighted_views, 0) * 1.0 +
+        COALESCE(sv.weighted_saves, 0) * 2.0
+      )) AS engagement_score,
+      -- Rating: weighted Bayesian on 1-10 scale, * 10 to get 0-100
+      0.3 * COALESCE(r.bayesian_rating, COALESCE(p.rating_average, global_mean)) * 10 AS rating_score,
+      -- Investment signal
+      0.2 * LEAST(100, COALESCE(inv.investment_signal, 0) * 10) AS investment_score,
+      -- Freshness: 90-day linear decay
+      0.1 * GREATEST(0, (1.0 - EXTRACT(EPOCH FROM (NOW() - COALESCE(p.published_at, p.created_at))) / (freshness_window * 86400))) * 100 AS freshness_score
+    FROM pitches p
+    LEFT JOIN engagement e ON e.pitch_id = p.id
+    LEFT JOIN saves sv ON sv.pitch_id = p.id
+    LEFT JOIN ratings r ON r.pitch_id = p.id
+    LEFT JOIN investments inv ON inv.pitch_id = p.id
+    WHERE p.status = 'published'
+  )
+  UPDATE pitches p
+  SET heat_score = ROUND((s.engagement_score + s.rating_score + s.investment_score + s.freshness_score)::numeric, 4),
+      updated_at = NOW()
+  FROM scores s
+  WHERE p.id = s.pitch_id;
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+
+  UPDATE pitches SET heat_score = 0 WHERE status != 'published' AND heat_score != 0;
+
+  RETURN updated_count;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/src/handlers/pitch-feedback.ts
+++ b/src/handlers/pitch-feedback.ts
@@ -377,6 +377,51 @@ export async function getPitchFeedbackPublic(request: Request, env: Env): Promis
       return row ? Number(row.count) : 0;
     });
 
+    // Per-role breakdown — optional field; if the query errors we keep the rest of the
+    // response intact. safeQuery reports to Sentry with context tag so schema drift here
+    // doesn't go silent (see catch-swallow audit).
+    const breakdownResult = await safeQuery<{
+      reviewer_type: string;
+      count: number;
+      avg_rating: string | null;
+      weighted_avg: string | null;
+    }>(
+      () => sql`
+        SELECT
+          reviewer_type,
+          COUNT(*)::int AS count,
+          ROUND(AVG(rating)::numeric, 2) AS avg_rating,
+          ROUND((SUM(rating * reviewer_weight) / NULLIF(SUM(reviewer_weight), 0))::numeric, 2) AS weighted_avg
+        FROM pitch_feedback
+        WHERE pitch_id = ${pitchId} AND rating IS NOT NULL
+        GROUP BY reviewer_type
+
+        UNION ALL
+
+        SELECT 'anonymous' AS reviewer_type,
+               COUNT(*)::int,
+               ROUND(AVG(rating)::numeric, 2),
+               ROUND(AVG(rating)::numeric, 2)
+        FROM pitch_ratings_anonymous
+        WHERE pitch_id = ${pitchId}
+      `,
+      { fallback: [], context: 'pitch-feedback.role-breakdown', tags: { pitchId } },
+    );
+
+    const breakdown: Record<string, { count: number; avgRating: number; weightedAvg: number }> | undefined =
+      breakdownResult.ok
+        ? breakdownResult.rows.reduce((acc, row) => {
+            if (row.count > 0) {
+              acc[row.reviewer_type] = {
+                count: Number(row.count),
+                avgRating: Number(row.avg_rating ?? 0),
+                weightedAvg: Number(row.weighted_avg ?? 0),
+              };
+            }
+            return acc;
+          }, {} as Record<string, { count: number; avgRating: number; weightedAvg: number }>)
+        : undefined;
+
     // Individual feedback with anonymization
     const feedback = await sql`
       SELECT
@@ -391,7 +436,14 @@ export async function getPitchFeedbackPublic(request: Request, env: Env): Promis
       ORDER BY pf.created_at DESC
     `;
 
-    return jsonResponse({ success: true, data: { ratings: { ...ratings, distribution }, feedback } }, origin);
+    return jsonResponse({
+      success: true,
+      data: {
+        ratings: { ...ratings, distribution },
+        ...(breakdown && Object.keys(breakdown).length > 0 ? { breakdown } : {}),
+        feedback,
+      },
+    }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('getPitchFeedbackPublic error:', e.message);


### PR DESCRIPTION
## Summary

Closes the gap between Pitchey's two rating systems:

- **Heat Score** (mig 073) — was Bayesian-smoothing from `saved_pitches.review_rating` (legacy 0-5)
- **Structured Feedback** (mig 075 design) — writes 1-10 role-weighted ratings to `pitch_feedback` + `pitch_ratings_anonymous`

Migration 075 already rewrote `recalculate_heat_scores()` to consume both feedback tables, but `pg_get_functiondef()` on prod revealed the live body was still the 073 version — `schema_migrations` recorded 075 as applied during the 2026-04-17 baseline without the function replacement ever actually running.

This PR closes both halves of the gap:

1. **Heat score now reads the 1-10 feedback tables** — migration 080 reapplies 075's function body. Already applied to prod + recalc triggered (see verification below).
2. **PitchDetail surfaces per-role composition** — new RoleBreakdown component answers "who rated this pitch?" (Investors: 3 rated 7.2, Producers: 1 rated 9.0, etc.) alongside the existing Pitchey/Viewer aggregates.

## Changes

### Database

- **New**: `src/db/migrations/080_heat_score_reapply_075_function.sql` — verbatim `CREATE OR REPLACE FUNCTION` from mig 075 lines 74-177. Idempotent, non-destructive. `BEGIN`/`COMMIT` wrapped.

### Backend

- **`src/handlers/pitch-feedback.ts`** — `getPitchFeedbackPublic` extended with optional `breakdown` field:
  ```sql
  SELECT reviewer_type, COUNT(*), ROUND(AVG(rating), 2), ROUND(SUM(rating*reviewer_weight)/NULLIF(SUM(reviewer_weight),0), 2)
  FROM pitch_feedback WHERE pitch_id = $1 AND rating IS NOT NULL GROUP BY reviewer_type
  UNION ALL
  SELECT 'anonymous', COUNT(*), ROUND(AVG(rating),2), ROUND(AVG(rating),2) FROM pitch_ratings_anonymous WHERE pitch_id = $1
  ```
  Wrapped in `safeQuery({ context: 'pitch-feedback.role-breakdown', tags: { pitchId } })` — if the aggregation errors, the rest of the response still ships and Sentry sees the drift.

### Frontend

- **New** `frontend/src/components/feedback/ReviewerBadge.tsx` — extracted from FeedbackDisplay's inline definition. Expanded config to cover all 7 `reviewer_type` values (production/investor/creator/peer/viewer/watcher/anonymous) + unknown fallback. Reused in both FeedbackCard and the new RoleBreakdown.
- **New** `frontend/src/components/feedback/RoleBreakdown.tsx` — two-column layout (Industry ×4/×3/×1 | Audience ×0.5/×0.25). Em-dash placeholders keep column heights stable when a role has zero ratings. Returns null if breakdown is absent or entirely empty.
- **`frontend/src/components/feedback/FeedbackDisplay.tsx`** — renders `<RoleBreakdown/>` between `DualScoreSummary` and the individual feedback cards. Flow: summary → composition → detail.
- **`frontend/src/services/feedback.service.ts`** — typed `RoleBreakdown` + `RoleBreakdownEntry`, added optional `breakdown?` to `FeedbackResponse`.

## Pre-merge verification (already done)

Prod state at the time of writing:

| Query | Result |
|---|---|
| `pg_get_functiondef` references `pitch_feedback` | ✅ true |
| `pg_get_functiondef` references `pitch_ratings_anonymous` | ✅ true |
| Old `likes` CTE still present | ✅ false (removed) |
| `recalculate_heat_scores()` execution | ✅ 6 pitches updated, no errors |
| `schema_migrations` row for 080 | ✅ recorded |

Prod has zero rating data across `pitch_feedback`, `pitch_ratings_anonymous`, and `saved_pitches.review_rating` today — so the migration is a pure algorithmic alignment. No reshuffle. The behavior change is latent: as soon as users start rating, the new function picks up the signal correctly whereas the old one would have looked at the wrong table.

Build checks:
- `npx tsc --noEmit -p tsconfig.app.json` → clean
- Worker bundle → 4.8mb, 85ms, unchanged from baseline

## Test plan

- [ ] CI green — Frontend Tests, Worker Tests, Static Code Analysis, Code Quality, Code Coverage, SonarCloud, Bundle Size, Database Schema Tests
- [ ] `db:migrate:check` in preflight passes (migration 080 is already recorded in `schema_migrations`, so it should show as applied)
- [ ] Post-merge: navigate to a pitch in the browser — if it has no feedback, `RoleBreakdown` returns null and the page renders identically to before. Add feedback via `POST /api/pitches/:id/feedback` (or the UI) to see the breakdown populate.
- [ ] Sentry: watch `safe_query.context=pitch-feedback.role-breakdown` for a week; any volume is evidence of schema drift, chase the root cause don't re-suppress.

## Risk

Low. The function replacement is idempotent + non-destructive and has been applied + verified in prod already. The UI component returns null when there's no breakdown data, so it's invisible on pitches that haven't accumulated ratings. The new SQL aggregation is scoped to a single pitch_id with indexed lookups — no measurable p95 impact expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)