### PR TITLE
Phase 1b B-site wrap (worker-integrated.ts) — 8 sites

### DIFF
--- a/docs/catch-swallow-prep-2026-05-05.md
+++ b/docs/catch-swallow-prep-2026-05-05.md
@@ -50,16 +50,18 @@ Phase 1a finalized counts:
 - **B — breadcrumb pending**: 4 sites (credit deduction + transaction log writes; Phase 2 prerequisite)
 - **C — TODO(catch-swallow): migrate**: 97 sites (read-side dashboard fallbacks + 3 gate-feeding sites flagged in TODO text)
 
-**Worker-integrated baseline** (Phase 1b scope): ~~59 untagged sites, 0 tagged~~ — closed 2026-05-06 by Phase 1b PR. Tree-wide gate metric across `src/` is now **0/168**.
+**Worker-integrated baseline** (Phase 1b scope): ~~59 untagged sites, 0 tagged~~ — closed 2026-05-06 by Phase 1b PR. Tree-wide gate metric across `src/` is now **0 untagged / 156 total** (164 after Phase 1b tag sweep, then -8 by Phase 1b B-site wrap below).
 
 Phase 1b finalized counts (worker-integrated.ts only):
 - **A — fire-and-forget**: 15 sites (post-login password rehash, Stripe cleanup, Axiom logging, search-click tracking, session DELETEs, share-event INSERTs)
-- **B — breadcrumb pending**: 8 sites (Stripe `getSubscription` reads, INSERT-RETURNING patterns where caller checks null, auth-optional fallback)
+- **B — breadcrumb pending**: ~~8 sites~~ → 0 sites (closed 2026-05-06 by Phase 1b B-site wrap; see below). Were: Stripe `getSubscription` reads (×2), INSERT/UPDATE-RETURNING with caller null-check (×5), auth-optional fallback (×1).
 - **C — TODO(catch-swallow): migrate**: 36 sites (analytics dashboard reads, browse aggregates, info_requests reads, NDA document lookups)
 
 Distribution: 25% A / 14% B / 61% C — close to the spot-check prediction of 25/25/50. Each site received per-site human classification (no bulk-by-file shortcut available — file is too mixed). Tagger config preserved as the audit artifact: see PR diff for the line→bucket mapping.
 
 **~~Residual risk this PR does not fix.~~ Closed 2026-05-06 by B-site wrap PR.** The 4 bucket-B sites (`ai-pitch-extract.ts:191/197`, `ai-production-autofill.ts:211/217`) were credit-deduction and transaction-log writes that could still fail silently. The B-site wrap landed `observedSwallow` (a `safeQuery`-style helper for best-effort writes) and converted all four sites; revenue/audit-trail leakage is now visible in Sentry under the `catch_swallow.context` tag. Bucket B count is now 0; total `.catch(() => …)` sites in scope dropped from 109 to 105.
+
+**Phase 1b B-site wrap (2026-05-06)** — sibling helper `observedSwallowReturning<T, F>` added to `src/db/safe-query.ts` for best-effort operations where the caller reads the result but accepts a fallback (typically `null`). Converted all 8 bucket-B sites in `worker-integrated.ts`: 2× `stripe.getSubscription` (Stripe webhook → invoice paid / checkout session), 3× INSERT-RETURNING with null-check (scheduled_reports, calendar_events, info_requests), 2× UPDATE-RETURNING with null-check (info_requests respond/update), 1× auth-optional fallback (demo request). Failures now produce a Sentry event tagged with the call site (e.g. `stripe-webhook.invoice-paid.get-subscription`, `info-request.update`, `demo-request.auth-optional`). Bucket B in `worker-integrated.ts` is 0; total `.catch(() => …)` sites in `src/` dropped from 164 to 156.
 
 **Gate-feeding sites identified during Phase 1a** — 3 sites on paths the original audit was written to address:
 - `services/file-validation.service.ts:394` — fail-open quota bypass; '0' on error lets user upload past quota

--- a/src/db/safe-query.ts
+++ b/src/db/safe-query.ts
@@ -127,3 +127,41 @@ export async function observedSwallow(
     }
   }
 }
+
+/**
+ * observedSwallowReturning — sibling of `observedSwallow` for best-effort
+ * operations where the caller *does* read the result but accepts a fallback
+ * on failure (typically `null` from an INSERT/UPDATE-RETURNING or an external
+ * API read). Catches, reports to Sentry with a context tag, and returns the
+ * fallback. Restores observability without changing the caller's null-check.
+ *
+ * Two generics so the fallback's shape doesn't need to match `T` exactly —
+ * the common case is `T = SomeRow[]`, fallback `null`, return `T | null`.
+ *
+ *   const result = await observedSwallowReturning(
+ *     () => this.db.query(`INSERT INTO ... RETURNING *`, [...]),
+ *     'handle-info-request.insert',
+ *     null,
+ *   );
+ *   if (result && result[0]) { ... }
+ */
+export async function observedSwallowReturning<T, F>(
+  fn: () => Promise<T>,
+  context: string,
+  fallback: F,
+): Promise<T | F> {
+  try {
+    return await fn();
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    try {
+      Sentry.withScope((scope) => {
+        scope.setTag('catch_swallow.context', context);
+        Sentry.captureException(error);
+      });
+    } catch {
+      // Sentry hub not initialized (test env, standalone scripts) — swallow.
+    }
+    return fallback;
+  }
+}

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -16,7 +16,7 @@ import * as Sentry from '@sentry/cloudflare';
 import { createAxiomLogger } from './middleware/axiom-logging';
 // Per-request trace context for SQLCommenter + Axiom query correlation
 import { traceStorage } from './db/trace-context';
-import { safeQuery } from './db/safe-query';
+import { safeQuery, observedSwallowReturning } from './db/safe-query';
 
 import { createDatabase } from './db/raw-sql-connection';
 import { UserProfileRoutes } from './routes/user-profile';
@@ -9980,8 +9980,11 @@ pitchey_analytics_datapoints_per_minute 1250
             const subId = session.subscription;
             let sub = null;
             if (subId) {
-              // TODO(catch-swallow): bucket-B breadcrumb pending — stripe.getSubscription, caller checks null
-              sub = await stripe.getSubscription(subId).catch(() => null);
+              sub = await observedSwallowReturning(
+                () => stripe.getSubscription(subId),
+                'stripe-webhook.checkout-session.get-subscription',
+                null,
+              );
             }
 
             const tierId = session.metadata?.tier || 'unknown';
@@ -10109,8 +10112,11 @@ pitchey_analytics_datapoints_per_minute 1250
             userId = historyRows[0].user_id;
             tierId = historyRows[0].new_tier;
           } else {
-            // TODO(catch-swallow): bucket-B breadcrumb pending — stripe.getSubscription, caller checks null
-            const sub = await stripe.getSubscription(subId).catch(() => null);
+            const sub = await observedSwallowReturning(
+              () => stripe.getSubscription(subId),
+              'stripe-webhook.invoice-paid.get-subscription',
+              null,
+            );
             const metaUserId = parseInt(sub?.metadata?.userId || '');
             const metaTier = sub?.metadata?.tier;
             if (metaUserId && metaTier) {
@@ -12990,12 +12996,15 @@ pitchey_analytics_datapoints_per_minute 1250
     try {
       const body = await request.json() as Record<string, unknown>;
 
-      // TODO(catch-swallow): bucket-B breadcrumb pending — INSERT scheduled_reports returning null; caller checks null
-      const result = await this.db.query(`
-        INSERT INTO scheduled_reports (user_id, report_type, frequency, filters, next_run, created_at)
-        VALUES ($1, $2, $3, $4, NOW() + INTERVAL '1 day', NOW())
-        RETURNING id, next_run
-      `, [authResult.user!.id, (body.type as string) || 'analytics', (body.frequency as string) || 'weekly', JSON.stringify(body.filters || {})]).catch(() => null);
+      const result = await observedSwallowReturning(
+        () => this.db.query(`
+          INSERT INTO scheduled_reports (user_id, report_type, frequency, filters, next_run, created_at)
+          VALUES ($1, $2, $3, $4, NOW() + INTERVAL '1 day', NOW())
+          RETURNING id, next_run
+        `, [authResult.user!.id, (body.type as string) || 'analytics', (body.frequency as string) || 'weekly', JSON.stringify(body.filters || {})]),
+        'scheduled-report.insert',
+        null,
+      );
 
       if (result && result[0]) {
         return builder.success({ success: true, reportId: result[0].id, nextRun: result[0].next_run });
@@ -13227,18 +13236,21 @@ pitchey_analytics_datapoints_per_minute 1250
       const body = await request.json() as Record<string, unknown>;
 
       // Create a calendar event for the meeting
-      // TODO(catch-swallow): bucket-B breadcrumb pending — INSERT calendar_events returning null; caller checks null
-      const result = await this.db.query(`
-        INSERT INTO calendar_events (user_id, title, description, start_date, end_date, event_type, color, created_at)
-        VALUES ($1, $2, $3, $4, $5, 'meeting', '#3b82f6', NOW())
-        RETURNING id, title, start_date
-      `, [
-        authResult.user!.id,
-        `Meeting: ${body.meetingType || 'general'}`,
-        (body.message as string) || '',
-        (body.dateTime as string) || new Date().toISOString(),
-        body.dateTime ? new Date(new Date(body.dateTime as string).getTime() + ((body.duration as number) || 60) * 60000).toISOString() : new Date(Date.now() + 3600000).toISOString()
-      ]).catch(() => null);
+      const result = await observedSwallowReturning(
+        () => this.db.query(`
+          INSERT INTO calendar_events (user_id, title, description, start_date, end_date, event_type, color, created_at)
+          VALUES ($1, $2, $3, $4, $5, 'meeting', '#3b82f6', NOW())
+          RETURNING id, title, start_date
+        `, [
+          authResult.user!.id,
+          `Meeting: ${body.meetingType || 'general'}`,
+          (body.message as string) || '',
+          (body.dateTime as string) || new Date().toISOString(),
+          body.dateTime ? new Date(new Date(body.dateTime as string).getTime() + ((body.duration as number) || 60) * 60000).toISOString() : new Date(Date.now() + 3600000).toISOString()
+        ]),
+        'meeting.calendar-event-insert',
+        null,
+      );
 
       if (result && result[0]) {
         return builder.success({
@@ -13393,11 +13405,14 @@ pitchey_analytics_datapoints_per_minute 1250
     const builder = new ApiResponseBuilder(request);
     try {
       const body = await request.json() as Record<string, unknown>;
-      // TODO(catch-swallow): bucket-B breadcrumb pending — INSERT info_requests returning null; caller checks null
-      const result = await this.db.query(`
-        INSERT INTO info_requests (requester_id, target_user_id, pitch_id, message, status, created_at)
-        VALUES ($1, $2, $3, $4, 'pending', NOW()) RETURNING *
-      `, [authResult.user!.id, body.targetUserId as string | number, (body.pitchId as string | number | null) || null, (body.message as string) || '']).catch(() => null);
+      const result = await observedSwallowReturning(
+        () => this.db.query(`
+          INSERT INTO info_requests (requester_id, target_user_id, pitch_id, message, status, created_at)
+          VALUES ($1, $2, $3, $4, 'pending', NOW()) RETURNING *
+        `, [authResult.user!.id, body.targetUserId as string | number, (body.pitchId as string | number | null) || null, (body.message as string) || '']),
+        'info-request.insert',
+        null,
+      );
 
       if (result && result[0]) {
         return builder.success(result[0]);
@@ -13416,11 +13431,14 @@ pitchey_analytics_datapoints_per_minute 1250
     const params = (request as any).params;
     try {
       const body = await request.json() as Record<string, unknown>;
-      // TODO(catch-swallow): bucket-B breadcrumb pending — UPDATE info_requests returning null; caller checks null
-      const result = await this.db.query(`
-        UPDATE info_requests SET response = $1, status = 'responded', updated_at = NOW()
-        WHERE id = $2 AND target_user_id = $3 RETURNING *
-      `, [body.response, params.id, authResult.user!.id]).catch(() => null);
+      const result = await observedSwallowReturning(
+        () => this.db.query(`
+          UPDATE info_requests SET response = $1, status = 'responded', updated_at = NOW()
+          WHERE id = $2 AND target_user_id = $3 RETURNING *
+        `, [body.response, params.id, authResult.user!.id]),
+        'info-request.respond',
+        null,
+      );
 
       if (result && result[0]) {
         return builder.success(result[0]);
@@ -13439,11 +13457,14 @@ pitchey_analytics_datapoints_per_minute 1250
     const params = (request as any).params;
     try {
       const body = await request.json() as Record<string, unknown>;
-      // TODO(catch-swallow): bucket-B breadcrumb pending — UPDATE info_requests returning null; caller checks null
-      const result = await this.db.query(`
-        UPDATE info_requests SET status = $1, updated_at = NOW()
-        WHERE id = $2 AND (requester_id = $3 OR target_user_id = $3) RETURNING *
-      `, [body.status, params.id, authResult.user!.id]).catch(() => null);
+      const result = await observedSwallowReturning(
+        () => this.db.query(`
+          UPDATE info_requests SET status = $1, updated_at = NOW()
+          WHERE id = $2 AND (requester_id = $3 OR target_user_id = $3) RETURNING *
+        `, [body.status, params.id, authResult.user!.id]),
+        'info-request.update',
+        null,
+      );
 
       if (result && result[0]) {
         return builder.success(result[0]);
@@ -13460,8 +13481,11 @@ pitchey_analytics_datapoints_per_minute 1250
       const body = await request.json() as Record<string, unknown>;
 
       // Log demo request (may or may not have auth)
-      // TODO(catch-swallow): bucket-B breadcrumb pending — auth-optional fallback; auth backend errors should be visible
-      const authResult = await this.requireAuth(request).catch(() => ({ authorized: false, user: null }));
+      const authResult = await observedSwallowReturning(
+        () => this.requireAuth(request),
+        'demo-request.auth-optional',
+        { authorized: false, user: null },
+      );
 
       // fire-and-forget — demo-request insert; non-fatal
       await this.db.query(`


### PR DESCRIPTION
## Summary
- Adds `observedSwallowReturning<T, F>(fn, context, fallback): Promise<T | F>` to `src/db/safe-query.ts` — sibling of `observedSwallow` (#86) for best-effort operations where the caller reads the return value.
- Wraps the 8 bucket-B `.catch(() => …)` sites in `worker-integrated.ts` tagged by Phase 1b (#87).
- Each silent failure now produces a Sentry event tagged with the call site (e.g. `stripe-webhook.invoice-paid.get-subscription`); caller's null-check semantics unchanged.

## Why a sibling helper rather than reusing `observedSwallow`?
`observedSwallow(fn, context): Promise<void>` discards the return. The 8 sites here all read the result — Stripe `getSubscription` reads, INSERT/UPDATE-RETURNING `[0]` reads, auth-optional fallback. Two generics on `observedSwallowReturning` so the fallback's shape doesn't need to match `T` exactly (typical case: `T = Row[]`, fallback `null`, return `Row[] | null`).

## Sites converted
| Was line | Context tag | Pattern |
|---|---|---|
| 9984  | `stripe-webhook.checkout-session.get-subscription` | `stripe.getSubscription(subId)` |
| 10113 | `stripe-webhook.invoice-paid.get-subscription` | `stripe.getSubscription(subId)` |
| 12998 | `scheduled-report.insert` | INSERT-RETURNING |
| 13241 | `meeting.calendar-event-insert` | INSERT-RETURNING |
| 13400 | `info-request.insert` | INSERT-RETURNING |
| 13423 | `info-request.respond` | UPDATE-RETURNING |
| 13446 | `info-request.update` | UPDATE-RETURNING |
| 13464 | `demo-request.auth-optional` | `requireAuth().catch(...)` |

## Stacking
Depends on PR #86 (helper file) and PR #87 (markers). Branched off PR #87's tip with PR #86 merged in. Once both base PRs land on main, this diff vs main collapses to just the new wrap commit (3 files, +106/-42).

## Gate metric (incl. worker-integrated.ts)
- Bucket B:           **8 → 0**
- Total .catch sites: 164 → 156
- Untagged:           0 → 0

## Test plan
- [x] Type-check (`tsc --noEmit` against root tsconfig.json) — 0 new errors; 12 pre-existing errors all in unrelated files
- [x] `node scripts/catch-swallow-gate.mjs --include-worker` shows B:0, untagged:0
- [ ] Behavioral verification deferred to Sentry traffic post-deploy (no semantic change on success path; helper just adds breadcrumbs on the error path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)