### PR TITLE
hotfix(ci): unbreak main deploy — composite action description was evaluating as expression

### DIFF
--- a/.github/actions/deploy-preflight/action.yml
+++ b/.github/actions/deploy-preflight/action.yml
@@ -13,8 +13,13 @@ inputs:
     required: false
     default: ""
     description: >
-      Newline-separated list of "NAME=${{ secrets.NAME }}" entries. Any entry
-      with an empty value fails the preflight. Omit to skip the secret gate.
+      Newline-separated list of "NAME=<secret value>" entries — callers should
+      pass each required secret via the expression syntax (see ci-cd.yml for an
+      example). Any entry with an empty value fails the preflight. Omit to skip
+      the secret gate. DO NOT inline GitHub Actions expression syntax here —
+      the YAML parser evaluates this description string at action-load time
+      and will fail with "Unrecognized named-value" because the secrets context
+      isn't available in action metadata scope.
 
 runs:
   using: composite


### PR DESCRIPTION
## Summary

**Main is broken.** The auto-deploy from PR #10's merge failed at the preflight step with:

```
Unrecognized named-value: 'secrets'.
Located at position 1 within expression: secrets.NAME
/home/runner/.../.github/actions/deploy-preflight/action.yml (Line: 15, Col: 18)
```

## Root cause

I shipped this in PR #4. The `required-secrets` input description contained literal `\${{ secrets.NAME }}` as prose text documenting the expected caller-side expression syntax. GitHub's YAML parser evaluates that string at **action-load time** — where the `secrets` context is not available in action metadata scope — and fails with the error above.

## Why it only surfaced now

Every main-branch auto-deploy since PR #4 merged would have hit this, but the bug was **latent**: the `deploy-production` job in `ci-cd.yml` is gated by `if: github.ref == 'refs/heads/main'`, so PR CI runs skipped the composite action invocation entirely. The first actual invocation was the PR #10 merge auto-deploy a few minutes ago, which exposed it immediately.

`deploy-production.yml` (manual dispatch) uses the same composite action and would have hit this too the moment someone ran it manually — we just got lucky nobody had tried yet today.

## Fix

Rewrite the description as literal prose with angle-bracket placeholders (`<secret value>`) instead of Actions expression syntax. Added a warning comment inside the description block so nobody re-introduces the `\${{ }}` form.

```yaml
description: >
  Newline-separated list of "NAME=<secret value>" entries — callers should
  pass each required secret via the expression syntax (see ci-cd.yml for an
  example). Any entry with an empty value fails the preflight. Omit to skip
  the secret gate. DO NOT inline GitHub Actions expression syntax here —
  the YAML parser evaluates this description string at action-load time
  and will fail with "Unrecognized named-value" because the secrets context
  isn't available in action metadata scope.
```

The input **value** passed by callers (in `ci-cd.yml` and `deploy-production.yml`) is unchanged — it continues to use `\${{ secrets.NAME }}` because at workflow runtime that context IS available. Only the prose inside the schema description was the problem.

## Test plan

- [ ] CI green on this branch
- [ ] After merge: next push-to-main triggers `deploy-production` job — expect the preflight step to **load the composite action successfully** (previously errored on validation) and proceed to the migrations + secrets check
- [ ] Optional: manually dispatch `deploy-production.yml` to verify the manual path also loads the action

## Risk

Zero runtime risk — this is a prose-only change inside action metadata. The fix unblocks deploys that were broken by the action failing to load entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)