### PR TITLE
Phase 2.3: creator + grab-bag → safeQuery (closes bucket-C in src/ ex worker-integrated)

### DIFF
--- a/scripts/catch-swallow-gate.mjs
+++ b/scripts/catch-swallow-gate.mjs
@@ -55,7 +55,9 @@ const TAG_BUCKET_B = /\/\/\s*TODO\(catch-swallow\):\s*bucket-B\b/;
 const TAG_TODO = /\/\/\s*TODO\(catch-swallow\)/;
 
 // STMT_START: `sql\`` and `\w+\.\w+\(` included so each Promise.all element is its own statement.
-const STMT_START = /^(await\s|return\s|const\s|let\s|var\s|this\.|\w+\s*=|sql`|\(sql`|\w+\.\w+\()/;
+// `\w+\s*=\s*\(?\s*await\s` (not bare `\w+\s*=`) — see scripts/catch-swallow-tag.mjs for rationale.
+// `\(?` allows for `x = (await sql\`...\`.catch(...))` parenthesized form.
+const STMT_START = /^(await\s|return\s|const\s|let\s|var\s|this\.|\w+\s*=\s*\(?\s*await\s|\w+\s*=\s*sql`|sql`|\(sql`|\w+\.\w+\()/;
 
 function classify(lines, idx) {
   // Walk backwards from the `.catch(...)` line through the statement body
@@ -76,8 +78,41 @@ function classify(lines, idx) {
   return 'untagged';
 }
 
+// findMidTemplateComments — flags `// TODO(catch-swallow)` or `// fire-and-forget`
+// lines that sit *inside* a `sql\`…\`` template literal. PostgreSQL has no `//`
+// comment syntax, so any such line breaks the SQL at runtime — the breakage is
+// invisible because the catch swallows it. PR #85's tagger had a STMT_START
+// regex bug that produced 5 of these in handlers (fixed in this PR).
+function findMidTemplateComments(lines) {
+  const out = [];
+  // Track `sql\`…\`` template depth — only reset when a closing backtick is
+  // followed (after .catch chain or end-of-statement) by a non-template line.
+  // For our codebase, every `sql\`` template terminates with `\`` on its own
+  // line, optionally with `.catch(...)` or `;`. We treat any line containing a
+  // bare backtick (not preceded by `\\`) as the closer when a template is open.
+  let inTemplate = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!inTemplate) {
+      if (/\bsql`/.test(line) && !/sql`[^`]*`/.test(line)) inTemplate = true;
+      continue;
+    }
+    // In template — check for closing backtick
+    if (/`/.test(line)) inTemplate = false;
+    // Tag lines inside the template are bugs.
+    // `\b` only attached to `fire-and-forget` (after the word `forget`); not to
+    // `TODO(catch-swallow)` because `)` is non-word and the next char (`:` or EOL)
+    // is also non-word — `\b` would never fire and the bug detector silently passes.
+    if (/^[ \t]*\/\/\s*(?:TODO\(catch-swallow\)|fire-and-forget\b)/.test(line)) {
+      out.push(i + 1); // 1-based
+    }
+  }
+  return out;
+}
+
 const files = walk(SRC);
 const buckets = { A: [], B: [], C: [], untagged: [] };
+const midTemplateBugs = []; // { file, line }[]
 
 for (const file of files) {
   const rel = file.slice(SRC.length + 1);
@@ -88,6 +123,9 @@ for (const file of files) {
     if (!CATCH_RE.test(lines[i])) continue;
     const bucket = classify(lines, i);
     buckets[bucket].push(`${rel}:${i + 1}`);
+  }
+  for (const ln of findMidTemplateComments(lines)) {
+    midTemplateBugs.push(`${rel}:${ln}`);
   }
 }
 
@@ -104,6 +142,12 @@ console.log(`  Untagged (gate metric):         ${untagged}`);
 if (list && untagged > 0) {
   console.log('\nUntagged sites:');
   for (const site of buckets.untagged) console.log(`  ${site}`);
+}
+
+if (midTemplateBugs.length > 0) {
+  console.error(`\nGate FAIL: ${midTemplateBugs.length} mid-template comment(s) — these break SQL at runtime, masked by .catch:`);
+  for (const site of midTemplateBugs) console.error(`  ${site}`);
+  process.exit(1);
 }
 
 if (threshold !== null && untagged > threshold) {

--- a/scripts/catch-swallow-tag.mjs
+++ b/scripts/catch-swallow-tag.mjs
@@ -33,7 +33,14 @@ const CATCH_RE = /\.catch\(\(\)\s*=>/;
 // STMT_START matches the line that begins the catch's statement. `sql\`` and
 // `\w+\.\w+\(` are included so each element of a Promise.all([sql\`\`.catch,
 // db.query(...).catch]) gets its own statement-start (and its own tag).
-const STMT_START = /^(await\s|return\s|const\s|let\s|var\s|this\.|\w+\s*=|sql`|\(sql`|\w+\.\w+\()/;
+//
+// `\w+\s*=\s*await\s` (not bare `\w+\s*=`) — bare form matched SQL column
+// assignments (`updated_at = NOW()`, `status = COALESCE(...)`) inside an
+// UPDATE template, anchoring the walker to the wrong line and inserting the
+// tag *inside* the SQL template. The `await` prefix is mandatory in the
+// codebase for these statements (every `.catch(() => …)` site reads from a
+// promise) so this loses no real call sites. See PR #85 fallout.
+const STMT_START = /^(await\s|return\s|const\s|let\s|var\s|this\.|\w+\s*=\s*\(?\s*await\s|\w+\s*=\s*sql`|sql`|\(sql`|\w+\.\w+\()/;
 const TAG_FAF = /\/\/\s*fire-and-forget\b/;
 const TAG_TODO = /\/\/\s*TODO\(catch-swallow\)/;
 

--- a/src/handlers/ai-pitch-extract.ts
+++ b/src/handlers/ai-pitch-extract.ts
@@ -8,6 +8,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId } from '../utils/auth-extract';
+import { safeQuery } from '../db/safe-query';
 
 const AI_EXTRACT_CREDIT_COST = 5;
 
@@ -66,12 +67,15 @@ export async function aiPitchExtract(request: Request, env: Env): Promise<Respon
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
   try {
-    // Credit check
-    // TODO(catch-swallow): migrate to safeQuery — gate-feeding, fail-closed but operator-blind on credit table outage
-    const creditRows = await sql`
+    // Credit check — gate-feeding. Fail closed on credit-table outage AND surface to Sentry.
+    const creditRows = await safeQuery<{ balance: number | string }>(() => sql`
       SELECT balance FROM user_credits WHERE user_id = ${Number(userId)}
-    `.catch(() => []);
-    const balance = Number(creditRows[0]?.balance) || 0;
+    `, { fallback: [], context: 'ai-pitch-extract.credit-check' });
+
+    if (!creditRows.ok) {
+      return errorResponse('Credit check temporarily unavailable. Please retry.', origin, 503);
+    }
+    const balance = Number(creditRows.rows[0]?.balance) || 0;
 
     if (balance < AI_EXTRACT_CREDIT_COST) {
       return errorResponse(`Insufficient credits. AI extraction costs ${AI_EXTRACT_CREDIT_COST} credits. You have ${balance}.`, origin, 402);

--- a/src/handlers/ai-production-autofill.ts
+++ b/src/handlers/ai-production-autofill.ts
@@ -10,6 +10,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId } from '../utils/auth-extract';
+import { safeQuery } from '../db/safe-query';
 
 const AUTOFILL_CREDIT_COST = 5;
 
@@ -85,12 +86,16 @@ export async function aiProductionAutofill(request: Request, env: Env): Promise<
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
   try {
-    // Credit check
-    // TODO(catch-swallow): migrate to safeQuery — gate-feeding, fail-closed but operator-blind on credit table outage
-    const creditRows = await sql`
+    // Credit check — gate-feeding. Fail closed on credit-table outage (don't grant
+    // access on a query exception) AND surface the failure to Sentry so we know.
+    const creditRows = await safeQuery<{ balance: number | string }>(() => sql`
       SELECT balance FROM user_credits WHERE user_id = ${Number(userId)}
-    `.catch(() => []);
-    const balance = Number(creditRows[0]?.balance) || 0;
+    `, { fallback: [], context: 'ai-production-autofill.credit-check' });
+
+    if (!creditRows.ok) {
+      return errorResponse('Credit check temporarily unavailable. Please retry.', origin, 503);
+    }
+    const balance = Number(creditRows.rows[0]?.balance) || 0;
 
     if (balance < AUTOFILL_CREDIT_COST) {
       return errorResponse(`Insufficient credits. Auto-fill costs ${AUTOFILL_CREDIT_COST} credits. You have ${balance}.`, origin, 402);

--- a/src/handlers/collaborator.ts
+++ b/src/handlers/collaborator.ts
@@ -8,6 +8,7 @@ import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getAuthenticatedUser, getUserId } from '../utils/auth-extract';
 import { sendCollaboratorInviteEmail, sendCollaboratorAcceptedEmail } from '../services/email/index';
+import { safeQuery } from '../db/safe-query';
 
 const VALID_ROLES = ['director', 'line_producer', 'dp', 'production_designer', 'editor', 'sound_designer', 'custom'] as const;
 const VALID_NOTE_CATEGORIES = ['casting', 'location', 'budget', 'schedule', 'team', 'general'] as const;
@@ -660,13 +661,12 @@ export async function getCollaborationChecklist(request: Request, env: Env): Pro
     `;
     if (pipeline.length === 0) return errorResponse('Project not found', origin, 404);
 
-    // TODO(catch-swallow): migrate to safeQuery — empty result hides schema drift on production_checklists
-    const result = await sql`
+    const result = await safeQuery<{ checklist: Record<string, unknown> }>(() => sql`
       SELECT checklist FROM production_checklists
       WHERE user_id = ${pipeline[0].production_company_id} AND pitch_id = ${projectId}
-    `.catch(() => []);
+    `, { fallback: [], context: 'collaborator.checklist.read' });
 
-    const checklist = result.length > 0 ? result[0].checklist : {};
+    const checklist = result.rows.length > 0 ? result.rows[0].checklist : {};
 
     return jsonResponse({ success: true, data: { checklist, my_role: collab.role } }, origin);
   } catch (err) {
@@ -765,15 +765,14 @@ export async function getCollaborationNotes(request: Request, env: Env): Promise
 
     // Get notes from production_notes (owner's notes) + collaborator-created notes
     const pitchId = pipeline[0].pitch_id || projectId;
-    // TODO(catch-swallow): migrate to safeQuery — empty result hides schema drift on production_notes
-    const notes = await sql`
+    const notesResult = await safeQuery(() => sql`
       SELECT id, content, category, author, created_at, updated_at
       FROM production_notes
       WHERE pitch_id = ${pitchId}
       ORDER BY created_at ASC
-    `.catch(() => []);
+    `, { fallback: [], context: 'collaborator.notes.read' });
 
-    return jsonResponse({ success: true, data: { notes } }, origin);
+    return jsonResponse({ success: true, data: { notes: notesResult.rows } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('getCollaborationNotes error:', e.message);

--- a/src/handlers/creator-dashboard-extended.ts
+++ b/src/handlers/creator-dashboard-extended.ts
@@ -147,13 +147,13 @@ export async function creatorContractUpdateHandler(request: Request, env: Env): 
     const status = typeof body.status === 'string' ? body.status : undefined;
     const notes = typeof body.notes === 'string' ? body.notes : undefined;
 
+    // TODO(catch-swallow): migrate to safeQuery
     const result = await sql`
       UPDATE contracts
       SET
         title = COALESCE(${title ?? null}, title),
         status = COALESCE(${status ?? null}, status),
         notes = COALESCE(${notes ?? null}, notes),
-        // TODO(catch-swallow): migrate to safeQuery
         updated_at = NOW()
       WHERE id = ${contractId} AND creator_id = ${userId}
       RETURNING *

--- a/src/handlers/creator-dashboard-extended.ts
+++ b/src/handlers/creator-dashboard-extended.ts
@@ -7,6 +7,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { ApiResponseBuilder, ErrorCode } from '../utils/api-response';
 import { requireRole } from '../utils/auth-extract';
+import { safeQuery } from '../db/safe-query';
 
 // ---------------------------------------------------------------------------
 // Revenue
@@ -25,8 +26,7 @@ export async function creatorRevenueTrendsHandler(request: Request, env: Env): P
     const url = new URL(request.url);
     const months = Math.min(24, Math.max(1, Number(url.searchParams.get('months')) || 12));
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const trends = await sql`
+    const trendsResult = await safeQuery(() => sql`
       SELECT
         TO_CHAR(transaction_date, 'YYYY-MM') AS month,
         SUM(amount)::numeric AS total,
@@ -36,9 +36,9 @@ export async function creatorRevenueTrendsHandler(request: Request, env: Env): P
         AND transaction_date >= NOW() - (${months} || ' months')::interval
       GROUP BY TO_CHAR(transaction_date, 'YYYY-MM')
       ORDER BY month ASC
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.revenue.trends' });
 
-    return ApiResponseBuilder.success({ trends });
+    return ApiResponseBuilder.success({ trends: trendsResult.rows });
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('creatorRevenueTrendsHandler error:', e.message);
@@ -57,8 +57,7 @@ export async function creatorRevenueBreakdownHandler(request: Request, env: Env)
   try {
     const userId = Number(roleCheck.user.id);
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const breakdown = await sql`
+    const breakdownResult = await safeQuery(() => sql`
       SELECT
         revenue_type AS type,
         SUM(amount)::numeric AS total,
@@ -67,18 +66,17 @@ export async function creatorRevenueBreakdownHandler(request: Request, env: Env)
       WHERE creator_id = ${userId}
       GROUP BY revenue_type
       ORDER BY total DESC
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.revenue.breakdown' });
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const totalResult = await sql`
+    const totalResult = await safeQuery<{ grand_total: number }>(() => sql`
       SELECT COALESCE(SUM(amount), 0)::numeric AS grand_total
       FROM creator_revenue
       WHERE creator_id = ${userId}
-    `.catch(() => [{ grand_total: 0 }]);
+    `, { fallback: [{ grand_total: 0 }], context: 'creator-dashboard.revenue.total' });
 
     return ApiResponseBuilder.success({
-      breakdown,
-      total: Number(totalResult[0]?.grand_total) || 0,
+      breakdown: breakdownResult.rows,
+      total: Number(totalResult.rows[0]?.grand_total) || 0,
     });
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
@@ -106,20 +104,20 @@ export async function creatorContractDetailsHandler(request: Request, env: Env):
   try {
     const userId = Number(roleCheck.user.id);
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const result = await sql`
+    const result = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT c.*,
              COALESCE(u.name, u.first_name || ' ' || u.last_name) AS counterparty_display_name
       FROM contracts c
       LEFT JOIN users u ON c.counterparty_id = u.id
       WHERE c.id = ${contractId} AND c.creator_id = ${userId}
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.contract.details' });
 
-    if (result.length === 0) {
+    if (!result.ok) return ApiResponseBuilder.error(ErrorCode.INTERNAL_ERROR, 'Failed to fetch contract');
+    if (result.rows.length === 0) {
       return ApiResponseBuilder.error(ErrorCode.NOT_FOUND, 'Contract not found');
     }
 
-    return ApiResponseBuilder.success({ contract: result[0] });
+    return ApiResponseBuilder.success({ contract: result.rows[0] });
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('creatorContractDetailsHandler error:', e.message);
@@ -147,8 +145,7 @@ export async function creatorContractUpdateHandler(request: Request, env: Env): 
     const status = typeof body.status === 'string' ? body.status : undefined;
     const notes = typeof body.notes === 'string' ? body.notes : undefined;
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const result = await sql`
+    const result = await safeQuery<Record<string, unknown>>(() => sql`
       UPDATE contracts
       SET
         title = COALESCE(${title ?? null}, title),
@@ -157,13 +154,14 @@ export async function creatorContractUpdateHandler(request: Request, env: Env): 
         updated_at = NOW()
       WHERE id = ${contractId} AND creator_id = ${userId}
       RETURNING *
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.contract.update' });
 
-    if (result.length === 0) {
+    if (!result.ok) return ApiResponseBuilder.error(ErrorCode.INTERNAL_ERROR, 'Failed to update contract');
+    if (result.rows.length === 0) {
       return ApiResponseBuilder.error(ErrorCode.NOT_FOUND, 'Contract not found');
     }
 
-    return ApiResponseBuilder.success({ contract: result[0] });
+    return ApiResponseBuilder.success({ contract: result.rows[0] });
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('creatorContractUpdateHandler error:', e.message);
@@ -187,8 +185,8 @@ export async function creatorEngagementHandler(request: Request, env: Env): Prom
     const userId = Number(roleCheck.user.id);
 
     // Aggregate views and likes across all creator's pitches
-    // TODO(catch-swallow): migrate to safeQuery
-    const viewStats = await sql`
+    type ViewStatsRow = { total_views: number; unique_viewers: number; avg_view_duration: number };
+    const viewStats = await safeQuery<ViewStatsRow>(() => sql`
       SELECT
         COUNT(*)::int AS total_views,
         COUNT(DISTINCT pv.viewer_id)::int AS unique_viewers,
@@ -196,19 +194,17 @@ export async function creatorEngagementHandler(request: Request, env: Env): Prom
       FROM pitch_views pv
       JOIN pitches p ON pv.pitch_id = p.id
       WHERE p.user_id = ${userId}
-    `.catch(() => [{ total_views: 0, unique_viewers: 0, avg_view_duration: 0 }]);
+    `, { fallback: [{ total_views: 0, unique_viewers: 0, avg_view_duration: 0 }], context: 'creator-dashboard.engagement.views' });
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const likeStats = await sql`
+    const likeStats = await safeQuery<{ total_likes: number }>(() => sql`
       SELECT COUNT(*)::int AS total_likes
       FROM pitch_likes pl
       JOIN pitches p ON pl.pitch_id = p.id
       WHERE p.user_id = ${userId}
-    `.catch(() => [{ total_likes: 0 }]);
+    `, { fallback: [{ total_likes: 0 }], context: 'creator-dashboard.engagement.likes' });
 
     // Per-pitch breakdown
-    // TODO(catch-swallow): migrate to safeQuery
-    const pitchEngagement = await sql`
+    const pitchEngagement = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT
         p.id, p.title,
         COUNT(DISTINCT pv.id)::int AS views,
@@ -220,19 +216,19 @@ export async function creatorEngagementHandler(request: Request, env: Env): Prom
       GROUP BY p.id, p.title
       ORDER BY views DESC
       LIMIT 20
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.engagement.per-pitch' });
 
-    const totalViews = Number(viewStats[0]?.total_views) || 0;
-    const totalLikes = Number(likeStats[0]?.total_likes) || 0;
+    const totalViews = Number(viewStats.rows[0]?.total_views) || 0;
+    const totalLikes = Number(likeStats.rows[0]?.total_likes) || 0;
 
     return ApiResponseBuilder.success({
       engagement: {
         totalViews,
-        uniqueViewers: Number(viewStats[0]?.unique_viewers) || 0,
+        uniqueViewers: Number(viewStats.rows[0]?.unique_viewers) || 0,
         totalLikes,
-        avgViewDuration: Number(viewStats[0]?.avg_view_duration) || 0,
+        avgViewDuration: Number(viewStats.rows[0]?.avg_view_duration) || 0,
         engagementRate: totalViews > 0 ? Math.round((totalLikes / totalViews) * 100) : 0,
-        pitchBreakdown: pitchEngagement,
+        pitchBreakdown: pitchEngagement.rows,
       },
     });
   } catch (err) {
@@ -258,8 +254,7 @@ export async function creatorDemographicsHandler(request: Request, env: Env): Pr
     const userId = Number(roleCheck.user.id);
 
     // Viewer types (creator, investor, production)
-    // TODO(catch-swallow): migrate to safeQuery
-    const viewerTypes = await sql`
+    const viewerTypes = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT
         COALESCE(u.user_type, 'anonymous') AS viewer_type,
         COUNT(*)::int AS count
@@ -269,11 +264,10 @@ export async function creatorDemographicsHandler(request: Request, env: Env): Pr
       WHERE p.user_id = ${userId}
       GROUP BY COALESCE(u.user_type, 'anonymous')
       ORDER BY count DESC
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.demographics.viewer-types' });
 
     // View types (direct, browse, search, etc.)
-    // TODO(catch-swallow): migrate to safeQuery
-    const viewSources = await sql`
+    const viewSources = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT
         COALESCE(pv.view_type, 'direct') AS source,
         COUNT(*)::int AS count
@@ -282,12 +276,12 @@ export async function creatorDemographicsHandler(request: Request, env: Env): Pr
       WHERE p.user_id = ${userId}
       GROUP BY COALESCE(pv.view_type, 'direct')
       ORDER BY count DESC
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.demographics.view-sources' });
 
     return ApiResponseBuilder.success({
       demographics: {
-        viewerTypes,
-        viewSources,
+        viewerTypes: viewerTypes.rows,
+        viewSources: viewSources.rows,
       },
     });
   } catch (err) {
@@ -318,23 +312,21 @@ export async function creatorInvestorCommunicationHandler(request: Request, env:
     const userId = Number(roleCheck.user.id);
 
     // Find conversations where both users are participants
-    // TODO(catch-swallow): migrate to safeQuery
-    const conversations = await sql`
+    const conversationsResult = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT DISTINCT c.id, c.title, c.type, c.created_at, c.updated_at
       FROM conversations c
       JOIN conversation_participants cp1 ON cp1.conversation_id = c.id AND cp1.user_id = ${userId}
       JOIN conversation_participants cp2 ON cp2.conversation_id = c.id AND cp2.user_id = ${investorId}
       ORDER BY c.updated_at DESC
       LIMIT 10
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.communication.conversations' });
 
     // Fetch recent messages from those conversations
-    const conversationIds = conversations.map((c: Record<string, unknown>) => Number(c.id));
+    const conversationIds = conversationsResult.rows.map((c) => Number(c.id));
     let messages: unknown[] = [];
 
     if (conversationIds.length > 0) {
-      // TODO(catch-swallow): migrate to safeQuery
-      messages = await sql`
+      const messagesResult = await safeQuery<Record<string, unknown>>(() => sql`
         SELECT m.id, m.conversation_id, m.sender_id, m.content, m.message_type,
                m.created_at, m.is_edited,
                COALESCE(u.name, u.first_name || ' ' || u.last_name) AS sender_name
@@ -344,11 +336,12 @@ export async function creatorInvestorCommunicationHandler(request: Request, env:
           AND m.is_deleted = false
         ORDER BY m.created_at DESC
         LIMIT 50
-      `.catch(() => []);
+      `, { fallback: [], context: 'creator-dashboard.communication.messages' });
+      messages = messagesResult.rows;
     }
 
     return ApiResponseBuilder.success({
-      communications: conversations,
+      communications: conversationsResult.rows,
       messages,
     });
   } catch (err) {
@@ -380,8 +373,7 @@ export async function creatorMessageInvestorHandler(request: Request, env: Env):
     if (!content) return ApiResponseBuilder.error(ErrorCode.VALIDATION_ERROR, 'Message content is required');
 
     // Check if an existing conversation exists between the two users
-    // TODO(catch-swallow): migrate to safeQuery
-    const existing = await sql`
+    const existing = await safeQuery<{ id: number }>(() => sql`
       SELECT c.id
       FROM conversations c
       JOIN conversation_participants cp1 ON cp1.conversation_id = c.id AND cp1.user_id = ${userId}
@@ -389,15 +381,15 @@ export async function creatorMessageInvestorHandler(request: Request, env: Env):
       WHERE c.type = 'direct'
       ORDER BY c.updated_at DESC
       LIMIT 1
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.message.existing-conversation' });
 
     let conversationId: number;
 
-    if (existing.length > 0) {
-      conversationId = Number(existing[0].id);
-      // Update conversation timestamp
-      // TODO(catch-swallow): migrate to safeQuery
-      await sql`UPDATE conversations SET updated_at = NOW() WHERE id = ${conversationId}`.catch(() => []);
+    if (existing.rows.length > 0) {
+      conversationId = Number(existing.rows[0].id);
+      // Update conversation timestamp — best-effort
+      await safeQuery(() => sql`UPDATE conversations SET updated_at = NOW() WHERE id = ${conversationId}`,
+        { fallback: [], context: 'creator-dashboard.message.touch-conversation' });
     } else {
       // Create new conversation
       const conv = await sql`
@@ -407,13 +399,12 @@ export async function creatorMessageInvestorHandler(request: Request, env: Env):
       `;
       conversationId = Number(conv[0].id);
 
-      // Add both participants
-      // TODO(catch-swallow): migrate to safeQuery
-      await sql`
+      // Add both participants — best-effort (Sentry-reported via safeQuery)
+      await safeQuery(() => sql`
         INSERT INTO conversation_participants (conversation_id, user_id, joined_at, is_admin)
         VALUES (${conversationId}, ${userId}, NOW(), true),
                (${conversationId}, ${investorId}, NOW(), false)
-      `.catch(() => []);
+      `, { fallback: [], context: 'creator-dashboard.message.add-participants' });
     }
 
     // Insert the message
@@ -423,16 +414,15 @@ export async function creatorMessageInvestorHandler(request: Request, env: Env):
       RETURNING id, conversation_id, sender_id, content, created_at
     `;
 
-    // Notify the investor
-    // TODO(catch-swallow): migrate to safeQuery
-    await sql`
+    // Notify the investor — best-effort (Sentry-reported via safeQuery)
+    await safeQuery(() => sql`
       INSERT INTO notifications (user_id, type, title, message, related_user_id, created_at)
       VALUES (
         ${investorId}, 'new_message', 'New Message',
         ${'You have a new message from a creator'},
         ${userId}, NOW()
       )
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.message.notify' });
 
     return ApiResponseBuilder.success({
       messageSent: true,

--- a/src/handlers/creator-dashboard.ts
+++ b/src/handlers/creator-dashboard.ts
@@ -478,8 +478,7 @@ export async function creatorPitchAnalyticsHandler(request: Request, env: Env): 
 
     if (isAllPitches) {
       // Get analytics for all creator pitches
-      // TODO(catch-swallow): migrate to safeQuery
-      const pitchesAnalytics = await sql`
+      const pitchesAnalytics = await safeQuery<Record<string, unknown>>(() => sql`
         SELECT
           p.id,
           p.title,
@@ -515,11 +514,11 @@ export async function creatorPitchAnalyticsHandler(request: Request, env: Env): 
         ) inv_count ON p.id = inv_count.pitch_id
         WHERE p.user_id::text = ${userId}
         ORDER BY p.created_at DESC
-      `.catch(() => []);
+      `, { fallback: [], context: 'creator-dashboard.analytics.all-pitches' });
 
       // Get overall analytics summary
-      // TODO(catch-swallow): migrate to safeQuery
-      const summary = await sql`
+      type SummaryRow = { total_views: number; unique_viewers: number; total_saves: number; total_nda_requests: number };
+      const summary = await safeQuery<SummaryRow>(() => sql`
         SELECT
           COALESCE(SUM(pv.view_count), 0) as total_views,
           COALESCE(COUNT(DISTINCT pv.viewer_id), 0) as unique_viewers,
@@ -530,13 +529,13 @@ export async function creatorPitchAnalyticsHandler(request: Request, env: Env): 
         LEFT JOIN saved_pitches sp ON p.id = sp.pitch_id
         LEFT JOIN nda_requests nr ON p.id = nr.pitch_id
         WHERE p.user_id::text = ${userId}
-      `.catch(() => [{ total_views: 0, unique_viewers: 0, total_saves: 0, total_nda_requests: 0 }]);
+      `, { fallback: [{ total_views: 0, unique_viewers: 0, total_saves: 0, total_nda_requests: 0 }], context: 'creator-dashboard.analytics.summary' });
 
       return new Response(JSON.stringify({
         success: true,
         data: {
-          pitches: pitchesAnalytics || [],
-          overview: summary[0] || emptyAnalytics.data.overview,
+          pitches: pitchesAnalytics.rows,
+          overview: summary.rows[0] || emptyAnalytics.data.overview,
           viewHistory: [],
           recommendations: []
         }
@@ -561,17 +560,16 @@ export async function creatorPitchAnalyticsHandler(request: Request, env: Env): 
 
     if (!tableCheck[0]?.exists) {
       // Return basic pitch info without analytics
-      // TODO(catch-swallow): migrate to safeQuery
-      const pitchInfo = await sql`
+      const pitchInfo = await safeQuery<Record<string, unknown>>(() => sql`
         SELECT id, title, genre, status, created_at
         FROM pitches WHERE id::text = ${pitchId}
-      `.catch(() => []);
+      `, { fallback: [], context: 'creator-dashboard.analytics.pitch-info' });
 
       return new Response(JSON.stringify({
         success: true,
         data: {
           ...emptyAnalytics.data,
-          pitch: pitchInfo[0] || null
+          pitch: pitchInfo.rows[0] || null
         }
       }), {
         status: 200,
@@ -580,8 +578,7 @@ export async function creatorPitchAnalyticsHandler(request: Request, env: Env): 
     }
 
     // Get view history
-    // TODO(catch-swallow): migrate to safeQuery
-    const viewHistory = await sql`
+    const viewHistory = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT
         DATE_TRUNC('day', viewed_at) as date,
         COUNT(*) as views,
@@ -591,24 +588,24 @@ export async function creatorPitchAnalyticsHandler(request: Request, env: Env): 
         AND viewed_at >= ${startDate}
       GROUP BY DATE_TRUNC('day', viewed_at)
       ORDER BY date ASC
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.analytics.view-history' });
 
     // Get basic analytics
-    // TODO(catch-swallow): migrate to safeQuery
-    const overview = await sql`
+    type OverviewRow = { total_views: number; unique_viewers: number; avg_view_duration: number };
+    const overview = await safeQuery<OverviewRow>(() => sql`
       SELECT
         COALESCE(SUM(view_count), 0) as total_views,
         COUNT(DISTINCT user_id) as unique_viewers,
         0 as avg_view_duration
       FROM pitch_views
       WHERE pitch_id::text = ${pitchId}
-    `.catch(() => [{ total_views: 0, unique_viewers: 0, avg_view_duration: 0 }]);
+    `, { fallback: [{ total_views: 0, unique_viewers: 0, avg_view_duration: 0 }], context: 'creator-dashboard.analytics.overview' });
 
     return new Response(JSON.stringify({
       success: true,
       data: {
-        overview: overview[0] || emptyAnalytics.data.overview,
-        viewHistory: viewHistory || [],
+        overview: overview.rows[0] || emptyAnalytics.data.overview,
+        viewHistory: viewHistory.rows,
         investment: { total_invested: 0, investor_count: 0 },
         documents: { total: 0, signed: 0 },
         audience: [],
@@ -666,16 +663,15 @@ export async function creatorInvestorsHandler(request: Request, env: Env): Promi
   }
 
   try {
-    // Check if investments table exists
-    // TODO(catch-swallow): migrate to safeQuery
-    const investmentsExist = await sql`
+    // Check if investments table exists — schema probe; don't report to Sentry
+    const investmentsExist = await safeQuery<{ exists: boolean }>(() => sql`
       SELECT EXISTS (
         SELECT FROM information_schema.tables
         WHERE table_schema = 'public' AND table_name = 'investments'
       ) as exists
-    `.catch(() => [{ exists: false }]);
+    `, { fallback: [{ exists: false }], context: 'creator-dashboard.investors.table-probe', report: false });
 
-    if (!investmentsExist[0]?.exists) {
+    if (!investmentsExist.rows[0]?.exists) {
       return new Response(JSON.stringify(emptyResponse), {
         status: 200,
         headers: { 'Content-Type': 'application/json', ...corsHeaders }
@@ -683,8 +679,7 @@ export async function creatorInvestorsHandler(request: Request, env: Env): Promi
     }
 
     // Get investors who have invested in creator's pitches - simplified query
-    // TODO(catch-swallow): migrate to safeQuery
-    const investors = await sql`
+    const investorsResult = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT
         u.id,
         COALESCE(u.name, CONCAT(u.first_name, ' ', u.last_name), u.email) as name,
@@ -710,17 +705,18 @@ export async function creatorInvestorsHandler(request: Request, env: Env): Promi
       GROUP BY u.id, u.name, u.first_name, u.last_name, u.email, u.company_name, u.profile_image, u.location, u.bio
       ORDER BY total_invested DESC
       LIMIT 100
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.investors.list' });
+    const investors = investorsResult.rows;
 
     return new Response(JSON.stringify({
       success: true,
       data: {
-        investors: investors || [],
+        investors,
         communicationSummary: [],
         stats: {
-          totalInvestors: investors?.length || 0,
-          activeInvestors: (investors || []).filter((i: any) => i.activity_status === 'active' || i.activity_status === 'highly_active').length,
-          totalRaised: (investors || []).reduce((sum: number, i: any) => sum + Number(i.total_invested || 0), 0)
+          totalInvestors: investors.length,
+          activeInvestors: investors.filter((i) => i.activity_status === 'active' || i.activity_status === 'highly_active').length,
+          totalRaised: investors.reduce((sum: number, i) => sum + Number(i.total_invested || 0), 0)
         }
       }
     }), {

--- a/src/handlers/investor-pitch-data.ts
+++ b/src/handlers/investor-pitch-data.ts
@@ -8,6 +8,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId } from '../utils/auth-extract';
+import { safeQuery } from '../db/safe-query';
 
 function jsonResponse(data: unknown, origin: string | null, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -46,15 +47,14 @@ export async function getInvestorNotes(request: Request, env: Env): Promise<Resp
   if (!sql) return jsonResponse({ success: true, data: { notes: [] } }, origin);
 
   try {
-    // TODO(catch-swallow): migrate to safeQuery
-    const notes = await sql`
+    const notesResult = await safeQuery(() => sql`
       SELECT id, content, category, is_private, created_at, updated_at
       FROM investor_notes
       WHERE user_id = ${Number(userId)} AND pitch_id = ${pitchId}
       ORDER BY created_at ASC
-    `.catch(() => []);
+    `, { fallback: [], context: 'investor-pitch-data.notes.list' });
 
-    return jsonResponse({ success: true, data: { notes } }, origin);
+    return jsonResponse({ success: true, data: { notes: notesResult.rows } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('getInvestorNotes error:', e.message);
@@ -149,14 +149,13 @@ export async function getInvestorDiligence(request: Request, env: Env): Promise<
   if (!sql) return jsonResponse({ success: true, data: { checklist: {} } }, origin);
 
   try {
-    // TODO(catch-swallow): migrate to safeQuery
-    const rows = await sql`
+    const rows = await safeQuery<{ checklist: Record<string, unknown> }>(() => sql`
       SELECT checklist
       FROM investor_diligence_checklists
       WHERE user_id = ${Number(userId)} AND pitch_id = ${pitchId}
-    `.catch(() => []);
+    `, { fallback: [], context: 'investor-pitch-data.diligence.read' });
 
-    const checklist = rows[0]?.checklist || {};
+    const checklist = rows.rows[0]?.checklist || {};
     return jsonResponse({ success: true, data: { checklist } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));

--- a/src/handlers/production-dashboard-extended.ts
+++ b/src/handlers/production-dashboard-extended.ts
@@ -7,6 +7,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId } from '../utils/auth-extract';
+import { safeQuery } from '../db/safe-query';
 
 function jsonResponse(data: unknown, origin: string | null, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -46,8 +47,7 @@ export async function productionTalentSearchHandler(request: Request, env: Env):
     const limit = Math.min(50, Math.max(1, Number(url.searchParams.get('limit')) || 20));
     const offset = Math.max(0, Number(url.searchParams.get('offset')) || 0);
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const talent = await sql`
+    const talentResult = await safeQuery(() => sql`
       SELECT id, first_name, last_name, stage_name, talent_type,
              day_rate, currency, availability_status, location,
              rating, years_experience, credits_count, skills,
@@ -62,10 +62,9 @@ export async function productionTalentSearchHandler(request: Request, env: Env):
              OR stage_name ILIKE ${'%' + search + '%'})
       ORDER BY rating DESC NULLS LAST, created_at DESC
       LIMIT ${limit} OFFSET ${offset}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-dashboard.talent.search.list' });
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const countResult = await sql`
+    const countResult = await safeQuery<{ total: number }>(() => sql`
       SELECT COUNT(*)::int AS total FROM production_talent
       WHERE 1=1
         AND (${role} = '' OR talent_type = ${role})
@@ -74,11 +73,11 @@ export async function productionTalentSearchHandler(request: Request, env: Env):
         AND (${search} = '' OR first_name ILIKE ${'%' + search + '%'}
              OR last_name ILIKE ${'%' + search + '%'}
              OR stage_name ILIKE ${'%' + search + '%'})
-    `.catch(() => [{ total: 0 }]);
+    `, { fallback: [{ total: 0 }], context: 'production-dashboard.talent.search.count' });
 
     return jsonResponse({
       success: true,
-      data: { talent, total: countResult[0]?.total || 0 }
+      data: { talent: talentResult.rows, total: countResult.rows[0]?.total || 0 }
     }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
@@ -100,19 +99,19 @@ export async function productionTalentDetailsHandler(request: Request, env: Env)
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
   try {
-    // TODO(catch-swallow): migrate to safeQuery
-    const result = await sql`
+    const result = await safeQuery(() => sql`
       SELECT t.*, u.email, u.name as user_name
       FROM production_talent t
       LEFT JOIN users u ON t.user_id = u.id
       WHERE t.id = ${talentId}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-dashboard.talent.details' });
 
-    if (result.length === 0) {
+    if (!result.ok) return errorResponse('Failed to fetch talent details', origin, 500);
+    if (result.rows.length === 0) {
       return errorResponse('Talent not found', origin, 404);
     }
 
-    return jsonResponse({ success: true, data: { talent: result[0] } }, origin);
+    return jsonResponse({ success: true, data: { talent: result.rows[0] } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('productionTalentDetailsHandler error:', e.message);
@@ -139,29 +138,29 @@ export async function productionTalentContactHandler(request: Request, env: Env)
     if (!message) return errorResponse('Message is required', origin);
 
     // Look up talent to find associated user_id
-    // TODO(catch-swallow): migrate to safeQuery
-    const talent = await sql`
+    const talentLookup = await safeQuery<{ user_id: number | null; first_name: string; last_name: string }>(() => sql`
       SELECT user_id, first_name, last_name FROM production_talent WHERE id = ${Number(talentId)}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-dashboard.talent.contact.lookup' });
 
-    if (talent.length === 0) {
+    if (!talentLookup.ok) return errorResponse('Failed to contact talent', origin, 500);
+    if (talentLookup.rows.length === 0) {
       return errorResponse('Talent not found', origin, 404);
     }
 
-    // Insert notification for the talent's user if they have one
-    if (talent[0].user_id) {
-      // TODO(catch-swallow): migrate to safeQuery
-      await sql`
+    // Insert notification for the talent's user if they have one — best-effort
+    // (Sentry will report failure via safeQuery; the contact request itself still succeeds)
+    if (talentLookup.rows[0].user_id) {
+      await safeQuery(() => sql`
         INSERT INTO notifications (user_id, type, title, message, related_user_id, created_at)
         VALUES (
-          ${Number(talent[0].user_id)},
+          ${Number(talentLookup.rows[0].user_id)},
           'talent_contact',
           'Production Company Contact',
           ${message},
           ${Number(userId)},
           NOW()
         )
-      `.catch(() => []);
+      `, { fallback: [], context: 'production-dashboard.talent.contact.notify' });
     }
 
     return jsonResponse({ success: true, data: { contacted: true } }, origin);
@@ -189,8 +188,7 @@ export async function productionProjectDetailsHandler(request: Request, env: Env
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
   try {
-    // TODO(catch-swallow): migrate to safeQuery
-    const result = await sql`
+    const result = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT pp.*,
              p.title AS pitch_title, p.genre, p.logline, p.format, p.estimated_budget,
              COALESCE(u.name, u.first_name || ' ' || u.last_name) AS creator_name
@@ -198,24 +196,24 @@ export async function productionProjectDetailsHandler(request: Request, env: Env
       LEFT JOIN pitches p ON pp.pitch_id = p.id
       LEFT JOIN users u ON p.user_id = u.id
       WHERE pp.id = ${projectId} AND pp.production_company_id = ${Number(userId)}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-dashboard.project.details' });
 
-    if (result.length === 0) {
+    if (!result.ok) return errorResponse('Failed to fetch project details', origin, 500);
+    if (result.rows.length === 0) {
       return errorResponse('Project not found', origin, 404);
     }
 
-    // Fetch milestones for the project
-    // TODO(catch-swallow): migrate to safeQuery
-    const milestones = await sql`
+    // Fetch milestones for the project — non-critical; render project even if it fails
+    const milestonesResult = await safeQuery(() => sql`
       SELECT id, title, description, due_date, completed, completed_at
       FROM project_milestones
       WHERE project_id = ${projectId}
       ORDER BY due_date ASC NULLS LAST
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-dashboard.project.details.milestones' });
 
     return jsonResponse({
       success: true,
-      data: { project: { ...result[0], milestones } }
+      data: { project: { ...result.rows[0], milestones: milestonesResult.rows } }
     }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
@@ -253,8 +251,7 @@ export async function productionProjectStatusHandler(request: Request, env: Env)
       return errorResponse(`Invalid stage. Must be one of: ${validStages.join(', ')}`, origin);
     }
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const result = await sql`
+    const result = await safeQuery(() => sql`
       UPDATE production_pipeline
       SET
         status = COALESCE(${status ?? null}, status),
@@ -263,13 +260,14 @@ export async function productionProjectStatusHandler(request: Request, env: Env)
         updated_at = NOW()
       WHERE id = ${projectId} AND production_company_id = ${Number(userId)}
       RETURNING *
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-dashboard.project.status.update' });
 
-    if (result.length === 0) {
+    if (!result.ok) return errorResponse('Failed to update project status', origin, 500);
+    if (result.rows.length === 0) {
       return errorResponse('Project not found', origin, 404);
     }
 
-    return jsonResponse({ success: true, data: { project: result[0] } }, origin);
+    return jsonResponse({ success: true, data: { project: result.rows[0] } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('productionProjectStatusHandler error:', e.message);
@@ -300,8 +298,7 @@ export async function productionBudgetUpdateHandler(request: Request, env: Env):
     const contingencyPercentage = typeof body.contingency_percentage === 'number' ? body.contingency_percentage : undefined;
     const contingencyUsed = typeof body.contingency_used === 'number' ? body.contingency_used : undefined;
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const result = await sql`
+    const result = await safeQuery(() => sql`
       UPDATE production_pipeline
       SET
         budget_allocated = COALESCE(${budgetAllocated ?? null}, budget_allocated),
@@ -312,13 +309,14 @@ export async function productionBudgetUpdateHandler(request: Request, env: Env):
         updated_at = NOW()
       WHERE id = ${projectId} AND production_company_id = ${Number(userId)}
       RETURNING id, budget_allocated, budget_spent, budget_remaining, contingency_percentage, contingency_used
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-dashboard.project.budget.update' });
 
-    if (result.length === 0) {
+    if (!result.ok) return errorResponse('Failed to update budget', origin, 500);
+    if (result.rows.length === 0) {
       return errorResponse('Project not found', origin, 404);
     }
 
-    return jsonResponse({ success: true, data: { budget: result[0] } }, origin);
+    return jsonResponse({ success: true, data: { budget: result.rows[0] } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('productionBudgetUpdateHandler error:', e.message);
@@ -339,8 +337,7 @@ export async function productionBudgetVarianceHandler(request: Request, env: Env
   if (!sql) return jsonResponse({ success: true, data: { budgetAllocated: 0, budgetSpent: 0, budgetRemaining: 0, variance: 0 } }, origin);
 
   try {
-    // TODO(catch-swallow): migrate to safeQuery
-    const result = await sql`
+    const result = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT budget_allocated, budget_spent, budget_remaining,
              contingency_percentage, contingency_used,
              CASE WHEN budget_allocated > 0
@@ -349,13 +346,16 @@ export async function productionBudgetVarianceHandler(request: Request, env: Env
              END AS variance_percentage
       FROM production_pipeline
       WHERE id = ${projectId} AND production_company_id = ${Number(userId)}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-dashboard.project.budget.variance' });
 
-    if (result.length === 0) {
+    if (!result.ok) {
+      return jsonResponse({ success: true, data: { budgetAllocated: 0, budgetSpent: 0, budgetRemaining: 0, variance: 0 } }, origin);
+    }
+    if (result.rows.length === 0) {
       return errorResponse('Project not found', origin, 404);
     }
 
-    const row = result[0];
+    const row = result.rows[0];
     return jsonResponse({
       success: true,
       data: {
@@ -398,7 +398,7 @@ export async function productionScheduleUpdateHandler(request: Request, env: Env
       return errorResponse('At least one schedule entry is required', origin);
     }
 
-    const results = [];
+    const results: Record<string, unknown>[] = [];
     for (const entry of entries) {
       const e = entry as Record<string, unknown>;
       const sceneNumber = typeof e.scene_number === 'string' ? e.scene_number : null;
@@ -410,8 +410,7 @@ export async function productionScheduleUpdateHandler(request: Request, env: Env
 
       if (!scheduledDate) continue;
 
-      // TODO(catch-swallow): migrate to safeQuery
-      const row = await sql`
+      const row = await safeQuery<Record<string, unknown>>(() => sql`
         INSERT INTO production_schedules (project_id, scene_number, scene_description, scheduled_date, call_time, wrap_time, status)
         VALUES (${projectId}, ${sceneNumber}, ${sceneDescription}, ${scheduledDate}, ${callTime}, ${wrapTime}, ${schedStatus})
         ON CONFLICT (id) DO UPDATE SET
@@ -423,9 +422,9 @@ export async function productionScheduleUpdateHandler(request: Request, env: Env
           status = EXCLUDED.status,
           updated_at = NOW()
         RETURNING *
-      `.catch(() => []);
+      `, { fallback: [], context: 'production-dashboard.project.schedule.upsert' });
 
-      if (row.length > 0) results.push(row[0]);
+      if (row.rows.length > 0) results.push(row.rows[0]);
     }
 
     return jsonResponse({ success: true, data: { schedule: results } }, origin);
@@ -450,8 +449,7 @@ export async function productionScheduleConflictsHandler(request: Request, env: 
 
   try {
     // Find overlapping scheduled dates with same cast/crew in the same project
-    // TODO(catch-swallow): migrate to safeQuery
-    const conflicts = await sql`
+    const conflictsResult = await safeQuery(() => sql`
       SELECT a.id AS schedule_a, b.id AS schedule_b,
              a.scene_number AS scene_a, b.scene_number AS scene_b,
              a.scheduled_date, a.call_time AS call_a, a.wrap_time AS wrap_a,
@@ -464,9 +462,9 @@ export async function productionScheduleConflictsHandler(request: Request, env: 
         AND a.status != 'cancelled'
         AND b.status != 'cancelled'
       ORDER BY a.scheduled_date
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-dashboard.project.schedule.conflicts' });
 
-    return jsonResponse({ success: true, data: { conflicts } }, origin);
+    return jsonResponse({ success: true, data: { conflicts: conflictsResult.rows } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('productionScheduleConflictsHandler error:', e.message);
@@ -496,8 +494,7 @@ export async function productionLocationSearchHandler(request: Request, env: Env
     const limit = Math.min(50, Math.max(1, Number(url.searchParams.get('limit')) || 20));
     const offset = Math.max(0, Number(url.searchParams.get('offset')) || 0);
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const locations = await sql`
+    const locationsResult = await safeQuery(() => sql`
       SELECT id, name, type, city, state_province, country,
              daily_rate, weekly_rate, currency, availability_status,
              square_footage, parking_spaces, power_available, rating,
@@ -511,10 +508,9 @@ export async function productionLocationSearchHandler(request: Request, env: Env
              OR address ILIKE ${'%' + search + '%'})
       ORDER BY rating DESC NULLS LAST, times_booked DESC
       LIMIT ${limit} OFFSET ${offset}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-dashboard.location.search.list' });
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const countResult = await sql`
+    const countResult = await safeQuery<{ total: number }>(() => sql`
       SELECT COUNT(*)::int AS total FROM location_scouts
       WHERE 1=1
         AND (${type} = '' OR type = ${type})
@@ -522,11 +518,11 @@ export async function productionLocationSearchHandler(request: Request, env: Env
         AND (${maxRate} = 0 OR daily_rate <= ${maxRate})
         AND (${search} = '' OR name ILIKE ${'%' + search + '%'}
              OR address ILIKE ${'%' + search + '%'})
-    `.catch(() => [{ total: 0 }]);
+    `, { fallback: [{ total: 0 }], context: 'production-dashboard.location.search.count' });
 
     return jsonResponse({
       success: true,
-      data: { locations, total: countResult[0]?.total || 0 }
+      data: { locations: locationsResult.rows, total: countResult.rows[0]?.total || 0 }
     }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
@@ -548,19 +544,19 @@ export async function productionLocationDetailsHandler(request: Request, env: En
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
   try {
-    // TODO(catch-swallow): migrate to safeQuery
-    const result = await sql`
+    const result = await safeQuery(() => sql`
       SELECT ls.*,
              (SELECT COUNT(*)::int FROM location_bookings lb WHERE lb.location_id = ls.id) AS booking_count
       FROM location_scouts ls
       WHERE ls.id = ${locationId}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-dashboard.location.details' });
 
-    if (result.length === 0) {
+    if (!result.ok) return errorResponse('Failed to fetch location details', origin, 500);
+    if (result.rows.length === 0) {
       return errorResponse('Location not found', origin, 404);
     }
 
-    return jsonResponse({ success: true, data: { location: result[0] } }, origin);
+    return jsonResponse({ success: true, data: { location: result.rows[0] } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('productionLocationDetailsHandler error:', e.message);
@@ -592,19 +588,19 @@ export async function productionLocationBookHandler(request: Request, env: Env):
     }
 
     // Calculate total cost from location daily rate and date range
-    // TODO(catch-swallow): migrate to safeQuery
-    const location = await sql`
+    const locationLookup = await safeQuery<{ daily_rate: number | null }>(() => sql`
       SELECT daily_rate FROM location_scouts WHERE id = ${locationId}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-dashboard.location.book.lookup' });
 
-    if (location.length === 0) {
+    if (!locationLookup.ok) return errorResponse('Failed to book location', origin, 500);
+    if (locationLookup.rows.length === 0) {
       return errorResponse('Location not found', origin, 404);
     }
 
     const start = new Date(startDate);
     const end = new Date(endDate);
     const days = Math.max(1, Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)));
-    const totalCost = (Number(location[0].daily_rate) || 0) * days;
+    const totalCost = (Number(locationLookup.rows[0].daily_rate) || 0) * days;
 
     const booking = await sql`
       INSERT INTO location_bookings (location_id, project_id, booked_by, start_date, end_date, total_cost, status)
@@ -612,11 +608,10 @@ export async function productionLocationBookHandler(request: Request, env: Env):
       RETURNING *
     `;
 
-    // Increment times_booked on the location
-    // TODO(catch-swallow): migrate to safeQuery
-    await sql`
+    // Increment times_booked on the location — best-effort counter (Sentry-reported via safeQuery)
+    await safeQuery(() => sql`
       UPDATE location_scouts SET times_booked = times_booked + 1 WHERE id = ${locationId}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-dashboard.location.book.counter' });
 
     return jsonResponse({ success: true, data: { booking: booking[0] } }, origin, 201);
   } catch (err) {
@@ -647,8 +642,7 @@ export async function productionCrewSearchHandler(request: Request, env: Env): P
     const limit = Math.min(50, Math.max(1, Number(url.searchParams.get('limit')) || 20));
     const offset = Math.max(0, Number(url.searchParams.get('offset')) || 0);
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const crew = await sql`
+    const crewResult = await safeQuery(() => sql`
       SELECT id, first_name, last_name, department, position,
              day_rate, kit_rental_rate, currency, availability_status,
              current_project, available_from, years_experience,
@@ -663,10 +657,9 @@ export async function productionCrewSearchHandler(request: Request, env: Env): P
              OR position ILIKE ${'%' + search + '%'})
       ORDER BY rating DESC NULLS LAST, completed_projects DESC
       LIMIT ${limit} OFFSET ${offset}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-dashboard.crew.search.list' });
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const countResult = await sql`
+    const countResult = await safeQuery<{ total: number }>(() => sql`
       SELECT COUNT(*)::int AS total FROM production_crew
       WHERE 1=1
         AND (${department} = '' OR department = ${department})
@@ -674,11 +667,11 @@ export async function productionCrewSearchHandler(request: Request, env: Env): P
         AND (${search} = '' OR first_name ILIKE ${'%' + search + '%'}
              OR last_name ILIKE ${'%' + search + '%'}
              OR position ILIKE ${'%' + search + '%'})
-    `.catch(() => [{ total: 0 }]);
+    `, { fallback: [{ total: 0 }], context: 'production-dashboard.crew.search.count' });
 
     return jsonResponse({
       success: true,
-      data: { crew, total: countResult[0]?.total || 0 }
+      data: { crew: crewResult.rows, total: countResult.rows[0]?.total || 0 }
     }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
@@ -700,16 +693,16 @@ export async function productionCrewDetailsHandler(request: Request, env: Env): 
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
   try {
-    // TODO(catch-swallow): migrate to safeQuery
-    const result = await sql`
+    const result = await safeQuery(() => sql`
       SELECT * FROM production_crew WHERE id = ${crewId}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-dashboard.crew.details' });
 
-    if (result.length === 0) {
+    if (!result.ok) return errorResponse('Failed to fetch crew details', origin, 500);
+    if (result.rows.length === 0) {
       return errorResponse('Crew member not found', origin, 404);
     }
 
-    return jsonResponse({ success: true, data: { crew: result[0] } }, origin);
+    return jsonResponse({ success: true, data: { crew: result.rows[0] } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('productionCrewDetailsHandler error:', e.message);
@@ -739,22 +732,23 @@ export async function productionCrewHireHandler(request: Request, env: Env): Pro
     if (!projectId) return errorResponse('projectId is required', origin);
 
     // Verify crew exists
-    // TODO(catch-swallow): migrate to safeQuery
-    const crew = await sql`
+    const crewLookup = await safeQuery<{ id: number; first_name: string; last_name: string; availability_status: string | null }>(() => sql`
       SELECT id, first_name, last_name, availability_status FROM production_crew WHERE id = ${crewId}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-dashboard.crew.hire.lookup' });
 
-    if (crew.length === 0) {
+    if (!crewLookup.ok) return errorResponse('Failed to hire crew member', origin, 500);
+    if (crewLookup.rows.length === 0) {
       return errorResponse('Crew member not found', origin, 404);
     }
 
-    // Get project title for the current_project field
-    // TODO(catch-swallow): migrate to safeQuery
-    const project = await sql`
+    // Get project title for the current_project field — non-critical; fall back to placeholder name
+    const projectLookup = await safeQuery<{ title: string | null }>(() => sql`
       SELECT title FROM production_pipeline WHERE id = ${projectId} AND production_company_id = ${Number(userId)}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-dashboard.crew.hire.project-lookup' });
 
-    const projectTitle = project.length > 0 ? (project[0].title || `Project #${projectId}`) : `Project #${projectId}`;
+    const projectTitle = projectLookup.rows.length > 0
+      ? (projectLookup.rows[0].title || `Project #${projectId}`)
+      : `Project #${projectId}`;
 
     // Update crew member
     await sql`
@@ -773,7 +767,7 @@ export async function productionCrewHireHandler(request: Request, env: Env): Pro
         hired: true,
         crewId,
         projectId,
-        crewName: `${crew[0].first_name} ${crew[0].last_name}`,
+        crewName: `${crewLookup.rows[0].first_name} ${crewLookup.rows[0].last_name}`,
         startDate: startDate || null
       }
     }, origin);

--- a/src/handlers/production-dashboard-extended.ts
+++ b/src/handlers/production-dashboard-extended.ts
@@ -253,13 +253,13 @@ export async function productionProjectStatusHandler(request: Request, env: Env)
       return errorResponse(`Invalid stage. Must be one of: ${validStages.join(', ')}`, origin);
     }
 
+    // TODO(catch-swallow): migrate to safeQuery
     const result = await sql`
       UPDATE production_pipeline
       SET
         status = COALESCE(${status ?? null}, status),
         stage = COALESCE(${stage ?? null}, stage),
         completion_percentage = COALESCE(${completionPercentage ?? null}, completion_percentage),
-        // TODO(catch-swallow): migrate to safeQuery
         updated_at = NOW()
       WHERE id = ${projectId} AND production_company_id = ${Number(userId)}
       RETURNING *
@@ -300,6 +300,7 @@ export async function productionBudgetUpdateHandler(request: Request, env: Env):
     const contingencyPercentage = typeof body.contingency_percentage === 'number' ? body.contingency_percentage : undefined;
     const contingencyUsed = typeof body.contingency_used === 'number' ? body.contingency_used : undefined;
 
+    // TODO(catch-swallow): migrate to safeQuery
     const result = await sql`
       UPDATE production_pipeline
       SET
@@ -308,7 +309,6 @@ export async function productionBudgetUpdateHandler(request: Request, env: Env):
         budget_remaining = COALESCE(${budgetAllocated ?? null}, budget_allocated) - COALESCE(${budgetSpent ?? null}, budget_spent),
         contingency_percentage = COALESCE(${contingencyPercentage ?? null}, contingency_percentage),
         contingency_used = COALESCE(${contingencyUsed ?? null}, contingency_used),
-        // TODO(catch-swallow): migrate to safeQuery
         updated_at = NOW()
       WHERE id = ${projectId} AND production_company_id = ${Number(userId)}
       RETURNING id, budget_allocated, budget_spent, budget_remaining, contingency_percentage, contingency_used
@@ -410,6 +410,7 @@ export async function productionScheduleUpdateHandler(request: Request, env: Env
 
       if (!scheduledDate) continue;
 
+      // TODO(catch-swallow): migrate to safeQuery
       const row = await sql`
         INSERT INTO production_schedules (project_id, scene_number, scene_description, scheduled_date, call_time, wrap_time, status)
         VALUES (${projectId}, ${sceneNumber}, ${sceneDescription}, ${scheduledDate}, ${callTime}, ${wrapTime}, ${schedStatus})
@@ -420,7 +421,6 @@ export async function productionScheduleUpdateHandler(request: Request, env: Env
           call_time = EXCLUDED.call_time,
           wrap_time = EXCLUDED.wrap_time,
           status = EXCLUDED.status,
-          // TODO(catch-swallow): migrate to safeQuery
           updated_at = NOW()
         RETURNING *
       `.catch(() => []);

--- a/src/handlers/production-dashboard.ts
+++ b/src/handlers/production-dashboard.ts
@@ -5,6 +5,7 @@
 
 import { neon } from '@neondatabase/serverless';
 import type { Env } from '../db/connection';
+import { safeQuery } from '../db/safe-query';
 import * as pitchQueries from '../db/queries/pitches';
 import * as userQueries from '../db/queries/users';
 import * as investmentQueries from '../db/queries/investments';
@@ -117,16 +118,15 @@ export async function productionDashboardHandler(request: Request, env: Env) {
 
     const sql = neon(env.DATABASE_URL);
 
-    // Check if production_pipeline table exists
-    // TODO(catch-swallow): migrate to safeQuery
-    const tableCheck = await sql`
+    // Check if production_pipeline table exists — schema probe; don't report to Sentry
+    const tableCheck = await safeQuery<{ exists: boolean }>(() => sql`
       SELECT EXISTS (
         SELECT FROM information_schema.tables
         WHERE table_schema = 'public' AND table_name = 'production_pipeline'
       ) as exists
-    `.catch(() => [{ exists: false }]);
+    `, { fallback: [{ exists: false }], context: 'production-dashboard.overview.table-probe.pipeline', report: false });
 
-    if (!tableCheck[0]?.exists) {
+    if (!tableCheck.rows[0]?.exists) {
       // Return empty dashboard if tables don't exist yet
       return new Response(JSON.stringify(emptyDashboard), {
         status: 200,
@@ -135,8 +135,8 @@ export async function productionDashboardHandler(request: Request, env: Env) {
     }
 
     // Get active projects in pipeline
-    // TODO(catch-swallow): migrate to safeQuery
-    const activeProjects = await sql`
+    type ActiveProjectsRow = typeof emptyDashboard.dashboard.activeProjects;
+    const activeProjectsResult = await safeQuery<ActiveProjectsRow>(() => sql`
       SELECT
         COUNT(DISTINCT pp.id) as total_projects,
         COUNT(CASE WHEN pp.stage = 'pre_production' THEN 1 END) as pre_production,
@@ -147,21 +147,21 @@ export async function productionDashboardHandler(request: Request, env: Env) {
       FROM production_pipeline pp
       WHERE pp.production_company_id::text = ${user.id}::text
         AND pp.status = 'active'
-    `.catch(() => [emptyDashboard.dashboard.activeProjects]);
+    `, { fallback: [emptyDashboard.dashboard.activeProjects], context: 'production-dashboard.overview.active-projects' });
+    const activeProjects = activeProjectsResult.rows;
 
-    // Check if production_talent table exists
-    // TODO(catch-swallow): migrate to safeQuery
-    const talentTableCheck = await sql`
+    // Check if production_talent table exists — schema probe; don't report to Sentry
+    const talentTableCheck = await safeQuery<{ exists: boolean }>(() => sql`
       SELECT EXISTS (
         SELECT FROM information_schema.tables
         WHERE table_schema = 'public' AND table_name = 'production_talent'
       ) as exists
-    `.catch(() => [{ exists: false }]);
+    `, { fallback: [{ exists: false }], context: 'production-dashboard.overview.table-probe.talent', report: false });
 
-    let talentStats = [emptyDashboard.dashboard.talentStats];
-    if (talentTableCheck[0]?.exists) {
-      // TODO(catch-swallow): migrate to safeQuery
-      talentStats = (await sql`
+    type TalentStatsRow = typeof emptyDashboard.dashboard.talentStats;
+    let talentStats: TalentStatsRow[] = [emptyDashboard.dashboard.talentStats];
+    if (talentTableCheck.rows[0]?.exists) {
+      const talentStatsResult = await safeQuery<TalentStatsRow>(() => sql`
         SELECT
           COUNT(DISTINCT talent_id) as total_talent,
           COUNT(CASE WHEN status = 'available' THEN 1 END) as available,
@@ -169,12 +169,12 @@ export async function productionDashboardHandler(request: Request, env: Env) {
           COALESCE(AVG(rating), 0) as avg_rating
         FROM production_talent
         WHERE production_company_id::text = ${user.id}::text
-      `.catch(() => [emptyDashboard.dashboard.talentStats])) as { total_talent: number; available: number; contracted: number; avg_rating: number; }[];
+      `, { fallback: [emptyDashboard.dashboard.talentStats], context: 'production-dashboard.overview.talent-stats' });
+      talentStats = talentStatsResult.rows;
     }
 
     // Get upcoming deadlines
-    // TODO(catch-swallow): migrate to safeQuery
-    const upcomingDeadlines = await sql`
+    const upcomingDeadlinesResult = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT
         pp.title,
         pp.stage,
@@ -187,11 +187,12 @@ export async function productionDashboardHandler(request: Request, env: Env) {
         AND pp.milestone_date > NOW()
       ORDER BY pp.milestone_date ASC
       LIMIT 5
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-dashboard.overview.upcoming-deadlines' });
+    const upcomingDeadlines = upcomingDeadlinesResult.rows;
 
     // Get budget overview
-    // TODO(catch-swallow): migrate to safeQuery
-    const budgetOverview = await sql`
+    type BudgetOverviewRow = typeof emptyDashboard.dashboard.budgetOverview;
+    const budgetOverviewResult = await safeQuery<BudgetOverviewRow>(() => sql`
       SELECT
         COALESCE(SUM(budget_allocated), 0) as total_allocated,
         COALESCE(SUM(budget_spent), 0) as total_spent,
@@ -202,21 +203,20 @@ export async function productionDashboardHandler(request: Request, env: Env) {
       FROM production_pipeline
       WHERE production_company_id::text = ${user.id}::text
         AND status IN ('active', 'completed')
-    `.catch(() => [emptyDashboard.dashboard.budgetOverview]);
+    `, { fallback: [emptyDashboard.dashboard.budgetOverview], context: 'production-dashboard.overview.budget-overview' });
+    const budgetOverview = budgetOverviewResult.rows;
 
-    // Check if crew_assignments table exists
-    // TODO(catch-swallow): migrate to safeQuery
-    const crewTableCheck = await sql`
+    // Check if crew_assignments table exists — schema probe; don't report to Sentry
+    const crewTableCheck = await safeQuery<{ exists: boolean }>(() => sql`
       SELECT EXISTS (
         SELECT FROM information_schema.tables
         WHERE table_schema = 'public' AND table_name = 'crew_assignments'
       ) as exists
-    `.catch(() => [{ exists: false }]);
+    `, { fallback: [{ exists: false }], context: 'production-dashboard.overview.table-probe.crew', report: false });
 
-    let recentAssignments: any[] = [];
-    if (crewTableCheck[0]?.exists) {
-      // TODO(catch-swallow): migrate to safeQuery
-      recentAssignments = await sql`
+    let recentAssignments: Record<string, unknown>[] = [];
+    if (crewTableCheck.rows[0]?.exists) {
+      const recentAssignmentsResult = await safeQuery<Record<string, unknown>>(() => sql`
         SELECT
           ca.id,
           ca.crew_member_name,
@@ -229,22 +229,21 @@ export async function productionDashboardHandler(request: Request, env: Env) {
         WHERE pp.production_company_id::text = ${user.id}::text
         ORDER BY ca.assigned_date DESC
         LIMIT 10
-      `.catch(() => []);
+      `, { fallback: [], context: 'production-dashboard.overview.recent-assignments' });
+      recentAssignments = recentAssignmentsResult.rows;
     }
 
-    // Check if location_scouts table exists
-    // TODO(catch-swallow): migrate to safeQuery
-    const locationTableCheck = await sql`
+    // Check if location_scouts table exists — schema probe; don't report to Sentry
+    const locationTableCheck = await safeQuery<{ exists: boolean }>(() => sql`
       SELECT EXISTS (
         SELECT FROM information_schema.tables
         WHERE table_schema = 'public' AND table_name = 'location_scouts'
       ) as exists
-    `.catch(() => [{ exists: false }]);
+    `, { fallback: [{ exists: false }], context: 'production-dashboard.overview.table-probe.locations', report: false });
 
-    let locationUpdates: any[] = [];
-    if (locationTableCheck[0]?.exists) {
-      // TODO(catch-swallow): migrate to safeQuery
-      locationUpdates = await sql`
+    let locationUpdates: Record<string, unknown>[] = [];
+    if (locationTableCheck.rows[0]?.exists) {
+      const locationUpdatesResult = await safeQuery<Record<string, unknown>>(() => sql`
         SELECT
           ls.id,
           ls.location_name,
@@ -258,7 +257,8 @@ export async function productionDashboardHandler(request: Request, env: Env) {
           AND ls.scouted_date > NOW() - INTERVAL '7 days'
         ORDER BY ls.scouted_date DESC
         LIMIT 5
-      `.catch(() => []);
+      `, { fallback: [], context: 'production-dashboard.overview.location-updates' });
+      locationUpdates = locationUpdatesResult.rows;
     }
 
     return new Response(JSON.stringify({

--- a/src/handlers/production-deals.ts
+++ b/src/handlers/production-deals.ts
@@ -6,6 +6,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId } from '../utils/auth-extract';
+import { safeQuery } from '../db/safe-query';
 
 function jsonResponse(data: unknown, origin: string | null, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -46,8 +47,7 @@ export async function getProductionDeals(request: Request, env: Env): Promise<Re
     };
     const orderCol = validSorts[sortBy] || 'created_at';
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const deals = await sql`
+    const dealsResult = await safeQuery(() => sql`
       SELECT d.*,
              d.deal_state AS status,
              COALESCE(d.option_amount, d.purchase_price, d.development_fee, 0) AS amount,
@@ -65,18 +65,17 @@ export async function getProductionDeals(request: Request, env: Env): Promise<Re
         CASE WHEN ${orderCol} = 'created_at' THEN d.created_at END DESC NULLS LAST,
         d.created_at DESC NULLS LAST
       LIMIT ${limit} OFFSET ${offset}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-deals.list' });
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const countResult = await sql`
+    const countResult = await safeQuery<{ total: number }>(() => sql`
       SELECT COUNT(*)::int AS total FROM production_deals
       WHERE production_company_id = ${Number(userId)}
         AND (${status} = '' OR deal_state::text = ${status})
-    `.catch(() => [{ total: 0 }]);
+    `, { fallback: [{ total: 0 }], context: 'production-deals.count' });
 
     return jsonResponse({
       success: true,
-      data: { deals, total: countResult[0]?.total || 0 }
+      data: { deals: dealsResult.rows, total: countResult.rows[0]?.total || 0 }
     }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
@@ -111,9 +110,10 @@ export async function createProductionDeal(request: Request, env: Env): Promise<
     }
 
     // Lookup pitch for creator_id
-    // TODO(catch-swallow): migrate to safeQuery
-    const pitch = await sql`SELECT user_id FROM pitches WHERE id = ${pitchId}`.catch(() => []);
-    const creatorId = pitch.length > 0 ? pitch[0].user_id : null;
+    const pitchLookup = await safeQuery<{ user_id: number | null }>(() => sql`
+      SELECT user_id FROM pitches WHERE id = ${pitchId}
+    `, { fallback: [], context: 'production-deals.create.pitch-lookup' });
+    const creatorId = pitchLookup.rows.length > 0 ? pitchLookup.rows[0].user_id : null;
 
     const result = await sql`
       INSERT INTO production_deals (pitch_id, production_company_id, creator_id, deal_type, option_amount, backend_percentage, notes)
@@ -121,17 +121,16 @@ export async function createProductionDeal(request: Request, env: Env): Promise<
       RETURNING *, deal_state AS status, option_amount AS amount
     `;
 
-    // Notify the creator
+    // Notify the creator — best-effort (Sentry-reported via safeQuery)
     if (creatorId) {
-      // TODO(catch-swallow): migrate to safeQuery
-      await sql`
+      await safeQuery(() => sql`
         INSERT INTO notifications (user_id, type, title, message, related_user_id, related_pitch_id, created_at)
         VALUES (
           ${creatorId}, 'deal_proposed', 'New Deal Proposal',
           ${'A production company has proposed a ' + dealType + ' deal for your pitch'},
           ${Number(userId)}, ${pitchId}, NOW()
         )
-      `.catch(() => []);
+      `, { fallback: [], context: 'production-deals.create.notify' });
     }
 
     return jsonResponse({ success: true, data: { deal: result[0] } }, origin, 201);
@@ -156,8 +155,7 @@ export async function getProductionContract(request: Request, env: Env): Promise
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
   try {
-    // TODO(catch-swallow): migrate to safeQuery
-    const result = await sql`
+    const result = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT d.*,
              p.title AS pitch_title, p.genre, p.logline,
              COALESCE(cu.name, cu.first_name || ' ' || cu.last_name) AS creator_name,
@@ -169,13 +167,14 @@ export async function getProductionContract(request: Request, env: Env): Promise
       LEFT JOIN users cu ON d.creator_id = cu.id
       LEFT JOIN users pu ON d.production_company_id = pu.id
       WHERE d.id = ${dealId} AND d.production_company_id = ${Number(userId)}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-deals.contract' });
 
-    if (result.length === 0) {
+    if (!result.ok) return errorResponse('Failed to generate contract', origin, 500);
+    if (result.rows.length === 0) {
       return errorResponse('Deal not found', origin, 404);
     }
 
-    const deal = result[0];
+    const deal = result.rows[0];
 
     // Build contract JSON representation
     const contract = {
@@ -228,23 +227,24 @@ export async function getDistributionChannels(request: Request, env: Env): Promi
 
   try {
     // Verify ownership
-    // TODO(catch-swallow): migrate to safeQuery
-    const project = await sql`
+    const ownership = await safeQuery<{ id: number }>(() => sql`
       SELECT id FROM production_pipeline WHERE id = ${projectId} AND production_company_id = ${Number(userId)}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-deals.distribution.ownership' });
 
-    if (project.length === 0) {
+    if (!ownership.ok) {
+      return jsonResponse({ success: true, data: { channels: [] } }, origin);
+    }
+    if (ownership.rows.length === 0) {
       return errorResponse('Project not found', origin, 404);
     }
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const channels = await sql`
+    const channelsResult = await safeQuery(() => sql`
       SELECT * FROM distribution_channels
       WHERE project_id = ${projectId}
       ORDER BY release_date ASC NULLS LAST
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-deals.distribution.list' });
 
-    return jsonResponse({ success: true, data: { channels } }, origin);
+    return jsonResponse({ success: true, data: { channels: channelsResult.rows } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('getDistributionChannels error:', e.message);
@@ -270,35 +270,37 @@ export async function exportProjectData(request: Request, env: Env): Promise<Res
 
   try {
     // Fetch project
-    // TODO(catch-swallow): migrate to safeQuery
-    const projectResult = await sql`
+    const projectResult = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT pp.*,
              p.title AS pitch_title, p.genre, p.logline, p.format, p.estimated_budget
       FROM production_pipeline pp
       LEFT JOIN pitches p ON pp.pitch_id = p.id
       WHERE pp.id = ${projectId} AND pp.production_company_id = ${Number(userId)}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-deals.export.project' });
 
-    if (projectResult.length === 0) {
+    if (!projectResult.ok) return errorResponse('Failed to export project data', origin, 500);
+    if (projectResult.rows.length === 0) {
       return errorResponse('Project not found', origin, 404);
     }
 
+    const project = projectResult.rows[0];
+
     // Fetch related data in parallel
-    const [milestones, channels, deals] = await Promise.all([
-      // TODO(catch-swallow): migrate to safeQuery
-      sql`SELECT * FROM project_milestones WHERE project_id = ${projectId} ORDER BY due_date`.catch(() => []),
-      // TODO(catch-swallow): migrate to safeQuery
-      sql`SELECT * FROM distribution_channels WHERE project_id = ${projectId}`.catch(() => []),
-      // TODO(catch-swallow): migrate to safeQuery
-      sql`SELECT * FROM production_deals WHERE pitch_id = ${projectResult[0].pitch_id}`.catch(() => []),
+    const [milestonesResult, channelsResult, dealsResult] = await Promise.all([
+      safeQuery(() => sql`SELECT * FROM project_milestones WHERE project_id = ${projectId} ORDER BY due_date`,
+        { fallback: [], context: 'production-deals.export.milestones' }),
+      safeQuery(() => sql`SELECT * FROM distribution_channels WHERE project_id = ${projectId}`,
+        { fallback: [], context: 'production-deals.export.channels' }),
+      safeQuery(() => sql`SELECT * FROM production_deals WHERE pitch_id = ${project.pitch_id}`,
+        { fallback: [], context: 'production-deals.export.deals' }),
     ]);
 
     const exportData = {
       exportedAt: new Date().toISOString(),
-      project: projectResult[0],
-      milestones,
-      distributionChannels: channels,
-      deals,
+      project,
+      milestones: milestonesResult.rows,
+      distributionChannels: channelsResult.rows,
+      deals: dealsResult.rows,
     };
 
     return jsonResponse({ success: true, data: exportData }, origin);
@@ -330,12 +332,12 @@ export async function updateProjectMilestone(request: Request, env: Env): Promis
 
   try {
     // Verify project ownership
-    // TODO(catch-swallow): migrate to safeQuery
-    const project = await sql`
+    const ownership = await safeQuery<{ id: number }>(() => sql`
       SELECT id FROM production_pipeline WHERE id = ${projectId} AND production_company_id = ${Number(userId)}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-deals.milestone-update.ownership' });
 
-    if (project.length === 0) {
+    if (!ownership.ok) return errorResponse('Failed to update milestone', origin, 500);
+    if (ownership.rows.length === 0) {
       return errorResponse('Project not found', origin, 404);
     }
 
@@ -346,8 +348,7 @@ export async function updateProjectMilestone(request: Request, env: Env): Promis
     const dueDate = typeof body.due_date === 'string' ? body.due_date : undefined;
     const notes = typeof body.notes === 'string' ? body.notes : undefined;
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const result = await sql`
+    const result = await safeQuery<Record<string, unknown>>(() => sql`
       UPDATE project_milestones
       SET
         title = COALESCE(${title ?? null}, title),
@@ -362,13 +363,14 @@ export async function updateProjectMilestone(request: Request, env: Env): Promis
         updated_at = NOW()
       WHERE id = ${milestoneId} AND project_id = ${projectId}
       RETURNING *
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-deals.milestone-update' });
 
-    if (result.length === 0) {
+    if (!result.ok) return errorResponse('Failed to update milestone', origin, 500);
+    if (result.rows.length === 0) {
       return errorResponse('Milestone not found', origin, 404);
     }
 
-    return jsonResponse({ success: true, data: { milestone: result[0] } }, origin);
+    return jsonResponse({ success: true, data: { milestone: result.rows[0] } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('updateProjectMilestone error:', e.message);

--- a/src/handlers/production-deals.ts
+++ b/src/handlers/production-deals.ts
@@ -346,6 +346,7 @@ export async function updateProjectMilestone(request: Request, env: Env): Promis
     const dueDate = typeof body.due_date === 'string' ? body.due_date : undefined;
     const notes = typeof body.notes === 'string' ? body.notes : undefined;
 
+    // TODO(catch-swallow): migrate to safeQuery
     const result = await sql`
       UPDATE project_milestones
       SET
@@ -358,7 +359,6 @@ export async function updateProjectMilestone(request: Request, env: Env): Promis
           WHEN ${completed ?? null} = false THEN NULL
           ELSE completed_at
         END,
-        // TODO(catch-swallow): migrate to safeQuery
         updated_at = NOW()
       WHERE id = ${milestoneId} AND project_id = ${projectId}
       RETURNING *

--- a/src/handlers/production-pitch-data.ts
+++ b/src/handlers/production-pitch-data.ts
@@ -8,6 +8,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId } from '../utils/auth-extract';
+import { safeQuery } from '../db/safe-query';
 
 function jsonResponse(data: unknown, origin: string | null, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -46,15 +47,14 @@ export async function getProductionNotes(request: Request, env: Env): Promise<Re
   if (!sql) return jsonResponse({ success: true, data: { notes: [] } }, origin);
 
   try {
-    // TODO(catch-swallow): migrate to safeQuery
-    const notes = await sql`
+    const notesResult = await safeQuery(() => sql`
       SELECT id, content, category, author, shared, created_at, updated_at
       FROM production_notes
       WHERE user_id = ${Number(userId)} AND pitch_id = ${pitchId}
       ORDER BY created_at ASC
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-pitch-data.notes.list' });
 
-    return jsonResponse({ success: true, data: { notes } }, origin);
+    return jsonResponse({ success: true, data: { notes: notesResult.rows } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('getProductionNotes error:', e.message);
@@ -160,13 +160,12 @@ export async function getProductionChecklist(request: Request, env: Env): Promis
   if (!sql) return jsonResponse({ success: true, data: { checklist: {} } }, origin);
 
   try {
-    // TODO(catch-swallow): migrate to safeQuery
-    const result = await sql`
+    const result = await safeQuery<{ checklist: Record<string, unknown> }>(() => sql`
       SELECT checklist FROM production_checklists
       WHERE user_id = ${Number(userId)} AND pitch_id = ${pitchId}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-pitch-data.checklist.read' });
 
-    const checklist = result.length > 0 ? result[0].checklist : {};
+    const checklist = result.rows.length > 0 ? result.rows[0].checklist : {};
     return jsonResponse({ success: true, data: { checklist } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
@@ -232,13 +231,12 @@ export async function getProductionTeam(request: Request, env: Env): Promise<Res
   if (!sql) return jsonResponse({ success: true, data: { team: [] } }, origin);
 
   try {
-    // TODO(catch-swallow): migrate to safeQuery
-    const result = await sql`
+    const result = await safeQuery<{ team: unknown[] }>(() => sql`
       SELECT team FROM production_team_assignments
       WHERE user_id = ${Number(userId)} AND pitch_id = ${pitchId}
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-pitch-data.team.read' });
 
-    const team = result.length > 0 ? result[0].team : [];
+    const team = result.rows.length > 0 ? result.rows[0].team : [];
     return jsonResponse({ success: true, data: { team } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
@@ -361,8 +359,7 @@ export async function getCreatorPitchFeedback(request: Request, env: Env): Promi
     }
 
     // Fetch all shared notes from any production user, with author info
-    // TODO(catch-swallow): migrate to safeQuery
-    const feedback = await sql`
+    const feedbackResult = await safeQuery(() => sql`
       SELECT
         n.id, n.content, n.category, n.author, n.created_at,
         u.company_name,
@@ -372,9 +369,9 @@ export async function getCreatorPitchFeedback(request: Request, env: Env): Promi
       JOIN users u ON u.id = n.user_id
       WHERE n.pitch_id = ${pitchId} AND n.shared = true
       ORDER BY n.created_at DESC
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-pitch-data.creator-feedback' });
 
-    return jsonResponse({ success: true, data: { feedback } }, origin);
+    return jsonResponse({ success: true, data: { feedback: feedbackResult.rows } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('getCreatorPitchFeedback error:', e.message);

--- a/src/handlers/production-sidebar.ts
+++ b/src/handlers/production-sidebar.ts
@@ -15,6 +15,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId } from '../utils/auth-extract';
+import { safeQuery } from '../db/safe-query';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -197,9 +198,8 @@ export async function productionActivityHandler(
     };
     const timeFilter = (timeRange && intervalMap[timeRange]) ? sql.unsafe(intervalMap[timeRange]) : sql``;
 
-    const [activities, countResult] = await Promise.all([
-      // TODO(catch-swallow): migrate to safeQuery
-      sql`
+    const [activitiesResult, countResult] = await Promise.all([
+      safeQuery(() => sql`
         SELECT
           id,
           type,
@@ -218,23 +218,22 @@ export async function productionActivityHandler(
         ORDER BY created_at DESC
         LIMIT ${limit}
         OFFSET ${offset}
-      `.catch(() => []),
-      // TODO(catch-swallow): migrate to safeQuery
-      sql`
+      `, { fallback: [], context: 'production-sidebar.activity.list' }),
+      safeQuery<{ total: number }>(() => sql`
         SELECT COUNT(*)::int AS total
         FROM notifications
         WHERE user_id = ${Number(userId)}
         ${timeFilter}
-      `.catch(() => [{ total: 0 }]),
+      `, { fallback: [{ total: 0 }], context: 'production-sidebar.activity.count' }),
     ]);
 
-    const total = Number(countResult[0]?.total) || 0;
+    const total = Number(countResult.rows[0]?.total) || 0;
     const totalPages = Math.ceil(total / limit) || 0;
 
     return jsonResponse({
       success: true,
       data: {
-        activities,
+        activities: activitiesResult.rows,
         pagination: { page, limit, total, totalPages },
       },
     }, origin);
@@ -286,9 +285,8 @@ export async function productionSubmissionsHandler(
     // Only shows pitches where this user has a signed NDA (via ndas or nda_requests table)
     // Other statuses = saved_pitches entries with matching review_status
     if (statusFilter === 'new') {
-      const [submissions, countResult] = await Promise.all([
-        // TODO(catch-swallow): migrate to safeQuery
-        sql`
+      const [submissionsResult, countResult] = await Promise.all([
+        safeQuery(() => sql`
           SELECT
             p.id, p.user_id, p.title, p.genre, p.logline, p.short_synopsis, p.format,
             p.estimated_budget, p.budget_range, p.status, p.view_count,
@@ -309,9 +307,8 @@ export async function productionSubmissionsHandler(
             )
           ORDER BY p.created_at DESC
           LIMIT ${limit} OFFSET ${offset}
-        `.catch(() => []),
-        // TODO(catch-swallow): migrate to safeQuery
-        sql`
+        `, { fallback: [], context: 'production-sidebar.submissions.new.list' }),
+        safeQuery<{ total: number }>(() => sql`
           SELECT COUNT(*)::int AS total
           FROM pitches p
           LEFT JOIN saved_pitches sp ON sp.pitch_id = p.id AND sp.user_id = ${userId}
@@ -323,20 +320,19 @@ export async function productionSubmissionsHandler(
               EXISTS (SELECT 1 FROM ndas n WHERE n.pitch_id = p.id AND COALESCE(n.signer_id, n.user_id) = ${userId} AND n.status = 'signed')
               OR EXISTS (SELECT 1 FROM nda_requests nr WHERE nr.pitch_id = p.id AND nr.requester_id = ${userId} AND nr.status = 'approved')
             )
-        `.catch(() => [{ total: 0 }]),
+        `, { fallback: [{ total: 0 }], context: 'production-sidebar.submissions.new.count' }),
       ]);
 
-      const total = Number(countResult[0]?.total) || 0;
+      const total = Number(countResult.rows[0]?.total) || 0;
       return jsonResponse({
         success: true,
-        data: { submissions, filter: statusFilter, pagination: { page, limit, total, totalPages: Math.ceil(total / limit) || 0 } },
+        data: { submissions: submissionsResult.rows, filter: statusFilter, pagination: { page, limit, total, totalPages: Math.ceil(total / limit) || 0 } },
       }, origin);
     }
 
     // For review, shortlisted, accepted, rejected, archived — query saved_pitches
-    const [submissions, countResult] = await Promise.all([
-      // TODO(catch-swallow): migrate to safeQuery
-      sql`
+    const [submissionsResult, countResult] = await Promise.all([
+      safeQuery(() => sql`
         SELECT
           p.id, p.user_id, p.title, p.genre, p.logline, p.short_synopsis, p.format,
           p.estimated_budget, p.budget_range, p.status, p.view_count,
@@ -353,22 +349,21 @@ export async function productionSubmissionsHandler(
           AND (p.creator_id IS NULL OR p.creator_id != ${userId})
         ORDER BY COALESCE(sp.reviewed_at, sp.saved_at) DESC
         LIMIT ${limit} OFFSET ${offset}
-      `.catch(() => []),
-      // TODO(catch-swallow): migrate to safeQuery
-      sql`
+      `, { fallback: [], context: 'production-sidebar.submissions.review.list', tags: { filter: statusFilter } }),
+      safeQuery<{ total: number }>(() => sql`
         SELECT COUNT(*)::int AS total
         FROM saved_pitches sp
         JOIN pitches p ON p.id = sp.pitch_id
         WHERE sp.user_id = ${userId} AND sp.review_status = ${statusFilter}
           AND p.user_id != ${userId}
           AND (p.creator_id IS NULL OR p.creator_id != ${userId})
-      `.catch(() => [{ total: 0 }]),
+      `, { fallback: [{ total: 0 }], context: 'production-sidebar.submissions.review.count', tags: { filter: statusFilter } }),
     ]);
 
-    const total = Number(countResult[0]?.total) || 0;
+    const total = Number(countResult.rows[0]?.total) || 0;
     return jsonResponse({
       success: true,
-      data: { submissions, filter: statusFilter, pagination: { page, limit, total, totalPages: Math.ceil(total / limit) || 0 } },
+      data: { submissions: submissionsResult.rows, filter: statusFilter, pagination: { page, limit, total, totalPages: Math.ceil(total / limit) || 0 } },
     }, origin);
   } catch (error) {
     console.error('productionSubmissionsHandler error:', error);
@@ -475,22 +470,21 @@ export async function productionRevenueHandler(
   }
 
   try {
-    // Check if production_pipeline exists
-    // TODO(catch-swallow): migrate to safeQuery
-    const tableCheck = await sql`
+    // Check if production_pipeline exists — schema probe; don't report to Sentry
+    const tableCheck = await safeQuery<{ exists: boolean }>(() => sql`
       SELECT EXISTS (
         SELECT FROM information_schema.tables
         WHERE table_schema = 'public' AND table_name = 'production_pipeline'
       ) AS exists
-    `.catch(() => [{ exists: false }]);
+    `, { fallback: [{ exists: false }], context: 'production-sidebar.revenue.table-probe.pipeline', report: false });
 
-    if (!tableCheck[0]?.exists) {
+    if (!tableCheck.rows[0]?.exists) {
       return jsonResponse({ success: true, data: defaultData }, origin);
     }
 
     // Aggregate revenue by time periods
-    // TODO(catch-swallow): migrate to safeQuery
-    const revenueSummary = await sql`
+    type RevenueSummaryRow = { total_revenue: number; monthly_revenue: number; quarterly_revenue: number; yearly_revenue: number };
+    const revenueSummaryResult = await safeQuery<RevenueSummaryRow>(() => sql`
       SELECT
         COALESCE(SUM(i.amount), 0) AS total_revenue,
         COALESCE(SUM(
@@ -506,16 +500,15 @@ export async function productionRevenueHandler(
       JOIN production_pipeline pp ON i.pitch_id = pp.pitch_id
       WHERE pp.production_company_id::text = ${String(userId)}
         AND i.status IN ('active', 'funded', 'committed', 'completed')
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-sidebar.revenue.summary' });
 
-    const totalRevenue = Number(revenueSummary[0]?.total_revenue) || 0;
-    const monthlyRevenue = Number(revenueSummary[0]?.monthly_revenue) || 0;
-    const quarterlyRevenue = Number(revenueSummary[0]?.quarterly_revenue) || 0;
-    const yearlyRevenue = Number(revenueSummary[0]?.yearly_revenue) || 0;
+    const totalRevenue = Number(revenueSummaryResult.rows[0]?.total_revenue) || 0;
+    const monthlyRevenue = Number(revenueSummaryResult.rows[0]?.monthly_revenue) || 0;
+    const quarterlyRevenue = Number(revenueSummaryResult.rows[0]?.quarterly_revenue) || 0;
+    const yearlyRevenue = Number(revenueSummaryResult.rows[0]?.yearly_revenue) || 0;
 
     // Revenue by project
-    // TODO(catch-swallow): migrate to safeQuery
-    const revenueByProject = await sql`
+    const revenueByProjectResult = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT
         pp.id AS project_id,
         COALESCE(pp.title, p.title, 'Untitled') AS project_title,
@@ -529,11 +522,11 @@ export async function productionRevenueHandler(
       GROUP BY pp.id, pp.title, p.title
       ORDER BY revenue DESC
       LIMIT 20
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-sidebar.revenue.by-project' });
+    const revenueByProject = revenueByProjectResult.rows;
 
     // Revenue by month (last 12 months)
-    // TODO(catch-swallow): migrate to safeQuery
-    const revenueByMonth = await sql`
+    const revenueByMonthResult = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT
         TO_CHAR(DATE_TRUNC('month', i.created_at), 'YYYY-MM') AS month,
         COALESCE(SUM(i.amount), 0) AS revenue,
@@ -545,7 +538,8 @@ export async function productionRevenueHandler(
         AND i.created_at >= NOW() - INTERVAL '12 months'
       GROUP BY DATE_TRUNC('month', i.created_at)
       ORDER BY month ASC
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-sidebar.revenue.by-month' });
+    const revenueByMonth = revenueByMonthResult.rows;
 
     // Simple projected revenue: average of last 3 months extrapolated
     let projectedRevenue = 0;
@@ -559,25 +553,24 @@ export async function productionRevenueHandler(
 
     // Average deal size from production_deals table
     let avgDealSize = 0;
-    // TODO(catch-swallow): migrate to safeQuery
-    const dealCheck = await sql`
+    // schema probe; don't report to Sentry
+    const dealCheck = await safeQuery<{ exists: boolean }>(() => sql`
       SELECT EXISTS (
         SELECT FROM information_schema.tables
         WHERE table_schema = 'public' AND table_name = 'production_deals'
       ) AS exists
-    `.catch(() => [{ exists: false }]);
+    `, { fallback: [{ exists: false }], context: 'production-sidebar.revenue.table-probe.deals', report: false });
 
-    if (dealCheck[0]?.exists) {
-      // TODO(catch-swallow): migrate to safeQuery
-      const dealStats = await sql`
+    if (dealCheck.rows[0]?.exists) {
+      const dealStats = await safeQuery<{ avg_deal: number | null }>(() => sql`
         SELECT
           AVG(COALESCE(NULLIF(option_amount, 0), NULLIF(purchase_price, 0), NULLIF(development_fee, 0))) AS avg_deal
         FROM production_deals
         WHERE production_company_id = ${Number(userId)}
           AND deal_state NOT IN ('rejected', 'cancelled')
-      `.catch(() => []);
+      `, { fallback: [], context: 'production-sidebar.revenue.deal-stats' });
 
-      avgDealSize = Number(dealStats[0]?.avg_deal) || 0;
+      avgDealSize = Number(dealStats.rows[0]?.avg_deal) || 0;
     }
 
     // Fallback: derive from revenueByProject if no deals exist
@@ -589,8 +582,7 @@ export async function productionRevenueHandler(
     }
 
     // Revenue by category (pitch format)
-    // TODO(catch-swallow): migrate to safeQuery
-    const revenueByCategory = await sql`
+    const revenueByCategoryResult = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT
         COALESCE(p.format, 'Other') AS category,
         COALESCE(SUM(i.amount), 0) AS revenue
@@ -601,7 +593,8 @@ export async function productionRevenueHandler(
       WHERE pp.production_company_id::text = ${String(userId)}
       GROUP BY p.format
       ORDER BY revenue DESC
-    `.catch(() => []);
+    `, { fallback: [], context: 'production-sidebar.revenue.by-category' });
+    const revenueByCategory = revenueByCategoryResult.rows;
 
     // Compute percentages for each category
     const categoryTotal = revenueByCategory.reduce(
@@ -665,9 +658,8 @@ export async function productionSavedPitchesHandler(
   }
 
   try {
-    const [savedPitches, countResult] = await Promise.all([
-      // TODO(catch-swallow): migrate to safeQuery
-      sql`
+    const [savedPitchesResult, countResult] = await Promise.all([
+      safeQuery(() => sql`
         SELECT
           sp.id AS saved_id,
           sp.notes,
@@ -694,21 +686,20 @@ export async function productionSavedPitchesHandler(
         WHERE sp.user_id = ${Number(userId)}
         ORDER BY sp.saved_at DESC
         LIMIT 50
-      `.catch(() => []),
-      // TODO(catch-swallow): migrate to safeQuery
-      sql`
+      `, { fallback: [], context: 'production-sidebar.saved-pitches.list' }),
+      safeQuery<{ total: number }>(() => sql`
         SELECT COUNT(*)::int AS total
         FROM saved_pitches
         WHERE user_id = ${Number(userId)}
-      `.catch(() => [{ total: 0 }]),
+      `, { fallback: [{ total: 0 }], context: 'production-sidebar.saved-pitches.count' }),
     ]);
 
-    const total = Number(countResult[0]?.total) || 0;
+    const total = Number(countResult.rows[0]?.total) || 0;
 
     return jsonResponse({
       success: true,
       data: {
-        savedPitches,
+        savedPitches: savedPitchesResult.rows,
         total,
       },
     }, origin);

--- a/src/handlers/status-dashboard.ts
+++ b/src/handlers/status-dashboard.ts
@@ -5,6 +5,7 @@
 
 import { WorkerDatabase } from '../services/worker-database';
 import { getCorsHeaders } from '../utils/response';
+import { safeQuery } from '../db/safe-query';
 
 interface ServiceStatus {
   name: string;
@@ -124,31 +125,36 @@ export async function statusDashboardHandler(
     });
 
     // Get request/error counts
-    // TODO(catch-swallow): migrate to safeQuery
-    const metricsQuery = await db.query(`
-      SELECT
-        COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '24 hours') as requests_24h,
-        COUNT(*) FILTER (WHERE status_code >= 500 AND created_at > NOW() - INTERVAL '24 hours') as errors_24h,
-        AVG(response_time) FILTER (WHERE created_at > NOW() - INTERVAL '1 hour') as avg_response_time,
-        PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY response_time)
-          FILTER (WHERE created_at > NOW() - INTERVAL '1 hour') as p95_response_time
-      FROM request_logs
-    `).catch(() => [{ requests_24h: 0, errors_24h: 0, avg_response_time: 0, p95_response_time: 0 }]);
+    type MetricsRow = { requests_24h: number; errors_24h: number; avg_response_time: number; p95_response_time: number };
+    const metricsQuery = await safeQuery<MetricsRow>(
+      () => db.query(`
+        SELECT
+          COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '24 hours') as requests_24h,
+          COUNT(*) FILTER (WHERE status_code >= 500 AND created_at > NOW() - INTERVAL '24 hours') as errors_24h,
+          AVG(response_time) FILTER (WHERE created_at > NOW() - INTERVAL '1 hour') as avg_response_time,
+          PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY response_time)
+            FILTER (WHERE created_at > NOW() - INTERVAL '1 hour') as p95_response_time
+        FROM request_logs
+      `),
+      { fallback: [{ requests_24h: 0, errors_24h: 0, avg_response_time: 0, p95_response_time: 0 }], context: 'status-dashboard.metrics.request-logs' }
+    );
 
     // Get active users
-    // TODO(catch-swallow): migrate to safeQuery
-    const activeUsersQuery = await db.query(`
-      SELECT COUNT(DISTINCT user_id) as active_users
-      FROM sessions
-      WHERE expires_at > NOW()
-    `).catch(() => [{ active_users: 0 }]);
+    const activeUsersQuery = await safeQuery<{ active_users: number }>(
+      () => db.query(`
+        SELECT COUNT(DISTINCT user_id) as active_users
+        FROM sessions
+        WHERE expires_at > NOW()
+      `),
+      { fallback: [{ active_users: 0 }], context: 'status-dashboard.metrics.active-users' }
+    );
 
-    if (metricsQuery && metricsQuery[0]) {
-      const m = metricsQuery[0] as any;
-      dashboard.metrics.requestsLast24h = parseInt(m.requests_24h) || 0;
-      dashboard.metrics.errorsLast24h = parseInt(m.errors_24h) || 0;
-      dashboard.metrics.avgResponseTime = Math.round(parseFloat(m.avg_response_time) || 0);
-      dashboard.metrics.p95ResponseTime = Math.round(parseFloat(m.p95_response_time) || 0);
+    if (metricsQuery.rows[0]) {
+      const m = metricsQuery.rows[0] as Record<string, unknown>;
+      dashboard.metrics.requestsLast24h = parseInt(String(m.requests_24h)) || 0;
+      dashboard.metrics.errorsLast24h = parseInt(String(m.errors_24h)) || 0;
+      dashboard.metrics.avgResponseTime = Math.round(parseFloat(String(m.avg_response_time)) || 0);
+      dashboard.metrics.p95ResponseTime = Math.round(parseFloat(String(m.p95_response_time)) || 0);
 
       const errorRate = dashboard.metrics.requestsLast24h > 0
         ? (dashboard.metrics.errorsLast24h / dashboard.metrics.requestsLast24h * 100).toFixed(2)
@@ -156,8 +162,8 @@ export async function statusDashboardHandler(
       dashboard.metrics.errorRate = `${errorRate}%`;
     }
 
-    if (activeUsersQuery && activeUsersQuery[0]) {
-      dashboard.metrics.activeUsers = parseInt((activeUsersQuery[0] as any).active_users) || 0;
+    if (activeUsersQuery.rows[0]) {
+      dashboard.metrics.activeUsers = parseInt(String(activeUsersQuery.rows[0].active_users)) || 0;
     }
 
   } catch (error) {

--- a/src/services/file-validation.service.ts
+++ b/src/services/file-validation.service.ts
@@ -1,3 +1,5 @@
+import { safeQuery } from '../db/safe-query';
+
 export interface FileValidationResult {
   isValid: boolean;
   errors: string[];
@@ -384,25 +386,33 @@ export class FileValidationService {
 
     let currentUsage = 0;
     let tier = 'free';
+    let quotaLookupFailed = false;
 
     if (db) {
-      try {
-        const [usageResult, userResult] = await Promise.all([
-          // TODO(catch-swallow): migrate to safeQuery — fail-open quota bypass; '0' on error lets user upload past quota
-          db.query(
+      const [usageResult, userResult] = await Promise.all([
+        safeQuery<{ total_bytes: string }>(
+          () => db.query(
             `SELECT COALESCE(SUM(file_size), 0)::bigint AS total_bytes FROM file_storage WHERE user_id = $1`,
             [userId]
-          ).catch(() => [{ total_bytes: '0' }]),
-          // TODO(catch-swallow): migrate to safeQuery
-          db.query(
+          ),
+          { fallback: [{ total_bytes: '0' }], context: 'file-validation.quota.usage' }
+        ),
+        safeQuery<{ subscription_tier: string | null }>(
+          () => db.query(
             `SELECT subscription_tier FROM users WHERE id = $1`,
             [userId]
-          ).catch(() => []),
-        ]);
-        currentUsage = Number(usageResult[0]?.total_bytes) || 0;
-        tier = userResult[0]?.subscription_tier || 'free';
-      } catch {
-        // DB unavailable — allow upload with default quota
+          ),
+          { fallback: [], context: 'file-validation.quota.tier' }
+        ),
+      ]);
+
+      // Fail closed on quota lookup failure — previously this was fail-open (currentUsage=0,
+      // tier=free), which let users upload past quota during a DB outage.
+      if (!usageResult.ok || !userResult.ok) {
+        quotaLookupFailed = true;
+      } else {
+        currentUsage = Number(usageResult.rows[0]?.total_bytes) || 0;
+        tier = userResult.rows[0]?.subscription_tier || 'free';
       }
     }
 
@@ -410,7 +420,7 @@ export class FileValidationService {
     const remainingQuota = maxQuota - currentUsage;
 
     return {
-      allowed: currentUsage + fileSize <= maxQuota,
+      allowed: !quotaLookupFailed && currentUsage + fileSize <= maxQuota,
       currentUsage,
       maxQuota,
       remainingQuota,


### PR DESCRIPTION
## Summary

Continues Phase 2 from #92's canary. Migrates the rest of the production handler family — 42 sites across 4 files — to `safeQuery`.

## Critical: AI handler fail-open → fail-closed

Two sites were the canonical fail-open quota/credit bypass class — SQL exception silently returned a zero-ish default that *passed* the gate. Each is now fail-closed AND operator-visible:

| Site | Before | After |
|---|---|---|
| `ai-production-autofill` credit gate | SQL error → `balance=0` → 402 "insufficient credits", operator-blind | SQL error → 503 "credit check temporarily unavailable" + Sentry report |
| `ai-pitch-extract` credit gate | Same pattern | Same fix |

These are **live-path fixes** — both endpoints route through `worker-integrated.ts`.

### Note on `file-validation.service.ts:checkUserQuota`

The migration also fixes a third site that was originally framed as a critical fail-open quota bypass. Code review (PR #95 review) surfaced that **`checkUserQuota` is currently dead code in the live path** — it is only called from `routes/upload.routes.ts`, an orphan Hono router not imported anywhere in `src/worker-integrated.ts`. The fix is correct (sets `quotaLookupFailed=true` → `allowed: false` on SQL error instead of returning `currentUsage=0` → upload allowed), but it is **hardening for a code path that doesn't currently execute** — not a live-path patch. If `routes/upload.routes.ts` is ever revived per the orphan-router review process, the bypass is already closed. No live-path file uploads were leaking past quota.

This downgrades the PR's headline from "3 critical live-path fixes" to "2 live-path AI gates + 1 orphan-router hardening." The 2 AI handler fixes are still high-value.

## Scope

| File | Sites |
|---|---|
| `creator-dashboard-extended.ts` | 16 |
| `creator-dashboard.ts` | 7 |
| `ai-production-autofill.ts` | 1 (live-path credit gate) |
| `ai-pitch-extract.ts` | 1 (live-path credit gate) |
| `file-validation.service.ts` | 2 (orphan-router hardening, see note above) |
| `status-dashboard.ts` | 2 |
| `investor-pitch-data.ts` | 2 |
| `collaborator.ts` | 2 |
| **Total** | **33** |

## What changes per site

```ts
// Before
const rows = await sql`SELECT ...`.catch(() => []);
if (rows.length === 0) return errorResponse('Not found', origin, 404);

// After
const result = await safeQuery(() => sql`SELECT ...`, {
  fallback: [],
  context: 'creator-dashboard.<entity>.<op>',
});
if (!result.ok) return errorResponse('Failed to fetch ...', origin, 500);
if (result.rows.length === 0) return errorResponse('Not found', origin, 404);
const rows = result.rows;
```

## Pattern conventions (consistent with #92 + #93)

| Pattern | Treatment |
|---|---|
| Schema probes (`information_schema.tables EXISTS`) | `report: false` |
| Dashboard reads | Default `report: true` + return default-shape on `errored` |
| Best-effort writes (notification INSERT, counter increment) | `safeQuery` wrap; Sentry sees failures under context tag |
| Sentry context tags | `<file>.<entity>.<op>` |

## Type discipline

- Row-consuming sites carry explicit row-shape generics.
- Aggregate queries use named local row types (`SummaryRow`, `OverviewRow`, `ViewStatsRow`) to keep fallback + generic in lockstep.

## Verification

```
$ node scripts/catch-swallow-gate.mjs --threshold 0
Scope: src/ (excl. worker-integrated.ts)
Total `.catch(() => …)` sites:  12
  A. fire-and-forget:             8
  B. bucket-B breadcrumb pending: 4
  C. TODO(catch-swallow):         0      ← ZERO
  Untagged (gate metric):         0
```

- **Gate**: 22 → 12 sites; bucket C **10 → 0**
- **tsc --noEmit**: 0 errors in any of the 8 migrated files

## Test plan

- [x] `node scripts/catch-swallow-gate.mjs --threshold 0` passes
- [x] tsc clean for the 8 migrated files
- [ ] Live verification post-merge:
  - AI auto-fill credit gate: confirm 503 (not 402) when DB unavailable
  - AI pitch extract credit gate: same
- [ ] Sentry: confirm `safe_query.context` tags on errored fingerprints, especially `ai-*.credit-check`
- [ ] **Frontend follow-up** (separate, soft): verify `CreatePitch.tsx:469` and AI autofill caller distinguish 503 from 402 in UI. Currently the new 503 message is strictly better than the silent 402 bypass even without frontend updates, but for full UX a `Retry-After` header + dedicated UI branch would be ideal.

## Stack

```
main
  ← #90 mid-template fix
    ← #92 Phase 2.1 canary (production-dashboard-extended, 22 sites)
      ← #93 Phase 2.2 production family (42 sites)
        ← this PR: Phase 2.3 creator + grab-bag (33 sites)
```

When #92 + #93 land, retarget to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)