### PR TITLE
ci: block catch-swallow regression with --threshold 0 gate

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -118,6 +118,15 @@ jobs:
           echo "🔍 Validating Worker syntax..."
           node -c dist/worker.js || echo "⚠️ Worker validation failed"
 
+      - name: 🪝 Catch-swallow gate (untagged residue)
+        # Blocks regression: every new `.catch(() => …)` site must carry an
+        # A/B/C tag (`// fire-and-forget` | `// TODO(catch-swallow): bucket-B`
+        # | `// TODO(catch-swallow)`). Default scope excludes worker-integrated.ts
+        # — that file's enforcement is a follow-up after PR #87 + #88 land.
+        # See docs/catch-swallow-prep-2026-05-05.md and
+        # docs/catch-swallow-audit-2026-04-17.md.
+        run: node scripts/catch-swallow-gate.mjs --threshold 0 --list
+
   # =================================================================
   # DATABASE TESTS
   # =================================================================


### PR DESCRIPTION
## Summary
Wires `node scripts/catch-swallow-gate.mjs --threshold 0 --list` into the Worker Tests job in `.github/workflows/ci-cd.yml`. Default scope (excl. `worker-integrated.ts`) is the orchestrator-prerequisite metric named in CLAUDE.md and `docs/strategy-five-pillars-2026-05-02.md`.

Any new untagged `.catch(() => …)` site in `src/handlers`, `src/services`, or `src/utils` now fails CI. The gate already passes on main today (0/109).

## Why this job, not a new one
The gate is a single-step pure-Node check (no install needed; the script reads files). Worker Tests is the smallest fast job in `ci-cd.yml` — natural home, zero install overhead.

## Why threshold 0 today
PR #85 (Phase 1a tag sweep) put the default-scope count at **0/109 untagged** on main. The orchestrator gate spec ("<30 untagged") is already cleared — locking it at 0 prevents drift back up.

## Why default scope, not include-worker
Worker-integrated still has 59 untagged on main today. PR #87 (Phase 1b tag sweep) closes that to 0; PR #88 (Phase 1b B-site wrap) further drops total .catch sites 164 → 156. Once both land, a second step with `--include-worker --threshold 0` becomes feasible — the strictest possible baseline. Doing it now would block all PRs.

## Test plan
- [x] Local run on main: `node scripts/catch-swallow-gate.mjs --threshold 0 --list` → `Untagged: 0`, exit 0.
- [x] Existing CI workflow's Worker Tests job runs on every PR + push to main; new step inherits that.
- [ ] Verify the step appears as a green check on this PR's CI run (pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)