### PR TITLE
fix(rollback): correct stale FRONTEND_URL to pitchey-5o8.pages.dev

### DIFF
--- a/scripts/rollback-deployment.sh
+++ b/scripts/rollback-deployment.sh
@@ -17,7 +17,7 @@ NC='\033[0m'
 WORKER_NAME="pitchey-production"
 FRONTEND_PROJECT="pitchey"
 WORKER_URL="https://pitchey-api-prod.ndlovucavelle.workers.dev"
-FRONTEND_URL="https://pitchey.pages.dev"
+FRONTEND_URL="https://pitchey-5o8.pages.dev"
 
 # Rollback options
 ROLLBACK_WORKER=false


### PR DESCRIPTION
Closes #72.

## What

\`scripts/rollback-deployment.sh:20\` had \`FRONTEND_URL=\"https://pitchey.pages.dev\"\`. That subdomain has NXDOMAIN'd since 2026-04-21 when the Cavelltheleaddev duplicate Pages project was deleted. Canonical URL is \`https://pitchey-5o8.pages.dev\`.

## Why now

This blocks Phase C.1 rollback drill — drill failure on the URL check would look identical to drill failure on \`wrangler rollback\` itself. 30 minutes of fix saves an hour of \"why did the drill fail\" debugging when Phase C.1 starts.

## Verification

\`\`\`bash
$ curl -s -o /dev/null -w \"%{http_code}\" --connect-timeout 5 --max-time 10 https://pitchey-5o8.pages.dev
200
\`\`\`

\`\`\`bash
$ grep pages.dev scripts/rollback-deployment.sh
20:FRONTEND_URL=\"https://pitchey-5o8.pages.dev\"
\`\`\`

Zero remaining \`pitchey.pages.dev\` refs in the rollback script. Cross-checked \`.github/workflows/emergency-rollback.yml\` — it uses CF API endpoints discovered at runtime via \`jq\`, so it doesn't have a stale URL.

## Acceptance

- [x] \`grep pitchey.pages.dev scripts/rollback-deployment.sh\` returns zero hits
- [x] \`curl pitchey-5o8.pages.dev\` returns 200
- [ ] (Optional, deferred to Phase C.1) Run the script's dry-run mode end-to-end and confirm post-rollback health check phase succeeds

Surfaced during PR #74's orchestrator decomposition cross-check (#70 review session, 2026-05-04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)