### PR TITLE
Wrap bucket-B sites with observedSwallow helper

### DIFF
--- a/docs/catch-swallow-prep-2026-05-05.md
+++ b/docs/catch-swallow-prep-2026-05-05.md
@@ -26,7 +26,7 @@ Phase 1a finalized counts:
 
 **Worker-integrated baseline** (Phase 1b scope): 59 untagged sites, 0 tagged. Including this scope, gate metric is 59/168. Phase 1b's job is to apply the same A/B/C framework with the higher per-site judgment density the prep doc spot-check anticipated (~50% C, ~25% B, ~25% A) — the file is too mixed for the bulk tagger; expect mostly hand-classification.
 
-**Residual risk this PR does not fix.** The 4 bucket-B sites (`ai-pitch-extract.ts:191/197`, `ai-production-autofill.ts:211/217`) are credit-deduction and transaction-log writes that can still fail silently between now and Phase 2 landing. They're tagged but not yet wrapped with breadcrumbs. The breadcrumb wrap is the smallest follow-up that actually changes runtime behavior — schedule it before Phase 2 begins, not after.
+**~~Residual risk this PR does not fix.~~ Closed 2026-05-06 by B-site wrap PR.** The 4 bucket-B sites (`ai-pitch-extract.ts:191/197`, `ai-production-autofill.ts:211/217`) were credit-deduction and transaction-log writes that could still fail silently. The B-site wrap landed `observedSwallow` (a `safeQuery`-style helper for best-effort writes) and converted all four sites; revenue/audit-trail leakage is now visible in Sentry under the `catch_swallow.context` tag. Bucket B count is now 0; total `.catch(() => …)` sites in scope dropped from 109 to 105.
 
 **Gate-feeding sites identified during Phase 1a** — 3 sites on paths the original audit was written to address:
 - `services/file-validation.service.ts:394` — fail-open quota bypass; '0' on error lets user upload past quota

--- a/src/db/safe-query.ts
+++ b/src/db/safe-query.ts
@@ -87,3 +87,43 @@ export async function safeQueryOne<T>(
     error: result.ok ? undefined : result.error,
   };
 }
+
+/**
+ * observedSwallow — for best-effort writes where the caller does not act on
+ * the result, but a silent failure represents real cost (revenue leakage,
+ * audit-trail loss, etc.). Catches the error, reports to Sentry with a
+ * context tag so volume is visible, then returns void.
+ *
+ * Use for: post-success cleanup writes (credit deduction after successful AI
+ * call, transaction-log inserts, idempotent state syncs). The original
+ * `.catch(() => {})` pattern was correct in shape — caller cannot recover —
+ * but invisible. This restores observability without changing call-site
+ * semantics.
+ *
+ * Do NOT use for: reads (use `safeQuery`), writes the caller acts on (let
+ * them throw), or true fire-and-forget telemetry where failure isn't a cost
+ * (use plain `.catch(() => {})` with `// fire-and-forget` tag).
+ *
+ *   await observedSwallow(
+ *     () => sql`UPDATE user_credits SET balance = balance - ${cost} ...`,
+ *     'ai-pitch-extract.credit-deduction',
+ *   );
+ */
+export async function observedSwallow(
+  fn: () => Promise<unknown>,
+  context: string,
+): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    try {
+      Sentry.withScope((scope) => {
+        scope.setTag('catch_swallow.context', context);
+        Sentry.captureException(error);
+      });
+    } catch {
+      // Sentry hub not initialized (test env, standalone scripts) — swallow.
+    }
+  }
+}

--- a/src/handlers/ai-pitch-extract.ts
+++ b/src/handlers/ai-pitch-extract.ts
@@ -8,6 +8,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId } from '../utils/auth-extract';
+import { observedSwallow } from '../db/safe-query';
 
 const AI_EXTRACT_CREDIT_COST = 5;
 
@@ -185,19 +186,23 @@ export async function aiPitchExtract(request: Request, env: Env): Promise<Respon
       return errorResponse('AI could not extract structured data from this document. Try a different file.', origin, 422);
     }
 
-    // Deduct credits
-    // TODO(catch-swallow): bucket-B breadcrumb pending — revenue leakage if silent
-    await sql`
-      UPDATE user_credits SET balance = balance - ${AI_EXTRACT_CREDIT_COST}, total_used = total_used + ${AI_EXTRACT_CREDIT_COST}, last_updated = NOW()
-      WHERE user_id = ${Number(userId)}
-    `.catch(() => {});
+    // Deduct credits + log transaction. Best-effort writes — AI response already
+    // returned to user; failures surface in Sentry as revenue/audit leakage.
+    await observedSwallow(
+      () => sql`
+        UPDATE user_credits SET balance = balance - ${AI_EXTRACT_CREDIT_COST}, total_used = total_used + ${AI_EXTRACT_CREDIT_COST}, last_updated = NOW()
+        WHERE user_id = ${Number(userId)}
+      `,
+      'ai-pitch-extract.credit-deduction',
+    );
 
-    // Log credit transaction
-    // TODO(catch-swallow): bucket-B breadcrumb pending — audit trail loss if silent
-    await sql`
-      INSERT INTO credit_transactions (user_id, type, amount, description, balance_before, balance_after, usage_type, created_at)
-      VALUES (${Number(userId)}, 'usage', ${-AI_EXTRACT_CREDIT_COST}, 'AI pitch extraction', ${balance}, ${balance - AI_EXTRACT_CREDIT_COST}, 'ai_extract', NOW())
-    `.catch(() => {});
+    await observedSwallow(
+      () => sql`
+        INSERT INTO credit_transactions (user_id, type, amount, description, balance_before, balance_after, usage_type, created_at)
+        VALUES (${Number(userId)}, 'usage', ${-AI_EXTRACT_CREDIT_COST}, 'AI pitch extraction', ${balance}, ${balance - AI_EXTRACT_CREDIT_COST}, 'ai_extract', NOW())
+      `,
+      'ai-pitch-extract.transaction-log',
+    );
 
     return jsonResponse({
       success: true,

--- a/src/handlers/ai-production-autofill.ts
+++ b/src/handlers/ai-production-autofill.ts
@@ -10,6 +10,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId } from '../utils/auth-extract';
+import { observedSwallow } from '../db/safe-query';
 
 const AUTOFILL_CREDIT_COST = 5;
 
@@ -205,19 +206,23 @@ export async function aiProductionAutofill(request: Request, env: Env): Promise<
       return errorResponse('AI returned incomplete data. Please try again.', origin, 422);
     }
 
-    // Deduct credits
-    // TODO(catch-swallow): bucket-B breadcrumb pending — revenue leakage if silent
-    await sql`
-      UPDATE user_credits SET balance = balance - ${AUTOFILL_CREDIT_COST}, total_used = total_used + ${AUTOFILL_CREDIT_COST}, last_updated = NOW()
-      WHERE user_id = ${Number(userId)}
-    `.catch(() => {});
+    // Deduct credits + log transaction. Best-effort writes — AI response already
+    // returned to user; failures surface in Sentry as revenue/audit leakage.
+    await observedSwallow(
+      () => sql`
+        UPDATE user_credits SET balance = balance - ${AUTOFILL_CREDIT_COST}, total_used = total_used + ${AUTOFILL_CREDIT_COST}, last_updated = NOW()
+        WHERE user_id = ${Number(userId)}
+      `,
+      'ai-production-autofill.credit-deduction',
+    );
 
-    // Log credit transaction
-    // TODO(catch-swallow): bucket-B breadcrumb pending — audit trail loss if silent
-    await sql`
-      INSERT INTO credit_transactions (user_id, type, amount, description, balance_before, balance_after, usage_type, created_at)
-      VALUES (${Number(userId)}, 'usage', ${-AUTOFILL_CREDIT_COST}, 'AI production auto-fill', ${balance}, ${balance - AUTOFILL_CREDIT_COST}, 'ai_autofill', NOW())
-    `.catch(() => {});
+    await observedSwallow(
+      () => sql`
+        INSERT INTO credit_transactions (user_id, type, amount, description, balance_before, balance_after, usage_type, created_at)
+        VALUES (${Number(userId)}, 'usage', ${-AUTOFILL_CREDIT_COST}, 'AI production auto-fill', ${balance}, ${balance - AUTOFILL_CREDIT_COST}, 'ai_autofill', NOW())
+      `,
+      'ai-production-autofill.transaction-log',
+    );
 
     return jsonResponse({
       success: true,


### PR DESCRIPTION
## Summary

Closes the residual risk flagged in #85's PR body — the 4 bucket-B sites that were tagged but not yet wrapped. Adds `observedSwallow` helper to `src/db/safe-query.ts` and converts all 4 sites.

| Site | Was | Now |
|---|---|---|
| `ai-pitch-extract.ts:191` (credit deduction) | `sql\`...\`.catch(() => {})` | `observedSwallow(() => sql\`...\`, 'ai-pitch-extract.credit-deduction')` |
| `ai-pitch-extract.ts:197` (transaction log) | same | tag `'ai-pitch-extract.transaction-log'` |
| `ai-production-autofill.ts:211` (credit deduction) | same | tag `'ai-production-autofill.credit-deduction'` |
| `ai-production-autofill.ts:217` (transaction log) | same | tag `'ai-production-autofill.transaction-log'` |

## What `observedSwallow` does

```ts
export async function observedSwallow(
  fn: () => Promise<unknown>,
  context: string,
): Promise<void>
```

Runs `fn`. On error: reports to Sentry via `withScope` + `captureException` with a `catch_swallow.context` tag set to `context`. Returns `void` either way. Inner try/catch around the Sentry call so missing-hub contexts (test env) don't throw.

Same shape as `safeQuery` but for best-effort writes. Use docstring discriminates clearly between this, `safeQuery` (reads), and `// fire-and-forget` (true telemetry).

## Why a helper, not inline try/catch

Four sites with identical 10-line scaffolding is past the inline-repetition threshold per CLAUDE.md ("three similar lines is better than premature abstraction" — four is past three). Helper inlines to ~3 lines per call site, and the Sentry-hub-not-initialized guard lives in one place.

## Gate metric (excl. `worker-integrated.ts`)

| | Before #85 | After #85 | After this PR |
|---|---:|---:|---:|
| Total `.catch(() => …)` | 114 | 109 | **105** |
| A. fire-and-forget | 0 | 8 | 8 |
| B. breadcrumb pending | — | 4 | **0** |
| C. TODO migrate | 0 | 97 | 97 |
| Untagged | 114 | 0 | 0 |

The 4 bucket-B sites are no longer `.catch(() => …)` patterns at all — they're function calls into the helper, so they drop out of the counter naturally.

## Behavior change (this PR has runtime impact, unlike #85)

Each silent credit-deduction or audit-log failure now produces a Sentry event with a `catch_swallow.context` tag identifying the call site. Revenue leakage and audit-trail loss are visible in the Sentry issue list rather than invisible in `.catch(() => {})` voids.

Search in Sentry: `tags["catch_swallow.context"]:"ai-pitch-extract.credit-deduction"` etc.

## Test plan

- [x] Gate counter reports `B = 0`, `Untagged = 0`
- [x] TS imports resolve (helper exported from existing `src/db/safe-query.ts`)
- [ ] CI green
- [ ] Behavioral check post-deploy: trigger a credit-deduction failure (e.g. revoke DB perms briefly in staging) and verify a Sentry event appears with the expected tag

## What this unblocks

Phase 2 prerequisite was "B-site wrap before per-site C migration" so a Phase-2 reviewer can distinguish "this PR migrated a site that was already observable" from "this PR migrated a site that was silent." With B sites now wrapped, Phase 2 PRs land on a clean baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)