### PR TITLE
docs(auth): describe actual auth path — custom handlers, not Better Auth (#19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Movie pitch platform connecting creators, investors, and production companies. E
 - **Frontend**: Cloudflare Pages — React 18 + Vite + Zustand + TailwindCSS
 - **Backend**: Cloudflare Worker (`src/worker-integrated.ts`) — single entry point for all API routing
 - **Database**: Neon PostgreSQL — raw SQL, no ORM
-- **Auth**: Better Auth — session cookies only, no JWT
+- **Auth**: Custom handlers on the legacy `users`/`sessions` tables, `pitchey-session` UUID cookie. Better Auth is imported but the `createAuthAdapter` call in `src/worker-integrated.ts` has been commented out since commit `41850ea1` (2025-12-18); BA's `session`/`user`/`account`/`verification` tables are empty in prod. No JWT. Decision on rip-out vs migrate tracked in issue #19.
 - **Cache**: Upstash Redis (global)
 - **Storage**: Cloudflare R2
 
@@ -30,7 +30,7 @@ Movie pitch platform connecting creators, investors, and production companies. E
 ## Code Conventions
 - TypeScript for all new code
 - Raw SQL only (no ORM)
-- Better Auth sessions only (no JWT)
+- Sessions live in the legacy `sessions` table; cookie is `pitchey-session` (UUID). No JWT. Better Auth imports are vestigial — see root "Auth" section and issue #19 before touching.
 - `credentials: 'include'` on all API calls
 - Defensive utils (`safeAccess`, `safeNumber`, `safeArray`) for runtime safety
 - In `catch` blocks: `const e = err instanceof Error ? err : new Error(String(err))`
@@ -133,7 +133,7 @@ Launch Chrome: `google-chrome-stable --remote-debugging-port=9222 --user-data-di
 - **Sentry**: `@sentry/cloudflare` with `withSentry()`, DSN in wrangler.toml. MCP server removed — use dashboard directly
 - **Axiom**: Dataset `pitchey-logs`, token via `wrangler secret put AXIOM_TOKEN`
 - **Analytics Engine**: 2 bindings — `pitchey_metrics`, `pitchey_database_metrics` (pruned from 7 on 2026-04-17; see `docs/observability-audit-2026-04-17.md`)
-- **Health**: `GET /api/health` checks DB, KV, R2, Resend, Better Auth (3s timeout each)
+- **Health**: `GET /api/health` checks DB, KV, R2, Resend, Better Auth (3s timeout each). Note: the Better Auth health probe returns healthy as long as the module is importable — it does not verify the adapter is wired into the live request path (it isn't; see Auth section and issue #19).
 - **Logging**: `src/lib/production-logger.ts` — structured JSON, auto-redaction, requestId/traceId propagation
 - **Auth**: `src/lib/auth-observability.ts` — login/signup/session events, brute force detection (5+ failures/15min)
 - **Tracing**: W3C Trace Context, 10% sampling, 30-day retention in R2 + Analytics Engine

--- a/docs/context-backend.md
+++ b/docs/context-backend.md
@@ -7,11 +7,41 @@ Cloudflare Worker handling all API routing, auth, database, caching, and storage
 - **Build**: esbuild (`esbuild.config.js` at root)
 - **Runtime**: Cloudflare Workers (V8 isolates, not Node.js)
 
-## Authentication — Better Auth ONLY
-- **Cookie-Based Sessions**: Secure HTTP-only cookies (`pitchey-session`)
-- **No JWT Headers**: Authorization headers are NOT used
-- **Unified Auth Flow**: Single system for all portal types
-- Migrated from JWT to Better Auth in December 2024
+## Authentication — Custom Handlers on Legacy Sessions
+
+The header used to say "Better Auth ONLY." It wasn't true. The live path is:
+
+- **Login**: `handlePortalLogin()` in `worker-integrated.ts` — direct SQL against `users`, writes a row to the legacy `sessions` table, returns a `pitchey-session` UUID cookie.
+- **Session lookup**: custom middleware reads `pitchey-session`, joins `sessions`.
+- **Sign-out**: deletes the `sessions` row; cookie-clear header also zeros a stray `better-auth-session` cookie name that nothing ever sets (theatre).
+- **No JWT headers**: `Authorization: Bearer …` is not used anywhere in the live flow.
+
+Better Auth is imported but the `createAuthAdapter` call in
+`src/worker-integrated.ts` has been commented out since commit `41850ea1`
+(2025-12-18). Grep to find the current site:
+
+```typescript
+// Initialize Better Auth adapter (commented out - causing runtime error)
+// this.authAdapter = createAuthAdapter(env);
+```
+
+BA's `user`, `session`, `account`, and `verification` tables are empty in prod;
+the `src/auth/better-auth-*.ts` files are code that doesn't execute. Some
+imports still compile-check against your handler shapes, which is where the
+"Better Auth is live" docs drift came from — types validated against BA's API
+surface even though no runtime call reached it.
+
+**Known side-effect**: `src/auth/auth-adapter.ts` returns 503 "Authentication
+system is being upgraded" for any non-demo email from its `authenticate()`
+fallback branch. `UserProfileRoutes` calls this adapter's `requireAuth()` in
+five handlers, so user-profile endpoints 503 for real (non-demo) users. Either
+the endpoints aren't hit by anyone real yet, or there's a bigger-than-BA bug
+hiding here. Flagged in issue #19.
+
+**Decision pending** (issue #19):
+1. Rip BA out entirely (smallest diff, requires grep sweep)
+2. Find the Dec 2025 runtime error, fix it, actually wire BA in (2–4 weeks)
+3. Document and leave (what this doc update does — least work, most honest)
 
 ### Primary Endpoints
 - `POST /api/auth/sign-in` — unified sign-in

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -14,10 +14,10 @@ Key file: `src/config.ts` — lazy-initialized Proxy, exports `API_URL`, `WS_URL
 
 ## Auth Session Flow
 
-Cookie: `pitchey-session` (HttpOnly, Secure, 30-day expiry on backend)
+Cookie: `pitchey-session` (HttpOnly, Secure, 30-day expiry on backend). Despite the file naming, the live backend auth is **custom handlers on the legacy `sessions` table**, not Better Auth — see root CLAUDE.md "Auth" section and issue #19. The `better-auth-*` files named below still work on the frontend because they're thin wrappers around `fetch(/api/auth/...)` with `credentials: 'include'`; they never call Better Auth's server APIs. Rename deferred to avoid a noisy refactor while issue #19's decision is pending.
 
-1. `src/lib/better-auth-client.tsx` — Better Auth client, `baseURL` is empty in prod, `credentials: 'include'`
-2. `src/store/betterAuthStore.ts` — primary auth state (Zustand)
+1. `src/lib/better-auth-client.tsx` — session-fetch client (name is legacy), `baseURL` is empty in prod, `credentials: 'include'`
+2. `src/store/betterAuthStore.ts` — primary auth state (Zustand), talks to the custom backend handlers
 3. `src/store/sessionCache.ts` — localStorage cache (5min TTL), invalidated when cookie fingerprint changes
 4. `src/lib/session-manager.ts` — deduplicates session checks (30s min interval), returns in-progress promise to prevent races
 

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -19,11 +19,19 @@ Content-Type, Authorization, X-Request-Id, X-Client-Id
 
 ## Cookie Configuration
 
-File: `auth/better-auth-cloudflare-config.ts` — `createBetterAuth()` (line 44)
+Live login writes the `pitchey-session` cookie from `handlePortalLogin()` in
+`worker-integrated.ts`. `pitchey-session` holds a UUID, is keyed to a row in the
+legacy `sessions` table, and is validated by the custom session handler —
+**not** by Better Auth. `auth/better-auth-cloudflare-config.ts` exists but its
+`createBetterAuth()` output is never wired into the live request path (issue
+#19 tracks the cleanup decision).
+
 - Name: `pitchey-session`
 - `SameSite=None`, `Secure`, `HttpOnly`, 30-day expiry, `path=/`
-- Session update age: 24 hours (avoids DB writes on every request)
-- Cookie cache: 5min (Better Auth built-in)
+- Session lookup: legacy `sessions` table, UUID key, refresh-on-use
+- Sign-out theatre: the sign-out handler also returns `Set-Cookie: better-auth-session=; Max-Age=0`
+  but nothing ever sets that cookie — it's a leftover from an earlier BA attempt
+  and can be removed in the issue #19 rip-out/migrate/document decision
 
 **Gotcha**: The Pages Functions proxy (`frontend/functions/api/[[path]].ts`) rewrites
 `SameSite=None` to `Lax` and strips `Domain`. This is correct for same-origin API calls
@@ -75,5 +83,5 @@ File: `db/logged-connection.ts` — `LoggedDatabase` wrapper
 
 ## Health & waitUntil
 
-- `GET /api/health` checks DB, KV, R2, Resend, Better Auth (3s timeout each) → `healthy | degraded | unhealthy`
+- `GET /api/health` checks DB, KV, R2, Resend, Better Auth (3s timeout each) → `healthy | degraded | unhealthy`. The Better Auth check only verifies the module imports; the adapter is not wired into live auth (see Cookie Configuration above and issue #19).
 - All `ctx.waitUntil()` promises catch internally, never break requests (fire-and-forget telemetry)


### PR DESCRIPTION
## Summary

Issue #19 Option 3 — document pass. Better Auth's runtime adapter has been commented out in `src/worker-integrated.ts` since commit `41850ea1` (2025-12-18). Live login is custom handlers against the legacy `users`/`sessions` tables with a `pitchey-session` UUID cookie, no JWT. BA's `user`/`session`/`account`/`verification` tables are empty in prod.

The CLAUDE.md hierarchy and `docs/context-backend.md` were treating BA as live. Every Claude session in the past four months read those docs and reasoned forward from them. This PR stops the docs from lying. It does **not** rip BA out or migrate to it — that decision is still pending (issue #19 captures the three options).

## Files touched

- **`CLAUDE.md`** — root: "Auth" line + code-convention line + health-check bullet describe the legacy-sessions reality and point to issue #19.
- **`src/CLAUDE.md`** — Cookie Configuration section rewritten. Documents the sign-out theatre (handler clears a `better-auth-session` cookie that nothing ever sets).
- **`frontend/CLAUDE.md`** — "Auth Session Flow" explains why `better-auth-client.tsx` works despite BA not running on the backend: the frontend files are thin `fetch(/api/auth/...)` wrappers with `credentials: 'include'`, not calls into BA's server APIs.
- **`docs/context-backend.md`** — header `## Authentication — Better Auth ONLY` was actively wrong; replaced with `## Authentication — Custom Handlers on Legacy Sessions` plus the three-options decision summary and the known `auth-adapter.ts` 503 side-effect on `UserProfileRoutes`.

## Design choices

- **Line-number references dropped.** Initial draft embedded `src/worker-integrated.ts:795` and `auth/auth-adapter.ts:91`. Line numbers drift — that's exactly the kind of drift #20's future audit is meant to catch, not introduce. Content-based references (`createAuthAdapter` call, `authenticate()` fallback branch) stay accurate through refactors.
- **No code changes.** BA imports stay, 12 BA auth files in `src/auth/` stay, empty BA tables stay. That work belongs to the rip-out/migrate decision (issue #19).
- **MFA claims checked.** Grepped CLAUDE.md hierarchy for `twoFactor`/`two_factor`/`mfa.service` — no matches. If the codebase grows a claim that BA handles MFA, a future drift-audit assertion can catch it.

## What this unblocks

- **Issue #20 drift-audit v1.** Assertion 1 can now be written against the agreed state (BA disabled, custom handlers live) and correctly fire only if someone re-enables BA without updating docs. If this PR doesn't land first, the audit script would just duplicate issue #19 on every run.
- **Future Claude sessions.** The three CLAUDE.md files are loaded into every session. The next agent will see real auth, not aspirational auth.

## What's explicitly NOT in this PR

- `docs/BETTER_AUTH_THREE_PORTAL_IMPLEMENTATION.md` and sibling historical docs still describe the intended BA system. Flagging them as superseded is a separate pass — in scope for issue #19's rip-out decision if it goes that way, or for issue #20's v2 audit if we keep BA on ice.
- `src/routes/mfa.routes.ts` (imports BA, not wired in — dead) and `src/auth/better-auth-*.ts` files untouched. Cleanup lives in the #19 decision.

Closes none of #17–#27 directly; reduces the blast radius for drift that #20 is designed to detect.

## Test plan

- [x] `grep -rn "Better Auth" CLAUDE.md src/CLAUDE.md frontend/CLAUDE.md docs/context-backend.md` — every remaining reference now either (a) acknowledges BA is imports-only/vestigial or (b) cross-references issue #19
- [x] `grep -n -i "twoFactor\|two_factor\|mfa.service" CLAUDE.md src/CLAUDE.md frontend/CLAUDE.md` — no matches, no MFA-as-BA claims to correct
- [x] Line-number references in edited docs: none remain (`:795`, `:91` removed)
- [x] Production auth flow unchanged — no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)