### PR TITLE
ci(neon-preview): fix bot's preview URL comment (broken alias + wrong API subdomain)

### DIFF
--- a/.github/workflows/neon-preview.yml
+++ b/.github/workflows/neon-preview.yml
@@ -101,7 +101,7 @@ jobs:
           projectName: pitchey
           directory: frontend/dist
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          deploymentName: pr-${{ github.event.pull_request.number }}
+          branch: pr-${{ github.event.pull_request.number }}
           wranglerVersion: '3'
         env:
           VITE_API_URL: https://pitchey-pr-${{ github.event.pull_request.number }}.ndlovucavelle.workers.dev
@@ -153,13 +153,15 @@ jobs:
             const neonBranch = 'preview/pr-' + prNumber;
             const dbHost = '${{ steps.create-branch.outputs.host }}';
             const previewUrl = 'https://pr-' + prNumber + '.pitchey-5o8.pages.dev';
-            const apiUrl = 'https://pitchey-pr-' + prNumber + '.workers.dev';
+            const directUrl = '${{ steps.cloudflare.outputs.url }}';
+            const apiUrl = 'https://pitchey-pr-' + prNumber + '.ndlovucavelle.workers.dev';
             
             const comment = `## 🚀 Preview Environment Ready!
             
             | Component | URL/Details |
             |-----------|-------------|
-            | 🌐 **Frontend** | [${previewUrl}](${previewUrl}) |
+            | 🌐 **Frontend (alias)** | [${previewUrl}](${previewUrl}) |
+            | 🌐 **Frontend (deployment)** | [${directUrl}](${directUrl}) |
             | ⚡ **API** | [${apiUrl}](${apiUrl}) |
             | 🗄️ **Database** | \`${neonBranch}\` |
             | 🔌 **DB Host** | \`${dbHost}\` |


### PR DESCRIPTION
## Summary
The neon-preview bot has been posting three wrong things on every PR. Surfaced during PR #70's gate verification — the advertised \`pr-70.pitchey-5o8.pages.dev\` returned NXDOMAIN.

## What was wrong

1. **\`deploymentName\` is silently ignored** by \`cloudflare/pages-action@v1\`. Each run logs \`##[warning]Unexpected input(s) 'deploymentName', valid inputs are [..., 'branch', ...]\`. The action falls back to its default branch handling, so no \`pr-N\` alias is created. Bot comment promised a URL that never existed.
2. **API URL subdomain was wrong** — comment said \`pitchey-pr-N.workers.dev\`, actual deploy is at \`pitchey-pr-N.ndlovucavelle.workers.dev\` (the build's \`VITE_API_URL\` was already correct).
3. **Alias propagation lag** — even with the right \`branch:\` input, the alias can take a minute. The commit-hash deployment URL (\`<hash>.pitchey-5o8.pages.dev\`) is live immediately.

## Fix
- \`deploymentName:\` → \`branch:\` so the \`pr-N\` alias actually gets created
- API URL gets the \`.ndlovucavelle\` subdomain
- Comment now shows both alias URL and the direct deployment URL from \`steps.cloudflare.outputs.url\` as a fallback

## Test plan
- [ ] Open this PR → bot posts a comment with both URLs resolving
- [ ] No more \`Unexpected input(s) 'deploymentName'\` warning in the deploy step

🤖 Generated with [Claude Code](https://claude.com/claude-code)