### PR TITLE
fix(preview): inject preview Worker origin into CSP (issue #18 gap 2)

### DIFF
--- a/.github/workflows/neon-preview.yml
+++ b/.github/workflows/neon-preview.yml
@@ -53,7 +53,45 @@ jobs:
           VITE_API_URL: https://pitchey-pr-${{ github.event.pull_request.number }}.ndlovucavelle.workers.dev
           VITE_WS_URL: wss://pitchey-pr-${{ github.event.pull_request.number }}.ndlovucavelle.workers.dev
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
-      
+
+      - name: Inject preview Worker origin into CSP (issue #18 gap 2)
+        run: |
+          # frontend/public/_headers ships a production-only CSP with
+          # pitchey-api-prod.ndlovucavelle.workers.dev hardcoded. Preview deploys
+          # hit pitchey-pr-<N>.ndlovucavelle.workers.dev for both HTTPS calls
+          # (when the Pages Functions proxy is unavailable) and WebSocket
+          # connections (which always bypass the proxy). Without this step
+          # every preview login silently fails in-browser with
+          # "Content Security Policy directive: connect-src" violations.
+          #
+          # We intentionally DO NOT wildcard *.ndlovucavelle.workers.dev — that
+          # would expose every Worker under the account. Only this preview's
+          # exact hostname is added.
+          PR_NUM="${{ github.event.pull_request.number }}"
+          PREVIEW_ORIGIN="pitchey-pr-${PR_NUM}.ndlovucavelle.workers.dev"
+          HEADERS_FILE="frontend/dist/_headers"
+
+          if [ ! -f "$HEADERS_FILE" ]; then
+            echo "❌ Expected $HEADERS_FILE after vite build; file missing"
+            exit 1
+          fi
+
+          sed -i -E \
+            "s|(connect-src 'self')|\1 https://${PREVIEW_ORIGIN} wss://${PREVIEW_ORIGIN}|" \
+            "$HEADERS_FILE"
+
+          # Verify the substitution landed — if connect-src was refactored
+          # upstream and the anchor regex no longer matches, fail loudly
+          # rather than silently shipping a broken preview CSP.
+          if ! grep -q "https://${PREVIEW_ORIGIN}" "$HEADERS_FILE"; then
+            echo "❌ Preview origin not injected into $HEADERS_FILE — did 'connect-src '\''self'\''' anchor change?"
+            echo "--- current $HEADERS_FILE contents ---"
+            cat "$HEADERS_FILE"
+            exit 1
+          fi
+
+          echo "✅ Injected ${PREVIEW_ORIGIN} into preview CSP"
+
       - name: Deploy preview to Cloudflare Pages
         id: cloudflare
         uses: cloudflare/pages-action@v1


### PR DESCRIPTION
## Summary

Addresses **Gap 2** from issue #18. `frontend/public/_headers` ships a production-only CSP with `pitchey-api-prod.ndlovucavelle.workers.dev` hardcoded. Preview deploys hit `pitchey-pr-<N>.ndlovucavelle.workers.dev` for direct Worker calls (when the Pages Functions proxy isn't in the path) and, always, for WebSocket connections (which bypass the proxy per `frontend/CLAUDE.md`).

Without this fix, every preview login silently fails in the browser with `CSP directive: connect-src` violations — the primary reason preview deploys have been browser-unreachable even though the Worker itself responds fine to curl.

## How

After `npm run build` in `neon-preview.yml`, a sed step injects `https://<preview-host>` and `wss://<preview-host>` right after `connect-src 'self'` in `frontend/dist/_headers`. The production deploy path is untouched — `frontend/public/_headers` source is unchanged, only the preview workflow rewrites the build artifact.

### Local verification

```console
$ PR_NUM=42 PREVIEW_ORIGIN="pitchey-pr-${PR_NUM}.ndlovucavelle.workers.dev"
$ sed -i -E "s|(connect-src 'self')|\1 https://${PREVIEW_ORIGIN} wss://${PREVIEW_ORIGIN}|" _headers
$ grep connect-src _headers
  ...connect-src 'self' https://pitchey-pr-42.ndlovucavelle.workers.dev wss://pitchey-pr-42.ndlovucavelle.workers.dev https://pitchey-api-prod.ndlovucavelle.workers.dev ...
```

## Design choices

- **No wildcarding.** `*.ndlovucavelle.workers.dev` would expose every Worker under the account to the preview's CSP allowlist. Only this preview's exact hostname is added.
- **Production URL kept in preview CSP.** Additive rather than replacing — preview deploys that do happen to fall back to the proxy path (which forwards to production Worker URL from `frontend/src/config.ts` if `VITE_API_URL` is unset for any reason) don't also break. Can scope this tighter in a later pass if desired.
- **Loud failure if the anchor breaks.** A post-sed `grep -q` verification fails the workflow if `connect-src 'self'` isn't found — guards against silent drift if the CSP gets refactored upstream and the sed regex stops matching.
- **`frontend/public/_headers` source untouched.** Keeps the production path a single source of truth; preview-specific mutations live in the preview workflow, not the shared file.

## Scope — what this PR is NOT

Gap 2 only. Issue #18's other gaps stay open or are already closed:

- **Gap 1** — rescoped in PR #23 as a wrong mental model (the `pitchey-5o8` subdomain is a legacy alias of the same project, not an orphan).
- **Gap 3** — CORS regex too permissive, tracked separately at issue #27. Don't block on #18.
- **Gap 4** — preview DB password leak, already fixed in commit `6c6ad32`. Verified by inspection: `neon-preview.yml` lines 116-117 only emit `dbHost`, and the DSN at line 102 is an env var for `wrangler deploy` — not printed in the PR comment. Will re-verify empirically on the next preview run after this PR.

## Test plan

- [x] Local sed-substitution smoke test (shown above)
- [x] Fail-loudly regex anchor check verified in the workflow file
- [ ] End-to-end: next PR that triggers `neon-preview.yml` against main (this PR is that test — the preview deploy this workflow spins up will have the injected CSP)
- [ ] Browser login on the preview URL succeeds without console CSP violations
- [ ] WebSocket connection on the preview URL establishes (should be visible via `wrangler tail --name pitchey-pr-<N>`)

End-to-end verification only possible on a real preview deploy — flagged for review-time check when this PR's preview actually spins up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)