### PR TITLE
feat(ci): v1 docs-vs-code drift audit (#20)

### DIFF
--- a/.github/workflows/docs-vs-code-audit.yml
+++ b/.github/workflows/docs-vs-code-audit.yml
@@ -1,0 +1,73 @@
+name: Docs vs Code Drift Audit
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Weekly on Monday 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  drift-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run drift audit script
+        id: audit
+        run: bash scripts/docs-vs-code-audit.sh
+        continue-on-error: true
+
+      - name: Open or update issue on failure
+        if: steps.audit.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const titlePrefix = '🚨 Docs-vs-code drift audit failed';
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              `Automated drift audit failed at ${new Date().toISOString()}.`,
+              ``,
+              `Workflow: ${context.workflow}`,
+              `Run: ${runUrl}`,
+              ``,
+              `This issue is updated instead of duplicated while unresolved.`,
+            ].join('\n');
+
+            const query = `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${titlePrefix}"`;
+            const { data: searchResults } = await github.rest.search.issuesAndPullRequests({
+              q: query,
+              per_page: 1,
+            });
+            const existing = searchResults.items[0];
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `Still failing — ${runUrl}`,
+              });
+              return;
+            }
+
+            const incidentLabelExists = await github.rest.issues.getLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'incident',
+            }).then(() => true).catch(() => false);
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `${titlePrefix} — ${new Date().toISOString().slice(0, 10)}`,
+              body,
+              ...(incidentLabelExists ? { labels: ['incident'] } : {}),
+            });
+
+      - name: Fail workflow when drift audit fails
+        if: steps.audit.outcome == 'failure'
+        run: exit 1

--- a/scripts/docs-vs-code-audit.sh
+++ b/scripts/docs-vs-code-audit.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FAILURES=0
+
+pass() {
+  echo "✅ $1"
+}
+
+fail() {
+  echo "❌ $1"
+  FAILURES=$((FAILURES + 1))
+}
+
+echo "Running docs-vs-code drift audit..."
+
+# 1) Better Auth adapter still commented out in worker-integrated.ts
+if grep -nE "^[[:space:]]*//[[:space:]]*this\\.authAdapter[[:space:]]*=[[:space:]]*createAuthAdapter\\(env\\);" \
+  "$ROOT_DIR/src/worker-integrated.ts" >/dev/null; then
+  pass "Better Auth adapter remains commented out in src/worker-integrated.ts."
+else
+  fail "Expected commented Better Auth adapter line was not found in src/worker-integrated.ts."
+fi
+
+# 2) FRONTEND_URL in deployed config matches CLAUDE.md claim
+WRANGLER_FRONTEND_URL="$(
+  sed -nE "s/^FRONTEND_URL[[:space:]]*=[[:space:]]*['\"]?([^'\"[:space:]]+)['\"]?.*$/\\1/p" \
+    "$ROOT_DIR/wrangler.toml" | head -n1
+)"
+
+if [[ -z "$WRANGLER_FRONTEND_URL" ]]; then
+  fail "Could not read FRONTEND_URL from wrangler.toml."
+elif grep -F "$WRANGLER_FRONTEND_URL" "$ROOT_DIR/CLAUDE.md" >/dev/null; then
+  pass "wrangler.toml FRONTEND_URL ($WRANGLER_FRONTEND_URL) is documented in CLAUDE.md."
+else
+  fail "FRONTEND_URL mismatch: wrangler.toml has $WRANGLER_FRONTEND_URL but CLAUDE.md does not."
+fi
+
+# 3) Every concrete .pages.dev URL in source/config resolves to HTTP 2xx/3xx.
+# Redirects (3xx) are intentionally accepted — canonicalization and HTTPS
+# upgrade redirects are legitimate and shouldn't fail the audit. curl uses
+# -L to follow redirects, but we still accept bare 3xx in case a URL is
+# reached with a redirect-loop or other terminal-3xx condition.
+URL_SOURCES=(
+  "$ROOT_DIR/src"
+  "$ROOT_DIR/frontend/src"
+  "$ROOT_DIR/.github/workflows"
+  "$ROOT_DIR/wrangler.toml"
+  "$ROOT_DIR/.env.example"
+  "$ROOT_DIR/.env.production.example"
+)
+
+mapfile -t PAGES_URLS < <(
+  grep -RhoE "https://([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9])\\.pages\\.dev" "${URL_SOURCES[@]}" 2>/dev/null | sort -u
+)
+
+if [[ "${#PAGES_URLS[@]}" -eq 0 ]]; then
+  fail "No .pages.dev URLs were found in configured source locations."
+else
+  echo "Checking ${#PAGES_URLS[@]} .pages.dev URL(s)..."
+  for url in "${PAGES_URLS[@]}"; do
+    status="$(curl -sS -L -o /dev/null -w "%{http_code}" --connect-timeout 5 --max-time 10 "$url" || true)"
+    if [[ -z "$status" ]]; then
+      status="000"
+    fi
+    if [[ "$status" =~ ^[23] ]]; then
+      pass "$url returned HTTP $status."
+    else
+      fail "$url returned HTTP $status (expected 2xx/3xx)."
+    fi
+  done
+fi
+
+if [[ "$FAILURES" -gt 0 ]]; then
+  echo
+  echo "Drift audit failed with $FAILURES issue(s)."
+  exit 1
+fi
+
+echo
+echo "Drift audit passed."


### PR DESCRIPTION
## Summary

First version of the docs-vs-code drift audit described in issue #20. Weekly cron (Mondays 06:00 UTC) runs three assertions against the repo; failures open a single deduplicated issue titled "Docs-vs-code drift audit failed" and subsequent failing runs comment on it instead of spamming.

## Assertions

### 1. Better Auth adapter state
Greps `src/worker-integrated.ts` for the commented `// this.authAdapter = createAuthAdapter(env);` line.

- **Passes** when the commented line is found (the agreed state, per issue #19 and PR #29).
- **Fails** if the line is uncommented, deleted, or the pattern otherwise changes.

This is the inverted form the earlier course-correction called for — passing on "BA disabled" because that's what CLAUDE.md now documents. If someone re-enables the adapter without updating the docs, the audit flags the drift.

### 2. FRONTEND_URL documented in CLAUDE.md
Extracts `FRONTEND_URL` from `wrangler.toml`, uses `grep -F` to confirm the value appears somewhere in root `CLAUDE.md`. Deliberately loose to survive the env-aware CSP refactor (Issue #18 Gap 2) — when `[env.production.vars]` / `[env.preview.vars]` blocks arrive, any documented URL still passes. Would have caught the stale `pitchey-5o8` FRONTEND_URL that PR #21 fixed.

### 3. .pages.dev reachability
Every `https://*.pages.dev` URL referenced in `src/`, `frontend/src/`, `.github/workflows/`, `wrangler.toml`, and `.env.*.example` must return HTTP 2xx/3xx. Accepts 3xx for canonicalization / HTTPS-upgrade redirects; only 4xx/5xx/timeouts fail.

## Provenance + refinements

Script drafted in parallel tonight by the GitHub Copilot agent on `copilot/update-handoff-doc-for-session`. Co-authored credit in the commit. Refinement on top of that work: **assertion 3 relaxed from strict `== "200"` to regex `^[23]`** so legitimate redirects don't false-fail the audit.

The copilot branch also duplicated PR #28's release-management.yml deletion and appended to the 2026-04-19 handoff doc; those overlaps are dropped here (only the script + workflow files are brought forward). The copilot branch will be deleted once this PR lands.

## First-run expectations — real drift surfaces immediately

Dry run on `main` (after PRs #28 and #29 merged) shows the audit correctly flags four stale subdomains referenced in source:

```
✅ Better Auth adapter remains commented out in src/worker-integrated.ts.
✅ wrangler.toml FRONTEND_URL (https://pitchey.pages.dev) is documented in CLAUDE.md.
Checking 5 .pages.dev URL(s)...
❌ https://pitchey-main.pages.dev       → HTTP 000 (DNS fails)
✅ https://pitchey.pages.dev            → HTTP 200
❌ https://pitchey-staging.pages.dev    → HTTP 000 (DNS fails)
❌ https://staging-pitchey.pages.dev    → HTTP 000 (DNS fails)
❌ https://staging.pitchey.pages.dev    → HTTP 404

Drift audit failed with 4 issue(s).
```

These are legitimate drift findings — source references subdomains that either never existed or were retired. First CI run after merge will open an issue containing this list. Reviewer's choice whether to remove the dead references (most likely in `src/config/security.production.ts` and `src/config/monitoring.production.ts`) or provision the subdomains. Either action resolves the audit.

Adjacent to issue #27's CORS regex investigation — the enumeration work there will probably eliminate most of these references as a side effect.

## Review note

Recommended to merge **with fresh eyes tomorrow** rather than tonight — the first-run behavior creates an issue, which is the intended design, but worth a sober second look at the workflow's issue-creation logic before it's live on a weekly cron.

## Test plan

- [x] Local dry-run: `bash scripts/docs-vs-code-audit.sh` — 2 passes + 4 fails, exit 1, output matches expectation above.
- [x] Workflow dedupe logic verified: searches for `in:title "🚨 Docs-vs-code drift audit failed"` among open issues before creating; comments on existing if found.
- [x] `permissions:` block scopes `issues: write` only (no broader scope needed for audit reads).
- [ ] First CI run after merge opens one issue with four failures — expected behavior, not a regression.

Partially addresses #20 — this is the v1 scaffold. More assertions to follow as drift categories surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — script drafted by GitHub Copilot agent.