### PR TITLE
fix(ci): drop SENTRY_DSN from wrangler secret put loop

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -254,7 +254,6 @@ jobs:
           echo "${{ secrets.JWT_SECRET }}" | npx wrangler secret put JWT_SECRET
           echo "${{ secrets.UPSTASH_REDIS_REST_URL }}" | npx wrangler secret put UPSTASH_REDIS_REST_URL
           echo "${{ secrets.UPSTASH_REDIS_REST_TOKEN }}" | npx wrangler secret put UPSTASH_REDIS_REST_TOKEN
-          echo "${{ secrets.SENTRY_DSN }}" | npx wrangler secret put SENTRY_DSN
           echo "${{ secrets.AXIOM_TOKEN }}" | npx wrangler secret put AXIOM_TOKEN
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -102,7 +102,6 @@ jobs:
           echo "${{ secrets.JWT_SECRET }}" | wrangler secret put JWT_SECRET
           echo "${{ secrets.UPSTASH_REDIS_REST_URL }}" | wrangler secret put UPSTASH_REDIS_REST_URL
           echo "${{ secrets.UPSTASH_REDIS_REST_TOKEN }}" | wrangler secret put UPSTASH_REDIS_REST_TOKEN
-          echo "${{ secrets.SENTRY_DSN }}" | wrangler secret put SENTRY_DSN
           echo "${{ secrets.AXIOM_TOKEN }}" | wrangler secret put AXIOM_TOKEN
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Unblocks every main-branch deploy — the **🔐 Sync Worker secrets** step has been failing on `wrangler secret put SENTRY_DSN` with Cloudflare error `10053: Binding name 'SENTRY_DSN' already in use` (see run [24664346735](https://github.com/WizardryPro/pitchey-app/actions/runs/24664346735)).
- Root cause: `SENTRY_DSN` is declared as a `[vars]` binding in `wrangler.toml:208` (plain_text). Cloudflare treats vars and secrets as a single namespace, so `wrangler secret put SENTRY_DSN` on the same Worker is rejected.
- Fix: remove the single `wrangler secret put SENTRY_DSN` line from the two deploy workflows. The DSN remains bound on the Worker via `[vars]`, and the GitHub Actions `SENTRY_DSN` secret remains referenced by `VITE_SENTRY_DSN` in the frontend build — no GitHub secret needs to change.

## Verification already done
- Queried Cloudflare MCP (`/workers/scripts/pitchey-api-prod/settings` + `/secrets`): `SENTRY_DSN` is bound as `plain_text`, and does **not** appear in the secrets list. No server-side cleanup needed.
- The preceding 4 secret puts in the failing run (`DATABASE_URL`, `JWT_SECRET`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`) succeeded; the 5th (`SENTRY_DSN`) is the one that aborts the pipeline. `AXIOM_TOKEN` never gets attempted.

## Test plan
- [ ] Merge PR; confirm the next push-to-main run of `🚀 Pitchey Platform CI/CD` reaches `🔐 Sync Worker secrets` and uploads all 5 secrets (DATABASE_URL, JWT_SECRET, UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN, AXIOM_TOKEN).
- [ ] Confirm the subsequent `🚀 Deploy Frontend to production` and `📊 Upload source maps to Sentry` steps run.
- [ ] Sanity check: `curl https://pitchey-api-prod.ndlovucavelle.workers.dev/api/health` returns 200; Sentry still receives events (the DSN is unchanged — just delivered via `[vars]` instead of a secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)