### PR TITLE
chore: complete URL consolidation missed by PR #14

### DIFF
--- a/.claude/agents/cloudflare-deployer.md
+++ b/.claude/agents/cloudflare-deployer.md
@@ -30,7 +30,7 @@ You are a Cloudflare deployment specialist for the Pitchey platform. Your expert
 ## Critical Configuration
 
 - **API URL**: https://pitchey-api-prod.ndlovucavelle.workers.dev
-- **Frontend**: https://pitchey-5o8.pages.dev
+- **Frontend**: https://pitchey.pages.dev
 - **Database**: Neon via Hyperdrive (raw SQL, no ORM)
 - **Cache**: Upstash Redis
 - **Storage**: Cloudflare R2

--- a/.claude/agents/frontend-debugger.md
+++ b/.claude/agents/frontend-debugger.md
@@ -39,7 +39,7 @@ You are an expert React/TypeScript frontend debugger for Pitchey, a three-portal
 ## Common Pitfalls
 - Auth flicker: sessionCache.ts prevents this — check if cache is being bypassed
 - CORS errors: API Workers are on different subdomains — verify credentials: 'include' in fetch calls
-- CORS origins: must match across pitchey-5o8.pages.dev, pitchey.com, www.pitchey.com
+- CORS origins: must match across pitchey.pages.dev, pitchey.com, www.pitchey.com
 - Cookie not sent: SameSite=None requires Secure flag AND https
 - Portal routing: RBAC redirects happen client-side based on user_type from session
 - Vite env vars must be prefixed with VITE_

--- a/.claude/agents/worker-debugger.md
+++ b/.claude/agents/worker-debugger.md
@@ -31,7 +31,7 @@ REQUEST -> Tracing -> CORS Preflight -> WebSocket Upgrade Detection -> Health Ch
 2. Trace the request through the lifecycle above — identify which stage fails
 3. Check wrangler.toml for binding configuration (KV, R2, Durable Objects, Hyperdrive)
 4. For auth issues: trace cookie -> KV session lookup -> Better Auth validation -> RBAC check
-5. For CORS: verify allowed origins include pitchey-5o8.pages.dev, pitchey.com, www.pitchey.com
+5. For CORS: verify allowed origins include pitchey.pages.dev, pitchey.com, www.pitchey.com
 6. For database errors: check raw SQL query syntax and parameterization
 7. For route errors: check RouteRegistry in worker-integrated.ts
 8. Implement fix and verify with `npx wrangler dev`
@@ -50,7 +50,7 @@ REQUEST -> Tracing -> CORS Preflight -> WebSocket Upgrade Detection -> Health Ch
 
 ## Common Issues
 - CORS: Worker must return Access-Control-Allow-Origin matching the requesting origin
-- CORS must allow: pitchey-5o8.pages.dev, pitchey.com, www.pitchey.com
+- CORS must allow: pitchey.pages.dev, pitchey.com, www.pitchey.com
 - CORS credentials: Access-Control-Allow-Credentials: true required for cookie auth
 - Session cookie: pitchey-session must be HttpOnly, Secure, SameSite=None
 - Hyperdrive: connection string format differs from direct Neon connection

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -74,7 +74,7 @@
       "Bash(python3 -c:*)",
       "WebSearch",
       "WebFetch(domain:localhost)",
-      "WebFetch(domain:pitchey-5o8.pages.dev)",
+      "WebFetch(domain:pitchey.pages.dev)",
       "WebFetch(domain:www.pitchey.com)",
       "Skill(test)",
       "Skill(deploy)",

--- a/.claude/skills/wrangler-deploy/SKILL.md
+++ b/.claude/skills/wrangler-deploy/SKILL.md
@@ -17,7 +17,7 @@ triggers:
 - Frontend Project: `pitchey` (Cloudflare Pages)
 - Worker Name: `pitchey-api-prod`
 - Production API: https://pitchey-api-prod.ndlovucavelle.workers.dev
-- Production Frontend: https://pitchey-5o8.pages.dev
+- Production Frontend: https://pitchey.pages.dev
 
 ## Deployment Commands
 
@@ -51,7 +51,7 @@ cd frontend && npm run build && npx wrangler pages deploy dist/ --project-name=p
 
 # 3. Verify both
 curl -s https://pitchey-api-prod.ndlovucavelle.workers.dev/api/health | jq
-curl -s -o /dev/null -w "%{http_code}" https://pitchey-5o8.pages.dev
+curl -s -o /dev/null -w "%{http_code}" https://pitchey.pages.dev
 ```
 
 ## Pre-Deploy Checklist

--- a/.env.example
+++ b/.env.example
@@ -167,8 +167,8 @@ USE_MOCK_STORAGE=true
 # Uncomment and configure for production
 
 # Production Frontend
-# FRONTEND_URL=https://pitchey-5o8.pages.dev
-# BASE_URL=https://pitchey-5o8.pages.dev
+# FRONTEND_URL=https://pitchey.pages.dev
+# BASE_URL=https://pitchey.pages.dev
 
 # Production Backend
 # APP_URL=https://pitchey-api-prod.ndlovucavelle.workers.dev

--- a/.env.production.example
+++ b/.env.production.example
@@ -11,7 +11,7 @@ VITE_WS_URL=wss://pitchey-api-production.your-domain.workers.dev/ws
 VITE_NODE_ENV=production
 
 # Backend URLs (Cloudflare Workers)
-FRONTEND_URL=https://pitchey-5o8.pages.dev
+FRONTEND_URL=https://pitchey.pages.dev
 
 # Application Mode
 NODE_ENV=production
@@ -48,7 +48,7 @@ RATE_LIMIT_MAX_REQUESTS=100
 RATE_LIMIT_STRICT_MODE=true
 
 # CORS Settings
-CORS_ORIGIN=https://pitchey-5o8.pages.dev
+CORS_ORIGIN=https://pitchey.pages.dev
 CORS_CREDENTIALS=true
 
 # ========================================

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Visit http://localhost:5173
 
 ## Production URLs
 
-- **Frontend**: https://pitchey-5o8.pages.dev
+- **Frontend**: https://pitchey.pages.dev
 - **API**: https://pitchey-api-prod.ndlovucavelle.workers.dev
 
 ## Tech Stack

--- a/scripts/automated-monitoring.sh
+++ b/scripts/automated-monitoring.sh
@@ -78,7 +78,7 @@ check_frontend_server() {
     if [ "$ENVIRONMENT" = "local" ]; then
         base_url="http://127.0.0.1:5173"
     else
-        base_url="https://pitchey-5o8-66n.pages.dev"
+        base_url="https://pitchey.pages.dev"
     fi
     
     log "INFO" "Checking frontend server at $base_url..."
@@ -108,7 +108,7 @@ run_monitoring() {
     if [ "$ENVIRONMENT" = "local" ]; then
         base_url="http://127.0.0.1:5173"
     else
-        base_url="https://pitchey-5o8-66n.pages.dev"
+        base_url="https://pitchey.pages.dev"
     fi
     
     # Set timeout based on route type
@@ -274,7 +274,7 @@ show_usage() {
     echo ""
     echo "Environments:"
     echo "  local      - Local development (http://127.0.0.1:5173)"
-    echo "  production - Production site (https://pitchey-5o8-66n.pages.dev)"
+    echo "  production - Production site (https://pitchey.pages.dev)"
     echo ""
     echo "Route Types:"
     echo "  critical   - Critical routes only (default)"

--- a/scripts/backup-disaster-recovery.sh
+++ b/scripts/backup-disaster-recovery.sh
@@ -593,7 +593,7 @@ EMERGENCY CONTACTS:
 - Infrastructure: [Add infra contact]
 
 CRITICAL ENDPOINTS:
-- Frontend: https://pitchey-5o8.pages.dev
+- Frontend: https://pitchey.pages.dev
 - API: https://pitchey-api-prod.ndlovucavelle.workers.dev
 - Health Check: https://pitchey-api-prod.ndlovucavelle.workers.dev/api/health
 EOF

--- a/scripts/deploy-and-verify.sh
+++ b/scripts/deploy-and-verify.sh
@@ -16,7 +16,7 @@ NC='\033[0m' # No Color
 
 # Configuration
 PROJECT_NAME="pitchey"
-PROD_URL="https://pitchey-5o8.pages.dev"
+PROD_URL="https://pitchey.pages.dev"
 DEMO_CREATOR_EMAIL="alex.creator@demo.com"
 DEMO_CREATOR_PASS="Demo123"
 

--- a/scripts/deploy-monitoring.sh
+++ b/scripts/deploy-monitoring.sh
@@ -18,7 +18,7 @@ NC='\033[0m' # No Color
 
 # Configuration
 API_URL="https://pitchey-api-prod.ndlovucavelle.workers.dev"
-FRONTEND_URL="https://pitchey-5o8.pages.dev"
+FRONTEND_URL="https://pitchey.pages.dev"
 MONITORING_DIR="./monitoring/logs"
 ALERT_WEBHOOK="${ALERT_WEBHOOK:-}" # Set via environment variable
 

--- a/scripts/fix-github-actions-now.sh
+++ b/scripts/fix-github-actions-now.sh
@@ -8,7 +8,7 @@ echo "🚨 Emergency GitHub Actions Stabilization Starting..."
 # 1. Fix health check URLs in workflows
 echo "📝 Step 1: Fixing health check URLs..."
 find .github/workflows -name "*.yml" -type f -exec sed -i \
-  's|https://pitchey-5o8.pages.dev/api/health|https://pitchey-api-prod.ndlovucavelle.workers.dev/api/health|g' {} \;
+  's|https://pitchey.pages.dev/api/health|https://pitchey-api-prod.ndlovucavelle.workers.dev/api/health|g' {} \;
 
 echo "✅ Health check URLs fixed"
 
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Check Frontend
         run: |
-          if curl -f https://pitchey-5o8.pages.dev/ > /dev/null 2>&1; then
+          if curl -f https://pitchey.pages.dev/ > /dev/null 2>&1; then
             echo "✅ Frontend is healthy"
           else
             echo "❌ Frontend is down"
@@ -104,4 +104,4 @@ echo ""
 echo "3. Monitor the simplified pipeline:"
 echo "   gh run list --limit 5"
 echo ""
-echo "Your app is still LIVE at https://pitchey-5o8.pages.dev ✅"
+echo "Your app is still LIVE at https://pitchey.pages.dev ✅"

--- a/scripts/migrate-to-hyperdrive.sh
+++ b/scripts/migrate-to-hyperdrive.sh
@@ -175,7 +175,7 @@ compatibility_flags = ["nodejs_compat"]
 account_id = "e16d3bf549153de23459a6c6a06a431b"
 
 [vars]
-FRONTEND_URL = "https://pitchey-5o8.pages.dev"
+FRONTEND_URL = "https://pitchey.pages.dev"
 ENVIRONMENT = "test"
 
 [[hyperdrive]]

--- a/scripts/performance-testing-suite.sh
+++ b/scripts/performance-testing-suite.sh
@@ -18,7 +18,7 @@ readonly PROJECT_ROOT="$(dirname "${SCRIPT_DIR}")"
 # Test environment configuration
 TEST_ENVIRONMENT="${TEST_ENVIRONMENT:-production}"
 TARGET_URL="${TARGET_URL:-https://pitchey-api-prod.ndlovucavelle.workers.dev}"
-FRONTEND_URL="${FRONTEND_URL:-https://pitchey-5o8-66n.pages.dev}"
+FRONTEND_URL="${FRONTEND_URL:-https://pitchey.pages.dev}"
 CONTAINERS_URL="${CONTAINERS_URL:-https://containers.pitchey.com}"
 
 # Test execution configuration

--- a/scripts/production-deploy.sh
+++ b/scripts/production-deploy.sh
@@ -28,7 +28,7 @@ CURRENT_SLOT_FILE="${DEPLOY_DIR}/current_slot"
 
 # Production URLs
 PROD_WORKER_URL="${PROD_WORKER_URL:-https://pitchey-api-prod.ndlovucavelle.workers.dev}"
-PROD_FRONTEND_URL="${PROD_FRONTEND_URL:-https://pitchey-5o8-66n.pages.dev}"
+PROD_FRONTEND_URL="${PROD_FRONTEND_URL:-https://pitchey.pages.dev}"
 STAGING_WORKER_URL="${STAGING_WORKER_URL:-https://pitchey-api-staging.ndlovucavelle.workers.dev}"
 
 # Health check configuration

--- a/scripts/rollback-deployment.sh
+++ b/scripts/rollback-deployment.sh
@@ -17,7 +17,7 @@ NC='\033[0m'
 WORKER_NAME="pitchey-production"
 FRONTEND_PROJECT="pitchey"
 WORKER_URL="https://pitchey-api-prod.ndlovucavelle.workers.dev"
-FRONTEND_URL="https://pitchey-5o8.pages.dev"
+FRONTEND_URL="https://pitchey.pages.dev"
 
 # Rollback options
 ROLLBACK_WORKER=false

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -9,7 +9,7 @@ set -e
 TEST_DIR="./scripts"
 RESULTS_DIR="./test_results_$(date +%Y%m%d_%H%M%S)"
 API_URL="${API_URL:-https://pitchey-api-prod.ndlovucavelle.workers.dev}"
-FRONTEND_URL="${FRONTEND_URL:-https://pitchey-5o8.pages.dev}"
+FRONTEND_URL="${FRONTEND_URL:-https://pitchey.pages.dev}"
 
 # Colors for output
 RED='\033[0;31m'

--- a/scripts/setup-cloudflare-token.md
+++ b/scripts/setup-cloudflare-token.md
@@ -74,5 +74,5 @@ curl -X GET "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_
 - Need to create it first: `wrangler pages project create pitchey`
 
 ## Current Production URLs
-- Frontend: https://pitchey-5o8-66n.pages.dev
+- Frontend: https://pitchey.pages.dev
 - API: https://pitchey-api-prod.ndlovucavelle.workers.dev

--- a/scripts/setup-production-monitoring.sh
+++ b/scripts/setup-production-monitoring.sh
@@ -120,7 +120,7 @@ create_monitoring_config() {
 
 # API Endpoints
 PRODUCTION_API=https://pitchey-api-prod.ndlovucavelle.workers.dev
-PRODUCTION_FRONTEND=https://pitchey-5o8.pages.dev
+PRODUCTION_FRONTEND=https://pitchey.pages.dev
 
 # Alert Thresholds
 RESPONSE_TIME_THRESHOLD=2.0

--- a/scripts/simple-health-monitor.sh
+++ b/scripts/simple-health-monitor.sh
@@ -16,7 +16,7 @@ NC='\033[0m'
 
 # Configuration
 API_URL="${API_URL:-https://pitchey-api-prod.ndlovucavelle.workers.dev}"
-FRONTEND_URL="${FRONTEND_URL:-https://pitchey-5o8.pages.dev}"
+FRONTEND_URL="${FRONTEND_URL:-https://pitchey.pages.dev}"
 ALERT_THRESHOLD="${ALERT_THRESHOLD:-3}" # seconds
 LOG_FILE="${LOG_FILE:-./monitoring/logs/health-monitor.log}"
 ALERT_LOG="${ALERT_LOG:-./monitoring/logs/alerts.log}"

--- a/scripts/test-all-improvements.sh
+++ b/scripts/test-all-improvements.sh
@@ -11,7 +11,7 @@ echo ""
 
 # Configuration
 API_URL="https://pitchey-api-prod.ndlovucavelle.workers.dev"
-FRONTEND_URL="https://pitchey-5o8.pages.dev"
+FRONTEND_URL="https://pitchey.pages.dev"
 TEST_RESULTS="./test-results-$(date +%Y%m%d-%H%M%S).log"
 
 # Colors

--- a/scripts/test-all-portal-routes.sh
+++ b/scripts/test-all-portal-routes.sh
@@ -11,7 +11,7 @@ echo ""
 
 # Configuration
 API_URL="https://pitchey-api-prod.ndlovucavelle.workers.dev"
-FRONTEND_URL="https://pitchey-5o8.pages.dev"
+FRONTEND_URL="https://pitchey.pages.dev"
 
 # Colors
 RED='\033[0;31m'
@@ -170,7 +170,7 @@ fi
 
 # Test CORS headers
 CORS_HEADER=$(curl -sI "$API_URL/api/health" | grep -i "access-control-allow-origin" | head -1)
-if [[ "$CORS_HEADER" == *"https://pitchey-5o8.pages.dev"* ]]; then
+if [[ "$CORS_HEADER" == *"https://pitchey.pages.dev"* ]]; then
     echo -e "  CORS configuration: ${GREEN}✅${NC}"
     ((PASSED_TESTS++))
 else

--- a/scripts/validate-production.sh
+++ b/scripts/validate-production.sh
@@ -15,7 +15,7 @@ NC='\033[0m'
 
 # Configuration
 WORKER_URL="https://pitchey-api-prod.ndlovucavelle.workers.dev"
-FRONTEND_URL="https://pitchey-5o8.pages.dev"
+FRONTEND_URL="https://pitchey.pages.dev"
 TIMEOUT=30
 RETRY_COUNT=3
 

--- a/scripts/validation-suite.sh
+++ b/scripts/validation-suite.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 PROJECT_ROOT="${PROJECT_ROOT:-/home/supremeisbeing/pitcheymovie/pitchey_v0.2}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 API_BASE_URL="${API_BASE_URL:-https://pitchey-api-prod.ndlovucavelle.workers.dev}"
-FRONTEND_URL="${FRONTEND_URL:-https://pitchey-5o8-66n.pages.dev}"
+FRONTEND_URL="${FRONTEND_URL:-https://pitchey.pages.dev}"
 TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-30}"
 MAX_RETRIES="${MAX_RETRIES:-3}"
 PARALLEL_TESTS="${PARALLEL_TESTS:-5}"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -156,7 +156,7 @@ crons = [
 # ===== ENVIRONMENT VARIABLES =====
 [vars]
 # Platform Configuration
-FRONTEND_URL = "https://pitchey-5o8.pages.dev"
+FRONTEND_URL = "https://pitchey.pages.dev"
 BACKEND_URL = "https://pitchey-api-prod.ndlovucavelle.workers.dev"
 ENVIRONMENT = "production"
 VERSION = "2.0-integrated"


### PR DESCRIPTION
## Summary

Fixes several latent production bugs caused by a stale `FRONTEND_URL` env var still pointing at the retired `pitchey-5o8.pages.dev` Pages project.

## The bugs this fixes

All silently broken because `FRONTEND_URL=pitchey-5o8.pages.dev` returns Cloudflare error 1101 (the project exists but its last deploy is broken):

| Symptom | Root cause | File |
|---|---|---|
| Password reset emails send links that 500 | `\${env.FRONTEND_URL}/reset-password?token=...` | `src/handlers/auth-password.ts:208` |
| Stripe checkout redirects to 500 post-payment | `success_url = \${FRONTEND_URL}/...` | `src/worker-integrated.ts:9309, 9723` |
| NDA notification emails contain dead links | 12 sites: `actionUrl`, `pitchUrl`, `dashboardUrl`, `unsubscribeUrl` | `src/services/nda.service.ts` |
| Email unsubscribe broken | `\${env.FRONTEND_URL}/unsubscribe?token=...` | `src/handlers/notifications.ts:610`, `src/services/email-template.service.ts:349,354` |
| Magic-link / WebAuthn scoped to dead origin | baseURL + WebAuthn origin | `src/auth/better-auth-*.ts` (BA is disabled per #19, so latent only) |

## Root cause

PR #14 (commit `002e905`) claimed to sweep 87 source/config/doc references from `pitchey-5o8.pages.dev` to `pitchey.pages.dev`. A grep surfaced 35 references PR #14 missed across 26 files — including the live `FRONTEND_URL = "https://pitchey-5o8.pages.dev"` in `wrangler.toml:159`.

## Scope

Pure string substitution: `pitchey-5o8.pages.dev` and `pitchey-5o8-66n.pages.dev` → `pitchey.pages.dev`. 26 files, 35 lines, zero logic changes.

## Deploy sequence (post-merge)

1. Snapshot pre-deploy state: \`npx wrangler deployments list --name pitchey-api-prod | head -3\`
2. \`npx wrangler deploy\` — pushes corrected FRONTEND_URL to the Worker
3. Wait 2 min for global propagation
4. \`curl https://pitchey-api-prod.ndlovucavelle.workers.dev/api/health\` — expect 200
5. Smoke-test password reset — **Resend dashboard is authoritative** (handler doesn't log the URL, so \`wrangler tail\` is useless for this test)
6. If HTML email shows \`pitchey.pages.dev/reset-password?...\` → delete orphan \`pitchey-5o8\` project in CF dashboard
7. Verify: \`curl https://pitchey-5o8.pages.dev/\` returns 404 post-delete

## Smoke test (step 5)

Trigger:
\`\`\`bash
curl -X POST https://pitchey-api-prod.ndlovucavelle.workers.dev/api/auth/password/reset-request \\
  -H "Content-Type: application/json" \\
  -H "Origin: https://pitchey.pages.dev" \\
  -d '{"email": "alex.creator@demo.com"}'
\`\`\`

Then: Resend → Logs → find most recent \`password_reset\` email → inspect rendered HTML. The \`<a href>\` in the reset button should start with \`https://pitchey.pages.dev/reset-password?token=...\`. If it still shows \`pitchey-5o8\`, the env var didn't apply — **do not delete the orphan** until resolved.

## Out of scope (deferred)

- **Tier 6 dead-code cleanup** — 13 unused worker variants (\`src/worker-ndlovucavelle*.ts\`, \`src/worker-lucia-auth.ts\`, \`src/worker-clean.ts\`, etc.) + \`src/auth/raw-sql-auth-config.ts\` + \`src/security-enhancements.ts\`. File as separate issue tagged \`cleanup\`.
- **Unclaimed-subdomain CORS allow-list entries** — \`pitchey-main.pages.dev\` (\`src/utils/response.ts:64\`), \`staging-pitchey.pages.dev\` (\`src/config/security.production.ts:461\`), \`staging.pitchey.pages.dev\` (\`src/workflows/wrangler.toml:94\`). CORS-hijack vector if any of these names get registered elsewhere. File separately tagged \`security\`, low-sev.
- **Issue #18 Gaps 2-4** (CSP, CORS regex narrowness, preview secrets) — follow-up plan.
- **Issue #20 drift-audit script** — PR #14's missed sweep is the canonical example for #20.

## Test plan

- [x] \`grep -rn "pitchey-5o8"\` returns only the 4 intentional historical files (CLAUDE.md historical bullet, docs/CLOUDFLARE_PAGES_SETUP.md retirement note, docs/sessions/2026-04-19-handoff.md, frontend/test-results snapshot)
- [x] \`grep -rn "5o8-66n"\` returns only \`docs/CLOUDFLARE_PAGES_SETUP.md:14\` retirement doc
- [x] \`git diff --stat\`: 26 files, 35 insertions + 35 deletions (pure substitution)
- [x] \`FRONTEND_URL\` in \`wrangler.toml\` appears only once (line 159); no \`[env.*.vars]\` override risk
- [ ] Post-merge: \`npx wrangler deploy\` + 2-min wait + curl health check
- [ ] Post-deploy: password-reset smoke via Resend dashboard
- [ ] Post-smoke: delete orphan in CF dashboard; confirm \`curl https://pitchey-5o8.pages.dev/\` returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)