### PR TITLE
chore(deps): zod v3 → v4 + better-auth-cloudflare 0.3.0 (closes #15)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"33f96bd8-dc04-4569-ab70-79df577ef29e","pid":6576,"acquiredAt":1776535736887}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"33f96bd8-dc04-4569-ab70-79df577ef29e","pid":6576,"acquiredAt":1776535736887}

--- a/.github/workflows/neon-preview.yml
+++ b/.github/workflows/neon-preview.yml
@@ -72,7 +72,16 @@ jobs:
       - name: Deploy Worker preview
         run: |
           npm install -g wrangler
-          wrangler deploy --name pitchey-pr-${{ github.event.pull_request.number }} --env preview
+          # Previously: `--env preview` — but no [env.preview] block exists in
+          # wrangler.toml, so wrangler silently fell back to top-level config
+          # where ENVIRONMENT="production". That tripped the AXIOM_TOKEN
+          # hard-require gate in worker-integrated.ts and 503'd every request.
+          # Override ENVIRONMENT via --var so the gate sees "preview" and skips
+          # the check. Axiom logging is a no-op without the token, which is fine
+          # for an ephemeral preview that tears down on PR close.
+          wrangler deploy \
+            --name pitchey-pr-${{ github.event.pull_request.number }} \
+            --var ENVIRONMENT:preview
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/neon-preview.yml
+++ b/.github/workflows/neon-preview.yml
@@ -47,8 +47,11 @@ jobs:
           cd frontend
           npm run build
         env:
-          VITE_API_URL: https://pitchey-pr-${{ github.event.pull_request.number }}.workers.dev
-          VITE_WS_URL: wss://pitchey-pr-${{ github.event.pull_request.number }}.workers.dev
+          # Worker URLs must include the account subdomain (ndlovucavelle.workers.dev),
+          # not the bare workers.dev which doesn't resolve. Matches the production pattern
+          # used by the live deploy (see worker routes in wrangler.toml).
+          VITE_API_URL: https://pitchey-pr-${{ github.event.pull_request.number }}.ndlovucavelle.workers.dev
+          VITE_WS_URL: wss://pitchey-pr-${{ github.event.pull_request.number }}.ndlovucavelle.workers.dev
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
       
       - name: Deploy preview to Cloudflare Pages
@@ -63,7 +66,7 @@ jobs:
           deploymentName: pr-${{ github.event.pull_request.number }}
           wranglerVersion: '3'
         env:
-          VITE_API_URL: https://pitchey-pr-${{ github.event.pull_request.number }}.workers.dev
+          VITE_API_URL: https://pitchey-pr-${{ github.event.pull_request.number }}.ndlovucavelle.workers.dev
           DATABASE_URL: ${{ steps.create-branch.outputs.db_url_with_pooler }}
           
       - name: Deploy Worker preview

--- a/.github/workflows/neon-preview.yml
+++ b/.github/workflows/neon-preview.yml
@@ -134,12 +134,16 @@ jobs:
             
             ### Useful Commands
             \`\`\`bash
-            # Connect to preview database
-            psql "${{ steps.create-branch.outputs.db_url_with_pooler }}"
-            
+            # Connect to preview database — password in Neon console or via:
+            #   neonctl cs <branch-id> --project-id $NEON_PROJECT_ID --role-name neondb_owner
+            psql --host=${dbHost} --username=neondb_owner --dbname=neondb
+
             # View logs
             wrangler tail --name pitchey-pr-${prNumber}
             \`\`\`
+
+            > **Note:** The connection password is intentionally NOT printed in this comment.
+            > A prior version of this workflow leaked the full DSN — fixed in commit after.
             
             ---
             *This preview will be automatically deleted when the PR is merged or closed.*`;

--- a/.github/workflows/neon-preview.yml
+++ b/.github/workflows/neon-preview.yml
@@ -80,13 +80,22 @@ jobs:
           # branch (not prod data), and JWT/UPSTASH are isolated to the preview
           # worker's name. No --env flag (no [env.preview] block exists, and the
           # fallback to top-level config is what we want).
+          # BETTER_AUTH_SECRET is NOT in GH secrets — on production it's set via
+          # `wrangler secret put BETTER_AUTH_SECRET` directly on the prod worker.
+          # For preview we use a fixed throwaway value since each preview worker
+          # is ephemeral (torn down on PR close) and only reaches a preview Neon
+          # branch with demo data. Real prod sessions can't be forged with this
+          # because they sign against the real BETTER_AUTH_SECRET on pitchey-api-prod.
           wrangler deploy \
             --name pitchey-pr-${{ github.event.pull_request.number }} \
             --var ENVIRONMENT:preview \
             --var DATABASE_URL:"$DATABASE_URL" \
             --var JWT_SECRET:"$JWT_SECRET" \
+            --var BETTER_AUTH_SECRET:"preview-only-throwaway-secret-32chars-min-abc123xyz789" \
             --var UPSTASH_REDIS_REST_URL:"$UPSTASH_REDIS_REST_URL" \
-            --var UPSTASH_REDIS_REST_TOKEN:"$UPSTASH_REDIS_REST_TOKEN"
+            --var UPSTASH_REDIS_REST_TOKEN:"$UPSTASH_REDIS_REST_TOKEN" \
+            --var ENCRYPTION_KEY:"$ENCRYPTION_KEY" \
+            --var MFA_SECRET:"$MFA_SECRET"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -94,6 +103,8 @@ jobs:
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
           UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
+          ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
+          MFA_SECRET: ${{ secrets.MFA_SECRET }}
       
       - name: Comment PR with preview links
         uses: actions/github-script@v7

--- a/.github/workflows/neon-preview.yml
+++ b/.github/workflows/neon-preview.yml
@@ -72,16 +72,21 @@ jobs:
       - name: Deploy Worker preview
         run: |
           npm install -g wrangler
-          # Previously: `--env preview` — but no [env.preview] block exists in
-          # wrangler.toml, so wrangler silently fell back to top-level config
-          # where ENVIRONMENT="production". That tripped the AXIOM_TOKEN
-          # hard-require gate in worker-integrated.ts and 503'd every request.
-          # Override ENVIRONMENT via --var so the gate sees "preview" and skips
-          # the check. Axiom logging is a no-op without the token, which is fine
-          # for an ephemeral preview that tears down on PR close.
+          # GH Actions `env:` passes vars to the wrangler PROCESS, not to the
+          # deployed Worker's runtime bindings. For the Worker to see these at
+          # runtime we pass them via `--var` at deploy time. Everything is
+          # plaintext in the CF dashboard, which is acceptable for an ephemeral
+          # preview that tears down on PR close — DATABASE_URL is a preview Neon
+          # branch (not prod data), and JWT/UPSTASH are isolated to the preview
+          # worker's name. No --env flag (no [env.preview] block exists, and the
+          # fallback to top-level config is what we want).
           wrangler deploy \
             --name pitchey-pr-${{ github.event.pull_request.number }} \
-            --var ENVIRONMENT:preview
+            --var ENVIRONMENT:preview \
+            --var DATABASE_URL:"$DATABASE_URL" \
+            --var JWT_SECRET:"$JWT_SECRET" \
+            --var UPSTASH_REDIS_REST_URL:"$UPSTASH_REDIS_REST_URL" \
+            --var UPSTASH_REDIS_REST_TOKEN:"$UPSTASH_REDIS_REST_TOKEN"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,12 +17,12 @@
         "axios": "^1.15.0",
         "bcryptjs": "^3.0.3",
         "better-auth": "^1.4.9",
-        "better-auth-cloudflare": "^0.2.9",
+        "better-auth-cloudflare": "^0.3.0",
         "playwright": "^1.57.0",
         "postgres": "3.4.4",
         "prom-client": "^15.1.0",
         "resend": "^6.6.0",
-        "zod": "^3.24.1"
+        "zod": "^4.3.4"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.0.0",
@@ -60,6 +60,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@better-auth/core": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.5.tgz",
+      "integrity": "sha512-T3u4rVsJcMWShG2qfQUlU1HdkQGLYX0+lcR48QV2Cp2kpBOLOTYdt+p6zZtGm2Omx/ReEouRQyKy7pYtahRQuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.39.0",
+        "@standard-schema/spec": "^1.1.0",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21",
+        "@cloudflare/workers-types": ">=4",
+        "@opentelemetry/api": "^1.9.0",
+        "better-call": "1.3.5",
+        "jose": "^6.1.0",
+        "kysely": "^0.28.5",
+        "nanostores": "^1.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/drizzle-adapter": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.5.tgz",
+      "integrity": "sha512-9YjPW35+h66D+QA+YqEJ9pFP97ClLFR+QrTPZojkeP0PTYqpW0ErBK3p1pwRTJG88yK+o3Y4yOwoacMTBxz0jQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.5",
+        "@better-auth/utils": "0.4.0",
+        "drizzle-orm": "^0.45.2"
+      },
+      "peerDependenciesMeta": {
+        "drizzle-orm": {
+          "optional": true
+        }
       }
     },
     "node_modules/@better-auth/utils": {
@@ -191,7 +233,6 @@
       "version": "4.20260418.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260418.1.tgz",
       "integrity": "sha512-bywXb2XmeSqrLCQYipcupLneqx015YhhNWz2v9b9iatpe8Cg551vP7ZuD5S2a6GfBka0dDnO70kIBiBvFglcrg==",
-      "devOptional": true,
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1597,23 +1638,219 @@
       }
     },
     "node_modules/better-auth-cloudflare": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/better-auth-cloudflare/-/better-auth-cloudflare-0.2.9.tgz",
-      "integrity": "sha512-hGnDPxkdD01jjtKmha19EJ3CJGERHFVgqL3sT8b6BMy94AnbnU8lIpQLYdteAw95JEDTBuXWdpHjy/Fqqr2HNg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/better-auth-cloudflare/-/better-auth-cloudflare-0.3.0.tgz",
+      "integrity": "sha512-u0TrMbFhHNL2IFzkCbCQYyA/beeBSivdL+vfrNywYnsVrQO1qT5CC/yKhnRdrkwXLeNi9tCeoSwWoygTMSl0Yg==",
       "license": "MIT",
       "dependencies": {
-        "drizzle-orm": "^0.44.5",
+        "drizzle-orm": "^0.45.0",
         "mime": "^4.1.0",
-        "zod": "^4.1.5"
+        "zod": "^4.3.0"
       },
       "peerDependencies": {
-        "better-auth": "^1.1.21"
+        "@better-auth/drizzle-adapter": "^1.5.0",
+        "@cloudflare/workers-types": "^4.0.0",
+        "better-auth": "^1.5.0"
       }
     },
-    "node_modules/better-auth-cloudflare/node_modules/drizzle-orm": {
-      "version": "0.44.7",
-      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.44.7.tgz",
-      "integrity": "sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ==",
+    "node_modules/better-auth-cloudflare/node_modules/mime": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
+      "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
+      "license": "MIT",
+      "bin": {
+        "mime": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/kysely-adapter": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.5.tgz",
+      "integrity": "sha512-kbevd70qzKNR3ZHF7q6/e0XXYRCXanLB2rvmTd3T8WbNEd9kYMqKjgTGNxL1ri5N+PEDUK6zfHx/HrvaEOfoHw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.5",
+        "@better-auth/utils": "0.4.0",
+        "kysely": "^0.28.14"
+      },
+      "peerDependenciesMeta": {
+        "kysely": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/memory-adapter": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.5.tgz",
+      "integrity": "sha512-5qFUpSdQi+RwHSmNyHMSsJIrFjed8d/ASS61L2xyW7sjBLTIuR7JcgS6hif5cQbtPeq+Qz+Wct5q8oKw33qyqQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.5",
+        "@better-auth/utils": "0.4.0"
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/mongo-adapter": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.5.tgz",
+      "integrity": "sha512-HvOUFTiSEFSGTzL/vE3FntTwQiZ79O/V+QcsCimR+65Bj3tOqdFaC1G2Yd1dQ9l2YHNXA9SNBrGekbk66RzJMw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.5",
+        "@better-auth/utils": "0.4.0",
+        "mongodb": "^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mongodb": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/prisma-adapter": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.5.tgz",
+      "integrity": "sha512-d7PUO5XoimYYDEG/DoYVbOSbyVYJBDuZgvY9pjf8INccBTCD1BzcyEJ9NQil4huXWj4fcNaGOt2FG0OI8NtWOA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.5",
+        "@better-auth/utils": "0.4.0",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@prisma/client": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/@better-auth/telemetry": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.5.tgz",
+      "integrity": "sha512-Ag3CjAP+tLretKPq+pYdU/gU4pFIcey/AoNQzw671wV5JQZXrMitS65INi8j8QuYfol2xgQrht5KVlcxGrkhHQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.5",
+        "@better-auth/utils": "0.4.0",
+        "@better-fetch/fetch": "1.1.21"
+      }
+    },
+    "node_modules/better-call": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.5.tgz",
+      "integrity": "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@better-auth/utils": "^0.4.0",
+        "@better-fetch/fetch": "^1.1.21",
+        "rou3": "^0.7.12",
+        "set-cookie-parser": "^3.0.1"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/drizzle-orm": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
+      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
@@ -1733,260 +1970,6 @@
         "sqlite3": {
           "optional": true
         }
-      }
-    },
-    "node_modules/better-auth-cloudflare/node_modules/mime": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
-      "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
-      "funding": [
-        "https://github.com/sponsors/broofa"
-      ],
-      "license": "MIT",
-      "bin": {
-        "mime": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/better-auth-cloudflare/node_modules/zod": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
-      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/better-auth/node_modules/@better-auth/core": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.5.tgz",
-      "integrity": "sha512-T3u4rVsJcMWShG2qfQUlU1HdkQGLYX0+lcR48QV2Cp2kpBOLOTYdt+p6zZtGm2Omx/ReEouRQyKy7pYtahRQuA==",
-      "license": "MIT",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.39.0",
-        "@standard-schema/spec": "^1.1.0",
-        "zod": "^4.3.6"
-      },
-      "peerDependencies": {
-        "@better-auth/utils": "0.4.0",
-        "@better-fetch/fetch": "1.1.21",
-        "@cloudflare/workers-types": ">=4",
-        "@opentelemetry/api": "^1.9.0",
-        "better-call": "1.3.5",
-        "jose": "^6.1.0",
-        "kysely": "^0.28.5",
-        "nanostores": "^1.0.1"
-      },
-      "peerDependenciesMeta": {
-        "@cloudflare/workers-types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/better-auth/node_modules/@better-auth/drizzle-adapter": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.5.tgz",
-      "integrity": "sha512-9YjPW35+h66D+QA+YqEJ9pFP97ClLFR+QrTPZojkeP0PTYqpW0ErBK3p1pwRTJG88yK+o3Y4yOwoacMTBxz0jQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.5",
-        "@better-auth/utils": "0.4.0",
-        "drizzle-orm": "^0.45.2"
-      },
-      "peerDependenciesMeta": {
-        "drizzle-orm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/better-auth/node_modules/@better-auth/kysely-adapter": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.5.tgz",
-      "integrity": "sha512-kbevd70qzKNR3ZHF7q6/e0XXYRCXanLB2rvmTd3T8WbNEd9kYMqKjgTGNxL1ri5N+PEDUK6zfHx/HrvaEOfoHw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.5",
-        "@better-auth/utils": "0.4.0",
-        "kysely": "^0.28.14"
-      },
-      "peerDependenciesMeta": {
-        "kysely": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/better-auth/node_modules/@better-auth/memory-adapter": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.5.tgz",
-      "integrity": "sha512-5qFUpSdQi+RwHSmNyHMSsJIrFjed8d/ASS61L2xyW7sjBLTIuR7JcgS6hif5cQbtPeq+Qz+Wct5q8oKw33qyqQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.5",
-        "@better-auth/utils": "0.4.0"
-      }
-    },
-    "node_modules/better-auth/node_modules/@better-auth/mongo-adapter": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.5.tgz",
-      "integrity": "sha512-HvOUFTiSEFSGTzL/vE3FntTwQiZ79O/V+QcsCimR+65Bj3tOqdFaC1G2Yd1dQ9l2YHNXA9SNBrGekbk66RzJMw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.5",
-        "@better-auth/utils": "0.4.0",
-        "mongodb": "^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "mongodb": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/better-auth/node_modules/@better-auth/prisma-adapter": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.5.tgz",
-      "integrity": "sha512-d7PUO5XoimYYDEG/DoYVbOSbyVYJBDuZgvY9pjf8INccBTCD1BzcyEJ9NQil4huXWj4fcNaGOt2FG0OI8NtWOA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.5",
-        "@better-auth/utils": "0.4.0",
-        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
-        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@prisma/client": {
-          "optional": true
-        },
-        "prisma": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/better-auth/node_modules/@better-auth/telemetry": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.5.tgz",
-      "integrity": "sha512-Ag3CjAP+tLretKPq+pYdU/gU4pFIcey/AoNQzw671wV5JQZXrMitS65INi8j8QuYfol2xgQrht5KVlcxGrkhHQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@better-auth/core": "^1.6.5",
-        "@better-auth/utils": "0.4.0",
-        "@better-fetch/fetch": "1.1.21"
-      }
-    },
-    "node_modules/better-auth/node_modules/better-call": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.5.tgz",
-      "integrity": "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==",
-      "license": "MIT",
-      "dependencies": {
-        "@better-auth/utils": "^0.4.0",
-        "@better-fetch/fetch": "^1.1.21",
-        "rou3": "^0.7.12",
-        "set-cookie-parser": "^3.0.1"
-      },
-      "peerDependencies": {
-        "zod": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/better-auth/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/bintrees": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
-      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
-      "license": "MIT"
-    },
-    "node_modules/blake3-wasm": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
-      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/defu": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
-      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
-      "license": "MIT"
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -2873,9 +2856,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -53,12 +53,12 @@
     "axios": "^1.15.0",
     "bcryptjs": "^3.0.3",
     "better-auth": "^1.4.9",
-    "better-auth-cloudflare": "^0.2.9",
+    "better-auth-cloudflare": "^0.3.0",
     "playwright": "^1.57.0",
     "postgres": "3.4.4",
     "prom-client": "^15.1.0",
     "resend": "^6.6.0",
-    "zod": "^3.24.1"
+    "zod": "^4.3.4"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.0.0",

--- a/src/handlers/contracts.ts
+++ b/src/handlers/contracts.ts
@@ -17,8 +17,8 @@ const CreateContractSchema = z.object({
     role: z.enum(['creator', 'investor', 'production', 'platform']),
     signatureRequired: z.boolean().default(true),
   })),
-  variables: z.record(z.any()).default({}),
-  metadata: z.record(z.any()).optional(),
+  variables: z.record(z.string(), z.any()).default({}),
+  metadata: z.record(z.string(), z.any()).optional(),
 });
 
 const SignContractSchema = z.object({

--- a/src/handlers/legal-document-automation.ts
+++ b/src/handlers/legal-document-automation.ts
@@ -16,7 +16,7 @@ import LegalPDFGenerator, { PDFGenerationOptions } from '../services/legal-pdf-g
 
 const generateDocumentSchema = z.object({
   template_id: z.string().uuid(),
-  variables: z.record(z.any()),
+  variables: z.record(z.string(), z.any()),
   jurisdiction: z.enum(['US', 'UK', 'EU', 'CA', 'AU']),
   parties: z.array(z.object({
     id: z.string().optional(),
@@ -44,7 +44,7 @@ const generateDocumentSchema = z.object({
 const customizeDocumentSchema = z.object({
   document_id: z.string().uuid(),
   updates: z.object({
-    variables: z.record(z.any()).optional(),
+    variables: z.record(z.string(), z.any()).optional(),
     custom_clauses: z.array(z.object({
       title: z.string(),
       content: z.string(),
@@ -58,7 +58,7 @@ const customizeDocumentSchema = z.object({
 const validateDocumentSchema = z.object({
   document_id: z.string().uuid().optional(),
   template_id: z.string().uuid().optional(),
-  variables: z.record(z.any()),
+  variables: z.record(z.string(), z.any()),
   jurisdiction: z.enum(['US', 'UK', 'EU', 'CA', 'AU']),
   validation_level: z.enum(['basic', 'compliance', 'full']).default('compliance')
 });
@@ -253,7 +253,7 @@ export class LegalDocumentHandler {
         return new Response(JSON.stringify({
           success: false,
           error: 'Invalid request data',
-          details: validation.error.errors
+          details: validation.error.issues
         }), {
           status: 400,
           headers: { 'Content-Type': 'application/json' }
@@ -481,7 +481,7 @@ export class LegalDocumentHandler {
         return new Response(JSON.stringify({
           success: false,
           error: 'Invalid request data',
-          details: validation.error.errors
+          details: validation.error.issues
         }), {
           status: 400,
           headers: { 'Content-Type': 'application/json' }

--- a/src/handlers/messaging.ts
+++ b/src/handlers/messaging.ts
@@ -12,7 +12,7 @@ const CreateConversationSchema = z.object({
   participantIds: z.array(z.string().uuid()),
   type: z.enum(['direct', 'group', 'pitch_discussion', 'investment_chat']).default('direct'),
   name: z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 });
 
 const SendMessageSchema = z.object({
@@ -27,7 +27,7 @@ const SendMessageSchema = z.object({
     thumbnailUrl: z.string().url().optional(),
   })).optional(),
   replyTo: z.string().uuid().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 });
 
 const EditMessageSchema = z.object({

--- a/src/handlers/notification-routes.ts
+++ b/src/handlers/notification-routes.ts
@@ -25,7 +25,7 @@ const SendNotificationSchema = z.object({
   actionUrl: z.string().optional(),
   actionText: z.string().max(100).optional(),
   expiresAt: z.string().datetime().optional(),
-  variables: z.record(z.any()).default({}),
+  variables: z.record(z.string(), z.any()).default({}),
   channels: z.object({
     email: z.boolean().optional(),
     push: z.boolean().optional(),

--- a/src/handlers/notifications.ts
+++ b/src/handlers/notifications.ts
@@ -25,7 +25,7 @@ const SendNotificationSchema = z.object({
   actionUrl: z.string().url().optional(),
   actionText: z.string().max(100).optional(),
   expiresAt: z.string().datetime().optional(),
-  variables: z.record(z.any()).default({}),
+  variables: z.record(z.string(), z.any()).default({}),
   channels: z.object({
     email: z.boolean().optional(),
     push: z.boolean().optional(),

--- a/src/routes/ab-testing.routes.ts
+++ b/src/routes/ab-testing.routes.ts
@@ -32,10 +32,10 @@ const createExperimentSchema = z.object({
     name: z.string().min(1).max(255),
     description: z.string().optional(),
     trafficAllocation: z.number().min(0).max(1),
-    config: z.record(z.any())
+    config: z.record(z.string(), z.any())
   })).min(2),
   trafficAllocation: z.number().min(0).max(1),
-  targetingRules: z.record(z.any()).default({}),
+  targetingRules: z.record(z.string(), z.any()).default({}),
   userSegments: z.array(z.string()).default([]),
   primaryMetric: z.string().min(1).max(100),
   secondaryMetrics: z.array(z.string()).default([]),
@@ -56,7 +56,7 @@ const assignmentRequestSchema = z.object({
     userAgent: z.string().optional(),
     ipAddress: z.string().optional(),
     referrer: z.string().optional(),
-    customProperties: z.record(z.any()).optional()
+    customProperties: z.record(z.string(), z.any()).optional()
   })
 });
 
@@ -73,7 +73,7 @@ const trackEventSchema = z.object({
   eventData: z.object({
     eventName: z.string().optional(),
     eventValue: z.number().optional(),
-    properties: z.record(z.any()).optional(),
+    properties: z.record(z.string(), z.any()).optional(),
     url: z.string().optional(),
     elementId: z.string().optional(),
     elementText: z.string().optional()
@@ -86,7 +86,7 @@ const featureFlagRequestSchema = z.object({
     userId: z.number().optional(),
     sessionId: z.string().optional(),
     userType: z.string().optional(),
-    customProperties: z.record(z.any()).optional()
+    customProperties: z.record(z.string(), z.any()).optional()
   }),
   defaultValue: z.any()
 });

--- a/src/routes/feature-flags.routes.ts
+++ b/src/routes/feature-flags.routes.ts
@@ -26,7 +26,7 @@ const featureFlagSchema = z.object({
     operator: z.enum(['equals', 'contains', 'greater_than', 'less_than', 'in', 'not_in']),
     value: z.any()
   })).optional(),
-  metadata: z.record(z.any()).optional()
+  metadata: z.record(z.string(), z.any()).optional()
 });
 
 const evaluateRequestSchema = z.object({
@@ -36,7 +36,7 @@ const evaluateRequestSchema = z.object({
     email: z.string().email().optional(),
     role: z.string().optional(),
     subscription: z.string().optional(),
-    attributes: z.record(z.any()).optional(),
+    attributes: z.record(z.string(), z.any()).optional(),
     segment: z.string().optional()
   }).optional()
 });

--- a/src/routes/notification.routes.ts
+++ b/src/routes/notification.routes.ts
@@ -75,7 +75,7 @@ const preferencesSchema = z.object({
   pushEnabled: z.boolean().optional(),
   smsEnabled: z.boolean().optional(),
   inAppEnabled: z.boolean().optional(),
-  typePreferences: z.record(z.boolean()).optional(),
+  typePreferences: z.record(z.string(), z.boolean()).optional(),
   quietHoursEnabled: z.boolean().optional(),
   quietHoursStart: z.string().regex(/^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/).optional(),
   quietHoursEnd: z.string().regex(/^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/).optional(),
@@ -179,7 +179,7 @@ const testNotificationSchema = z.object({
   title: z.string().optional(),
   message: z.string().optional(),
   priority: z.enum(["low", "medium", "high", "urgent"]).optional(),
-  metadata: z.record(z.any()).optional()
+  metadata: z.record(z.string(), z.any()).optional()
 });
 
 notificationRoutes.post(

--- a/src/services/worker-database.ts
+++ b/src/services/worker-database.ts
@@ -534,5 +534,5 @@ export const DatabaseSchemas = {
   id: z.number().int().positive(),
   email: z.string().email(),
   url: z.string().url(),
-  jsonObject: z.record(z.unknown()),
+  jsonObject: z.record(z.string(), z.unknown()),
 };

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -134,7 +134,7 @@ export const InvestmentSchema = z.object({
 export const ApiSuccessSchema = <T extends z.ZodType>(dataSchema: T) => z.object({
   success: z.literal(true),
   data: dataSchema,
-  meta: z.record(z.any()).optional()
+  meta: z.record(z.string(), z.any()).optional()
 });
 
 export const ApiErrorSchema = z.object({
@@ -196,7 +196,7 @@ export const NotificationSchema = z.object({
   ]),
   title: z.string(),
   message: z.string(),
-  data: z.record(z.any()).optional(),
+  data: z.record(z.string(), z.any()).optional(),
   read: z.boolean().default(false),
   createdAt: z.string().datetime()
 });
@@ -212,9 +212,9 @@ export const PitchAnalyticsSchema = z.object({
   averageViewTime: z.number(), // in seconds
   conversionRate: z.number(), // percentage
   demographics: z.object({
-    byUserType: z.record(z.number()),
-    byLocation: z.record(z.number()),
-    byDevice: z.record(z.number())
+    byUserType: z.record(z.string(), z.number()),
+    byLocation: z.record(z.string(), z.number()),
+    byDevice: z.record(z.string(), z.number())
   }),
   engagement: z.object({
     clickThroughRate: z.number(),

--- a/src/support/ticket-system.ts
+++ b/src/support/ticket-system.ts
@@ -37,11 +37,11 @@ export enum TicketStatus {
 // Ticket schema
 export const TicketSchema = z.object({
   id: z.string().uuid(),
-  userType: z.nativeEnum(UserType),
+  userType: z.enum(UserType),
   userId: z.string(),
-  category: z.nativeEnum(TicketCategory),
-  priority: z.nativeEnum(TicketPriority),
-  status: z.nativeEnum(TicketStatus),
+  category: z.enum(TicketCategory),
+  priority: z.enum(TicketPriority),
+  status: z.enum(TicketStatus),
   title: z.string().min(5).max(200),
   description: z.string().min(10).max(2000),
   attachments: z.array(z.string()).optional(),


### PR DESCRIPTION
Closes #15. Ready for review.

## Summary

Root workspace was on `zod@^3.24.1` while frontend already ran `zod@^4.3.4`. This aligns them and unblocks the `better-auth-cloudflare` semver-major bump that #15 tracked. Net effect: GHSA-gpj5-g38j-94v9 (drizzle-orm SQL injection) is resolved **transitively** — `better-auth-cloudflare@0.3.0` pulls `drizzle-orm@0.45.2`, the patched version.

## Numbers

|  | Before | After |
|---|---|---|
| `npm audit` high-severity (root) | 2 | **0** |
| Backend `tsc` errors | 9 (baseline) | 9 (same baseline, zero new) |
| Frontend `tsc` errors | 0 | 0 |
| First-party drizzle imports | 0 (from PR #14) | 0 |
| Transitive drizzle-orm version | 0.44.7 (vulnerable) | **0.45.2 (patched)** |

## Dependency changes

`package.json`:
```diff
-"better-auth-cloudflare": "^0.2.9",
+"better-auth-cloudflare": "^0.3.0",
-"zod": "^3.24.1"
+"zod": "^4.3.4"
```

Transitive (lockfile only):
- `better-auth`: 1.4.9 → 1.6.5
- `drizzle-orm`: 0.44.7 → 0.45.2 (patched; advisory closed)
- New transitives: `@better-auth/{drizzle,kysely,memory,mongo,prisma}-adapter@1.6.5`, `@better-auth/core@1.6.5`, `better-call@1.3.5`

## Zod v4 migration — all mechanical

1. **`z.record(X)` → `z.record(z.string(), X)`** — 19 sites across 7 files
2. **`ZodError.error.errors` → `.error.issues`** — 2 sites in `legal-document-automation.ts`
3. **`z.nativeEnum(X)` → `z.enum(X)`** — 4 sites in `support/ticket-system.ts`

Incidental: narrowed `ReturnType<typeof neon>` → `ReturnType<typeof neon<false, false>>` in `company-verification.service.ts` (latent type issue surfaced by the install).

## Validation — what was actually tested

Preview environment was stood up for this PR. Browser smoke-test blocked by infrastructure gaps (tracked in **Issue #18** — CSP hardcoded to production Worker URL, Pages deploys landing on orphan `pitchey-5o8` project, etc). Pivoted to **curl validation against the preview Worker** directly:

- ✅ `POST /api/auth/sign-in` for creator / investor / production — all 200, cookies set with correct flags (`SameSite=None; Secure; HttpOnly`)
- ✅ `GET /api/auth/session` with cookie — 200, user data returned
- ✅ `POST /api/auth/sign-out` — cookie cleared, subsequent session check 401
- ✅ Session row written to DB on login, deleted on logout
- ✅ zod v4 `ValidationSchemas.userLogin.parse(body)` in the login handler — no errors, validates as expected

## What this PR does NOT validate

**The Better Auth 1.4.9 → 1.6.5 runtime bump was not exercised.** Discovered during smoke-test investigation:

- `src/worker-integrated.ts:795` — `// Initialize Better Auth adapter (commented out - causing runtime error)` — has been disabled since commit `41850ea1` on 2025-12-18
- The `/api/auth/sign-in` handler calls `handlePortalLogin`, which queries the legacy `users`/`sessions` tables directly. Better Auth's `session` / `user` / `account` / `verification` tables remain empty after login.
- Verified via DB inspection during the curl smoke test: `session` (BA) had 0 rows before and after 3 logins; `sessions` (legacy) incremented as expected.

**So the better-auth version bump in this PR is effectively a type-definition update**, not a runtime change. The risk surface of "does BA 1.6.5 break auth" is zero because BA isn't running. The risk surface of "does zod v4 break validation" is real and was tested end-to-end.

This broader finding is tracked in **Issue #19** (BA adapter disabled, docs describe a system that isn't running) — decision on whether to rip it out, migrate onto it properly, or document-and-leave is deferred to next week.

## Test plan

- [x] `npm audit`: 0 high-severity (down from 2)
- [x] `grep -rnE "z\.record\([^,)]+\)" src/` — zero single-arg matches
- [x] `grep -rn "z\.nativeEnum" src/` — zero
- [x] Backend `tsc --noEmit` — 9 errors, all pre-existing baseline in `handlers/slates.ts` (8) and `handlers/pitch-feedback.ts` (1). Zero introduced by this change.
- [x] Frontend `tsc --noEmit` — 0 errors
- [x] Curl sign-in / session / sign-out against preview Worker — all pass
- [x] Zod v4 request validation — exercised via `ValidationSchemas.userLogin.parse`

## Housekeeping (separate commits on this branch)

- `f86b003` — fix preview `VITE_API_URL` (account subdomain was missing)
- `d2b6c00` — bypass `AXIOM_TOKEN` gate in preview via `ENVIRONMENT=preview`
- `cca5a13` — pass `BETTER_AUTH_SECRET` + `ENCRYPTION_KEY` + `MFA_SECRET` as --vars to preview worker
- `6c6ad32` — stop leaking preview DB password in auto-posted PR comment

These are preview-infrastructure fixes discovered while trying to smoke-test this PR. They benefit all future preview deploys. Related to (but not solving) the broader issues in #18.

## Risk

- **Zod v4 migration**: low. All changes are mechanical and well-understood v4 patterns; type-check + curl validation cover the real surface. Pre-existing tsc errors unchanged.
- **Drizzle transitive bump**: zero runtime risk on Pitchey's first-party code (no drizzle imports remain); closes a CVE on a transitive dep used internally by better-auth-cloudflare.
- **Better-auth 1.4.9 → 1.6.5 transitive bump**: zero runtime risk because the adapter isn't wired up (see Issue #19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)