### PR TITLE
fix(catch-swallow): Phase 1a tagger inserted // comments mid-SQL-template

### DIFF
--- a/scripts/catch-swallow-gate.mjs
+++ b/scripts/catch-swallow-gate.mjs
@@ -55,7 +55,9 @@ const TAG_BUCKET_B = /\/\/\s*TODO\(catch-swallow\):\s*bucket-B\b/;
 const TAG_TODO = /\/\/\s*TODO\(catch-swallow\)/;
 
 // STMT_START: `sql\`` and `\w+\.\w+\(` included so each Promise.all element is its own statement.
-const STMT_START = /^(await\s|return\s|const\s|let\s|var\s|this\.|\w+\s*=|sql`|\(sql`|\w+\.\w+\()/;
+// `\w+\s*=\s*\(?\s*await\s` (not bare `\w+\s*=`) — see scripts/catch-swallow-tag.mjs for rationale.
+// `\(?` allows for `x = (await sql\`...\`.catch(...))` parenthesized form.
+const STMT_START = /^(await\s|return\s|const\s|let\s|var\s|this\.|\w+\s*=\s*\(?\s*await\s|\w+\s*=\s*sql`|sql`|\(sql`|\w+\.\w+\()/;
 
 function classify(lines, idx) {
   // Walk backwards from the `.catch(...)` line through the statement body
@@ -76,8 +78,41 @@ function classify(lines, idx) {
   return 'untagged';
 }
 
+// findMidTemplateComments — flags `// TODO(catch-swallow)` or `// fire-and-forget`
+// lines that sit *inside* a `sql\`…\`` template literal. PostgreSQL has no `//`
+// comment syntax, so any such line breaks the SQL at runtime — the breakage is
+// invisible because the catch swallows it. PR #85's tagger had a STMT_START
+// regex bug that produced 5 of these in handlers (fixed in this PR).
+function findMidTemplateComments(lines) {
+  const out = [];
+  // Track `sql\`…\`` template depth — only reset when a closing backtick is
+  // followed (after .catch chain or end-of-statement) by a non-template line.
+  // For our codebase, every `sql\`` template terminates with `\`` on its own
+  // line, optionally with `.catch(...)` or `;`. We treat any line containing a
+  // bare backtick (not preceded by `\\`) as the closer when a template is open.
+  let inTemplate = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!inTemplate) {
+      if (/\bsql`/.test(line) && !/sql`[^`]*`/.test(line)) inTemplate = true;
+      continue;
+    }
+    // In template — check for closing backtick
+    if (/`/.test(line)) inTemplate = false;
+    // Tag lines inside the template are bugs.
+    // `\b` only attached to `fire-and-forget` (after the word `forget`); not to
+    // `TODO(catch-swallow)` because `)` is non-word and the next char (`:` or EOL)
+    // is also non-word — `\b` would never fire and the bug detector silently passes.
+    if (/^[ \t]*\/\/\s*(?:TODO\(catch-swallow\)|fire-and-forget\b)/.test(line)) {
+      out.push(i + 1); // 1-based
+    }
+  }
+  return out;
+}
+
 const files = walk(SRC);
 const buckets = { A: [], B: [], C: [], untagged: [] };
+const midTemplateBugs = []; // { file, line }[]
 
 for (const file of files) {
   const rel = file.slice(SRC.length + 1);
@@ -88,6 +123,9 @@ for (const file of files) {
     if (!CATCH_RE.test(lines[i])) continue;
     const bucket = classify(lines, i);
     buckets[bucket].push(`${rel}:${i + 1}`);
+  }
+  for (const ln of findMidTemplateComments(lines)) {
+    midTemplateBugs.push(`${rel}:${ln}`);
   }
 }
 
@@ -104,6 +142,12 @@ console.log(`  Untagged (gate metric):         ${untagged}`);
 if (list && untagged > 0) {
   console.log('\nUntagged sites:');
   for (const site of buckets.untagged) console.log(`  ${site}`);
+}
+
+if (midTemplateBugs.length > 0) {
+  console.error(`\nGate FAIL: ${midTemplateBugs.length} mid-template comment(s) — these break SQL at runtime, masked by .catch:`);
+  for (const site of midTemplateBugs) console.error(`  ${site}`);
+  process.exit(1);
 }
 
 if (threshold !== null && untagged > threshold) {

--- a/scripts/catch-swallow-tag.mjs
+++ b/scripts/catch-swallow-tag.mjs
@@ -33,7 +33,14 @@ const CATCH_RE = /\.catch\(\(\)\s*=>/;
 // STMT_START matches the line that begins the catch's statement. `sql\`` and
 // `\w+\.\w+\(` are included so each element of a Promise.all([sql\`\`.catch,
 // db.query(...).catch]) gets its own statement-start (and its own tag).
-const STMT_START = /^(await\s|return\s|const\s|let\s|var\s|this\.|\w+\s*=|sql`|\(sql`|\w+\.\w+\()/;
+//
+// `\w+\s*=\s*await\s` (not bare `\w+\s*=`) — bare form matched SQL column
+// assignments (`updated_at = NOW()`, `status = COALESCE(...)`) inside an
+// UPDATE template, anchoring the walker to the wrong line and inserting the
+// tag *inside* the SQL template. The `await` prefix is mandatory in the
+// codebase for these statements (every `.catch(() => …)` site reads from a
+// promise) so this loses no real call sites. See PR #85 fallout.
+const STMT_START = /^(await\s|return\s|const\s|let\s|var\s|this\.|\w+\s*=\s*\(?\s*await\s|\w+\s*=\s*sql`|sql`|\(sql`|\w+\.\w+\()/;
 const TAG_FAF = /\/\/\s*fire-and-forget\b/;
 const TAG_TODO = /\/\/\s*TODO\(catch-swallow\)/;
 

--- a/src/handlers/creator-dashboard-extended.ts
+++ b/src/handlers/creator-dashboard-extended.ts
@@ -147,13 +147,13 @@ export async function creatorContractUpdateHandler(request: Request, env: Env): 
     const status = typeof body.status === 'string' ? body.status : undefined;
     const notes = typeof body.notes === 'string' ? body.notes : undefined;
 
+    // TODO(catch-swallow): migrate to safeQuery
     const result = await sql`
       UPDATE contracts
       SET
         title = COALESCE(${title ?? null}, title),
         status = COALESCE(${status ?? null}, status),
         notes = COALESCE(${notes ?? null}, notes),
-        // TODO(catch-swallow): migrate to safeQuery
         updated_at = NOW()
       WHERE id = ${contractId} AND creator_id = ${userId}
       RETURNING *

--- a/src/handlers/production-dashboard-extended.ts
+++ b/src/handlers/production-dashboard-extended.ts
@@ -253,13 +253,13 @@ export async function productionProjectStatusHandler(request: Request, env: Env)
       return errorResponse(`Invalid stage. Must be one of: ${validStages.join(', ')}`, origin);
     }
 
+    // TODO(catch-swallow): migrate to safeQuery
     const result = await sql`
       UPDATE production_pipeline
       SET
         status = COALESCE(${status ?? null}, status),
         stage = COALESCE(${stage ?? null}, stage),
         completion_percentage = COALESCE(${completionPercentage ?? null}, completion_percentage),
-        // TODO(catch-swallow): migrate to safeQuery
         updated_at = NOW()
       WHERE id = ${projectId} AND production_company_id = ${Number(userId)}
       RETURNING *
@@ -300,6 +300,7 @@ export async function productionBudgetUpdateHandler(request: Request, env: Env):
     const contingencyPercentage = typeof body.contingency_percentage === 'number' ? body.contingency_percentage : undefined;
     const contingencyUsed = typeof body.contingency_used === 'number' ? body.contingency_used : undefined;
 
+    // TODO(catch-swallow): migrate to safeQuery
     const result = await sql`
       UPDATE production_pipeline
       SET
@@ -308,7 +309,6 @@ export async function productionBudgetUpdateHandler(request: Request, env: Env):
         budget_remaining = COALESCE(${budgetAllocated ?? null}, budget_allocated) - COALESCE(${budgetSpent ?? null}, budget_spent),
         contingency_percentage = COALESCE(${contingencyPercentage ?? null}, contingency_percentage),
         contingency_used = COALESCE(${contingencyUsed ?? null}, contingency_used),
-        // TODO(catch-swallow): migrate to safeQuery
         updated_at = NOW()
       WHERE id = ${projectId} AND production_company_id = ${Number(userId)}
       RETURNING id, budget_allocated, budget_spent, budget_remaining, contingency_percentage, contingency_used
@@ -410,6 +410,7 @@ export async function productionScheduleUpdateHandler(request: Request, env: Env
 
       if (!scheduledDate) continue;
 
+      // TODO(catch-swallow): migrate to safeQuery
       const row = await sql`
         INSERT INTO production_schedules (project_id, scene_number, scene_description, scheduled_date, call_time, wrap_time, status)
         VALUES (${projectId}, ${sceneNumber}, ${sceneDescription}, ${scheduledDate}, ${callTime}, ${wrapTime}, ${schedStatus})
@@ -420,7 +421,6 @@ export async function productionScheduleUpdateHandler(request: Request, env: Env
           call_time = EXCLUDED.call_time,
           wrap_time = EXCLUDED.wrap_time,
           status = EXCLUDED.status,
-          // TODO(catch-swallow): migrate to safeQuery
           updated_at = NOW()
         RETURNING *
       `.catch(() => []);

--- a/src/handlers/production-deals.ts
+++ b/src/handlers/production-deals.ts
@@ -346,6 +346,7 @@ export async function updateProjectMilestone(request: Request, env: Env): Promis
     const dueDate = typeof body.due_date === 'string' ? body.due_date : undefined;
     const notes = typeof body.notes === 'string' ? body.notes : undefined;
 
+    // TODO(catch-swallow): migrate to safeQuery
     const result = await sql`
       UPDATE project_milestones
       SET
@@ -358,7 +359,6 @@ export async function updateProjectMilestone(request: Request, env: Env): Promis
           WHEN ${completed ?? null} = false THEN NULL
           ELSE completed_at
         END,
-        // TODO(catch-swallow): migrate to safeQuery
         updated_at = NOW()
       WHERE id = ${milestoneId} AND project_id = ${projectId}
       RETURNING *


### PR DESCRIPTION
## Summary

The Phase 1a tagger (PR #85, `4b8ec2b3`) had a `STMT_START` regex bug that anchored the comment-insertion walker on SQL column-assignment lines (e.g. `updated_at = NOW()`, `status = COALESCE(...)`) inside `UPDATE` templates. As a result, 5 `// TODO(catch-swallow): migrate to safeQuery` lines were inserted **inside** `sql\`…\`` template literals.

PostgreSQL has no `//` comment syntax — these queries fail at parse time. The breakage is invisible because each site is wrapped in `.catch(() => [])` (the exact anti-pattern Phase 1 was tagging for migration).

## Affected sites

All on the live request path:
- `src/handlers/creator-dashboard-extended.ts:156` — `UPDATE contracts SET … status = $1`
- `src/handlers/production-dashboard-extended.ts:262` — `UPDATE production_pipeline SET status`
- `src/handlers/production-dashboard-extended.ts:311` — `UPDATE production_pipeline SET budget`
- `src/handlers/production-dashboard-extended.ts:423` — `UPSERT production_schedules`
- `src/handlers/production-deals.ts:361` — `UPDATE project_milestones`

## Fixes

1. **Move comments out of templates** — relocated all 5 `// TODO(catch-swallow)` lines to before `const result = await sql\``.
2. **`scripts/catch-swallow-tag.mjs`** — tightened `STMT_START` to require `await` (or parenthesized `(?await`) after `=` so SQL column assignments no longer match.
3. **`scripts/catch-swallow-gate.mjs`** — same regex fix + new `findMidTemplateComments()` walker that flags any `// TODO(catch-swallow)` or `// fire-and-forget` line sitting inside a `sql\`…\`` template literal; gate exits 1 if any are found.
4. **Regex care**: `\b` is **not** attached to `TODO(catch-swallow)` (`)` is non-word, next char also non-word — boundary never fires). `\b` retained only on `fire-and-forget` to prevent matching `fire-and-forgetting`. This was the bug that initially hid the broken state during gate verification.

## Verification

```
$ node scripts/catch-swallow-gate.mjs --threshold 0
Scope: src/ (excl. worker-integrated.ts)
Total `.catch(() => …)` sites:  109
  A. fire-and-forget:             8
  B. bucket-B breadcrumb pending: 4
  C. TODO(catch-swallow):         97
  Untagged (gate metric):         0
---exit=0---
```

Reverting any of the 5 fixes (e.g. moving the comment back into the template) makes the gate exit 1 with `Gate FAIL: N mid-template comment(s)`.

## Test plan

- [x] Gate passes with all 5 fixes in place (0 untagged, 0 mid-template)
- [x] Gate fails with 1 mid-template error if any fix is reverted
- [x] `tsc --noEmit` clean for all 5 modified handler files
- [ ] Live verification post-merge: dashboard endpoints exercising the 5 SQL paths return 200 instead of degraded

🤖 Generated with [Claude Code](https://claude.com/claude-code)