### PR TITLE
ci(security-scan): fix daily-run failures (perms scoping + ZAP bump + Newman cleanup)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -242,21 +242,6 @@ jobs:
             report_md.md
           if-no-files-found: ignore
 
-      - name: Newman API Tests with Security Checks
-        run: |
-          npm install -g newman newman-reporter-htmlextra
-          newman run tests/security/api-security-tests.json \
-            -e tests/security/environment.json \
-            --reporters cli,htmlextra \
-            --reporter-htmlextra-export security-report.html
-
-      - name: Upload API security results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: api-security-report
-          path: security-report.html
-
   # License compliance check
   license-check:
     name: License Compliance

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -12,12 +12,10 @@ on:
 
 permissions:
   contents: read
-  security-events: write
-  actions: read
-  # pull-requests: required by security-report job to post scan-summary comments on PRs
-  # issues: required by the "Create issue for failures" step on main-branch / scheduled runs
-  pull-requests: write
-  issues: write
+# Write perms are job-scoped (least privilege). Required by ossf/scorecard-action,
+# which 400s publication if any non-read perm is set at the top level. Job-level
+# blocks below grant `security-events: write` to SARIF uploaders (sast-scan, iac-scan)
+# and `issues: write` / `pull-requests: write` to security-report.
 
 jobs:
   # Secret scanning
@@ -141,6 +139,8 @@ jobs:
   sast-scan:
     name: Static Code Analysis
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # CodeQL analyze uploads SARIF to Security tab
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -177,6 +177,8 @@ jobs:
   iac-scan:
     name: Infrastructure Security
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # Checkov SARIF upload
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -213,7 +215,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: OWASP ZAP API Scan
-        uses: zaproxy/action-api-scan@v0.7.0
+        # v0.7.0 bundled upload-artifact@v3 (deprecated 2024-11-30, EOL'd by GitHub),
+        # which 400'd "artifact name zap_scan is not valid" against the dead v3 API.
+        # v0.10.0 uses upload-artifact@v4.
+        uses: zaproxy/action-api-scan@v0.10.0
         with:
           target: 'https://pitchey-api-prod.ndlovucavelle.workers.dev'
           rules_file_name: '.zap/rules.tsv'
@@ -305,6 +310,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [secret-scan, dependency-scan, sast-scan, iac-scan]
     if: always()
+    permissions:
+      contents: read
+      issues: write          # "Create issue for failures" step on main / scheduled
+      pull-requests: write   # "Comment on PR" step
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Three fixes for the daily Security Scan workflow, all targeting jobs that only run on `schedule`/`workflow_dispatch` (so they don't block PR/push CI but were failing every night).

### 1. Scorecard — top-level perms violation
`ossf/scorecard-action` 400'd publication with:
> `workflow verification failed: global perm is set to write: permission for security-events is set to write` / `permission for issues is set to write`

Scorecard requires top-level `permissions:` to be read-only with writes scoped to the jobs that need them. Top-level is now `contents: read` only; `security-events: write` moved to `sast-scan` (CodeQL) + `iac-scan` (Checkov SARIF); `issues: write` + `pull-requests: write` moved to `security-report`. Side benefit: least-privilege.

⚠️ **Cannot verify on a feature branch** — Scorecard rejects non-default branches with `refs/heads/ci/security-scan-fixes not supported with workflow_dispatch event. Only the default branch main is supported.` The fix is mechanically correct (we removed exactly the perms named in the original 400), but final verification has to come from the next scheduled run after merge.

### 2. ZAP artifact upload — deprecated upload-artifact@v3 ✅ verified
`zaproxy/action-api-scan@v0.7.0` bundled `upload-artifact@v3` (deprecated 2024-11-30, EOL'd by GitHub), failing with `"artifact name zap_scan is not valid"` against the dead v3 API (`api-version=6.0-preview`). Bumped to `v0.10.0` which uses `upload-artifact@v4`.

Confirmed working on dispatch run [25319727535](https://github.com/WizardryPro/pitchey-app/actions/runs/25319727535) — `Artifact name is valid!` and the scan itself was always passing (`FAIL-NEW: 0  PASS: 122`).

### 3. Newman step — never had backing fixtures
The Newman step referenced `tests/security/api-security-tests.json` and `tests/security/environment.json`, neither of which has ever existed in git history. The only file ever in `tests/security/` was `security-validation-framework.ts`, deleted in `35d1a62f` (Feb 2026 root cleanup).

Silently broken from the start — the prior ZAP artifact-upload failure masked it via step ordering. Fixing ZAP exposed it. Deleted rather than `continue-on-error`'d: half-finished implementation per CLAUDE.md.

## Test plan
- [x] YAML validates (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] ZAP artifact upload works on `workflow_dispatch` against this branch
- [ ] Scorecard publication clears 400 — verifiable only after merge, on next scheduled run (`0 2 * * *` UTC) or manual `workflow_dispatch` against main
- [ ] No regressions to other jobs (`secret-scan`, `dependency-scan`, `sast-scan`, `iac-scan`, `license-check`) — they don't use top-level write perms; verify on next push run

🤖 Generated with [Claude Code](https://claude.com/claude-code)