### PR TITLE
Phase 2.4: worker-integrated.ts → safeQuery (36 sites — closes bucket-C in worker)

### DIFF
--- a/docs/catch-swallow-prep-2026-05-05.md
+++ b/docs/catch-swallow-prep-2026-05-05.md
@@ -26,7 +26,7 @@ Phase 1a finalized counts:
 
 **Worker-integrated baseline** (Phase 1b scope): 59 untagged sites, 0 tagged. Including this scope, gate metric is 59/168. Phase 1b's job is to apply the same A/B/C framework with the higher per-site judgment density the prep doc spot-check anticipated (~50% C, ~25% B, ~25% A) — the file is too mixed for the bulk tagger; expect mostly hand-classification.
 
-**Residual risk this PR does not fix.** The 4 bucket-B sites (`ai-pitch-extract.ts:191/197`, `ai-production-autofill.ts:211/217`) are credit-deduction and transaction-log writes that can still fail silently between now and Phase 2 landing. They're tagged but not yet wrapped with breadcrumbs. The breadcrumb wrap is the smallest follow-up that actually changes runtime behavior — schedule it before Phase 2 begins, not after.
+**~~Residual risk this PR does not fix.~~ Closed 2026-05-06 by B-site wrap PR.** The 4 bucket-B sites (`ai-pitch-extract.ts:191/197`, `ai-production-autofill.ts:211/217`) were credit-deduction and transaction-log writes that could still fail silently. The B-site wrap landed `observedSwallow` (a `safeQuery`-style helper for best-effort writes) and converted all four sites; revenue/audit-trail leakage is now visible in Sentry under the `catch_swallow.context` tag. Bucket B count is now 0; total `.catch(() => …)` sites in scope dropped from 109 to 105.
 
 **Gate-feeding sites identified during Phase 1a** — 3 sites on paths the original audit was written to address:
 - `services/file-validation.service.ts:394` — fail-open quota bypass; '0' on error lets user upload past quota

--- a/docs/catch-swallow-prep-2026-05-05.md
+++ b/docs/catch-swallow-prep-2026-05-05.md
@@ -24,7 +24,14 @@ Phase 1a finalized counts:
 - **B — breadcrumb pending**: 4 sites (credit deduction + transaction log writes; Phase 2 prerequisite)
 - **C — TODO(catch-swallow): migrate**: 97 sites (read-side dashboard fallbacks + 3 gate-feeding sites flagged in TODO text)
 
-**Worker-integrated baseline** (Phase 1b scope): 59 untagged sites, 0 tagged. Including this scope, gate metric is 59/168. Phase 1b's job is to apply the same A/B/C framework with the higher per-site judgment density the prep doc spot-check anticipated (~50% C, ~25% B, ~25% A) — the file is too mixed for the bulk tagger; expect mostly hand-classification.
+**Worker-integrated baseline** (Phase 1b scope): ~~59 untagged sites, 0 tagged~~ — closed 2026-05-06 by Phase 1b PR. Tree-wide gate metric across `src/` is now **0/168**.
+
+Phase 1b finalized counts (worker-integrated.ts only):
+- **A — fire-and-forget**: 15 sites (post-login password rehash, Stripe cleanup, Axiom logging, search-click tracking, session DELETEs, share-event INSERTs)
+- **B — breadcrumb pending**: 8 sites (Stripe `getSubscription` reads, INSERT-RETURNING patterns where caller checks null, auth-optional fallback)
+- **C — TODO(catch-swallow): migrate**: 36 sites (analytics dashboard reads, browse aggregates, info_requests reads, NDA document lookups)
+
+Distribution: 25% A / 14% B / 61% C — close to the spot-check prediction of 25/25/50. Each site received per-site human classification (no bulk-by-file shortcut available — file is too mixed). Tagger config preserved as the audit artifact: see PR diff for the line→bucket mapping.
 
 **Residual risk this PR does not fix.** The 4 bucket-B sites (`ai-pitch-extract.ts:191/197`, `ai-production-autofill.ts:211/217`) are credit-deduction and transaction-log writes that can still fail silently between now and Phase 2 landing. They're tagged but not yet wrapped with breadcrumbs. The breadcrumb wrap is the smallest follow-up that actually changes runtime behavior — schedule it before Phase 2 begins, not after.
 

--- a/docs/catch-swallow-prep-2026-05-05.md
+++ b/docs/catch-swallow-prep-2026-05-05.md
@@ -24,16 +24,18 @@ Phase 1a finalized counts:
 - **B — breadcrumb pending**: 4 sites (credit deduction + transaction log writes; Phase 2 prerequisite)
 - **C — TODO(catch-swallow): migrate**: 97 sites (read-side dashboard fallbacks + 3 gate-feeding sites flagged in TODO text)
 
-**Worker-integrated baseline** (Phase 1b scope): ~~59 untagged sites, 0 tagged~~ — closed 2026-05-06 by Phase 1b PR. Tree-wide gate metric across `src/` is now **0/168**.
+**Worker-integrated baseline** (Phase 1b scope): ~~59 untagged sites, 0 tagged~~ — closed 2026-05-06 by Phase 1b PR. Tree-wide gate metric across `src/` is now **0 untagged / 156 total** (164 after Phase 1b tag sweep, then -8 by Phase 1b B-site wrap below).
 
 Phase 1b finalized counts (worker-integrated.ts only):
 - **A — fire-and-forget**: 15 sites (post-login password rehash, Stripe cleanup, Axiom logging, search-click tracking, session DELETEs, share-event INSERTs)
-- **B — breadcrumb pending**: 8 sites (Stripe `getSubscription` reads, INSERT-RETURNING patterns where caller checks null, auth-optional fallback)
+- **B — breadcrumb pending**: ~~8 sites~~ → 0 sites (closed 2026-05-06 by Phase 1b B-site wrap; see below). Were: Stripe `getSubscription` reads (×2), INSERT/UPDATE-RETURNING with caller null-check (×5), auth-optional fallback (×1).
 - **C — TODO(catch-swallow): migrate**: 36 sites (analytics dashboard reads, browse aggregates, info_requests reads, NDA document lookups)
 
 Distribution: 25% A / 14% B / 61% C — close to the spot-check prediction of 25/25/50. Each site received per-site human classification (no bulk-by-file shortcut available — file is too mixed). Tagger config preserved as the audit artifact: see PR diff for the line→bucket mapping.
 
 **~~Residual risk this PR does not fix.~~ Closed 2026-05-06 by B-site wrap PR.** The 4 bucket-B sites (`ai-pitch-extract.ts:191/197`, `ai-production-autofill.ts:211/217`) were credit-deduction and transaction-log writes that could still fail silently. The B-site wrap landed `observedSwallow` (a `safeQuery`-style helper for best-effort writes) and converted all four sites; revenue/audit-trail leakage is now visible in Sentry under the `catch_swallow.context` tag. Bucket B count is now 0; total `.catch(() => …)` sites in scope dropped from 109 to 105.
+
+**Phase 1b B-site wrap (2026-05-06)** — sibling helper `observedSwallowReturning<T, F>` added to `src/db/safe-query.ts` for best-effort operations where the caller reads the result but accepts a fallback (typically `null`). Converted all 8 bucket-B sites in `worker-integrated.ts`: 2× `stripe.getSubscription` (Stripe webhook → invoice paid / checkout session), 3× INSERT-RETURNING with null-check (scheduled_reports, calendar_events, info_requests), 2× UPDATE-RETURNING with null-check (info_requests respond/update), 1× auth-optional fallback (demo request). Failures now produce a Sentry event tagged with the call site (e.g. `stripe-webhook.invoice-paid.get-subscription`, `info-request.update`, `demo-request.auth-optional`). Bucket B in `worker-integrated.ts` is 0; total `.catch(() => …)` sites in `src/` dropped from 164 to 156.
 
 **Gate-feeding sites identified during Phase 1a** — 3 sites on paths the original audit was written to address:
 - `services/file-validation.service.ts:394` — fail-open quota bypass; '0' on error lets user upload past quota

--- a/scripts/catch-swallow-tag-per-site.mjs
+++ b/scripts/catch-swallow-tag-per-site.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// Per-site tagger — applies bucket tags from a JSON config keyed by line number.
+// Used for files (e.g. worker-integrated.ts) where bulk-by-file tagging is wrong
+// because sites span multiple buckets. Idempotent: skips already-tagged sites.
+//
+// Config shape:
+//   {
+//     "src/worker-integrated.ts": [
+//       { "line": 1402, "bucket": "A" },
+//       { "line": 9973, "bucket": "B", "reason": "stripe getSubscription, null fallback" },
+//       { "line": 8751, "bucket": "C" }
+//     ]
+//   }
+//
+// Usage:
+//   node scripts/catch-swallow-tag-per-site.mjs <config.json>
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const configPath = process.argv[2];
+if (!configPath) {
+  console.error('Usage: catch-swallow-tag-per-site.mjs <config.json>');
+  process.exit(2);
+}
+
+const config = JSON.parse(readFileSync(configPath, 'utf8'));
+
+const STMT_START = /^(await\s|return\s|const\s|let\s|var\s|this\.|\w+\s*=|sql`|\(sql`|\w+\.\w+\()/;
+const TAG_FAF = /\/\/\s*fire-and-forget\b/;
+const TAG_TODO = /\/\/\s*TODO\(catch-swallow\)/;
+
+function findStmtStart(lines, idx) {
+  for (let j = idx; j >= 0 && j >= idx - 60; j--) {
+    if (STMT_START.test(lines[j].trim())) return j;
+  }
+  return idx;
+}
+
+function alreadyTagged(lines, stmtStart) {
+  for (let j = stmtStart - 1; j >= 0 && j >= stmtStart - 5; j--) {
+    const t = lines[j].trim();
+    if (t === '') continue;
+    return TAG_FAF.test(t) || TAG_TODO.test(t);
+  }
+  return false;
+}
+
+function tagText(bucket, reason) {
+  const suffix = reason ? ` — ${reason}` : '';
+  if (bucket === 'A') return `// fire-and-forget${suffix}`;
+  if (bucket === 'B') return `// TODO(catch-swallow): bucket-B breadcrumb pending${suffix}`;
+  if (bucket === 'C') return `// TODO(catch-swallow): migrate to safeQuery${suffix}`;
+  throw new Error(`Unknown bucket: ${bucket}`);
+}
+
+let totalTagged = 0;
+for (const [file, sites] of Object.entries(config)) {
+  const path = resolve(file);
+  const text = readFileSync(path, 'utf8');
+  const lines = text.split('\n');
+  // Sort bottom-up so earlier insertions don't shift later line numbers
+  const sortedSites = [...sites].sort((a, b) => b.line - a.line);
+  const insertions = [];
+  for (const { line, bucket, reason } of sortedSites) {
+    const idx = line - 1;
+    const stmtStart = findStmtStart(lines, idx);
+    if (alreadyTagged(lines, stmtStart)) {
+      console.log(`  ${file}:${line} already tagged, skipping`);
+      continue;
+    }
+    const indent = lines[stmtStart].match(/^\s*/)[0];
+    insertions.push({ at: stmtStart, line: `${indent}${tagText(bucket, reason)}` });
+  }
+  for (const { at, line } of insertions) {
+    lines.splice(at, 0, line);
+  }
+  writeFileSync(path, lines.join('\n'));
+  console.log(`${file}: +${insertions.length}`);
+  totalTagged += insertions.length;
+}
+console.log(`---\nTotal sites tagged: ${totalTagged}`);

--- a/src/db/safe-query.ts
+++ b/src/db/safe-query.ts
@@ -87,3 +87,43 @@ export async function safeQueryOne<T>(
     error: result.ok ? undefined : result.error,
   };
 }
+
+/**
+ * observedSwallow — for best-effort writes where the caller does not act on
+ * the result, but a silent failure represents real cost (revenue leakage,
+ * audit-trail loss, etc.). Catches the error, reports to Sentry with a
+ * context tag so volume is visible, then returns void.
+ *
+ * Use for: post-success cleanup writes (credit deduction after successful AI
+ * call, transaction-log inserts, idempotent state syncs). The original
+ * `.catch(() => {})` pattern was correct in shape — caller cannot recover —
+ * but invisible. This restores observability without changing call-site
+ * semantics.
+ *
+ * Do NOT use for: reads (use `safeQuery`), writes the caller acts on (let
+ * them throw), or true fire-and-forget telemetry where failure isn't a cost
+ * (use plain `.catch(() => {})` with `// fire-and-forget` tag).
+ *
+ *   await observedSwallow(
+ *     () => sql`UPDATE user_credits SET balance = balance - ${cost} ...`,
+ *     'ai-pitch-extract.credit-deduction',
+ *   );
+ */
+export async function observedSwallow(
+  fn: () => Promise<unknown>,
+  context: string,
+): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    try {
+      Sentry.withScope((scope) => {
+        scope.setTag('catch_swallow.context', context);
+        Sentry.captureException(error);
+      });
+    } catch {
+      // Sentry hub not initialized (test env, standalone scripts) — swallow.
+    }
+  }
+}

--- a/src/db/safe-query.ts
+++ b/src/db/safe-query.ts
@@ -127,3 +127,41 @@ export async function observedSwallow(
     }
   }
 }
+
+/**
+ * observedSwallowReturning — sibling of `observedSwallow` for best-effort
+ * operations where the caller *does* read the result but accepts a fallback
+ * on failure (typically `null` from an INSERT/UPDATE-RETURNING or an external
+ * API read). Catches, reports to Sentry with a context tag, and returns the
+ * fallback. Restores observability without changing the caller's null-check.
+ *
+ * Two generics so the fallback's shape doesn't need to match `T` exactly —
+ * the common case is `T = SomeRow[]`, fallback `null`, return `T | null`.
+ *
+ *   const result = await observedSwallowReturning(
+ *     () => this.db.query(`INSERT INTO ... RETURNING *`, [...]),
+ *     'handle-info-request.insert',
+ *     null,
+ *   );
+ *   if (result && result[0]) { ... }
+ */
+export async function observedSwallowReturning<T, F>(
+  fn: () => Promise<T>,
+  context: string,
+  fallback: F,
+): Promise<T | F> {
+  try {
+    return await fn();
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    try {
+      Sentry.withScope((scope) => {
+        scope.setTag('catch_swallow.context', context);
+        Sentry.captureException(error);
+      });
+    } catch {
+      // Sentry hub not initialized (test env, standalone scripts) — swallow.
+    }
+    return fallback;
+  }
+}

--- a/src/handlers/ai-pitch-extract.ts
+++ b/src/handlers/ai-pitch-extract.ts
@@ -8,6 +8,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId } from '../utils/auth-extract';
+import { observedSwallow } from '../db/safe-query';
 
 const AI_EXTRACT_CREDIT_COST = 5;
 
@@ -185,19 +186,23 @@ export async function aiPitchExtract(request: Request, env: Env): Promise<Respon
       return errorResponse('AI could not extract structured data from this document. Try a different file.', origin, 422);
     }
 
-    // Deduct credits
-    // TODO(catch-swallow): bucket-B breadcrumb pending — revenue leakage if silent
-    await sql`
-      UPDATE user_credits SET balance = balance - ${AI_EXTRACT_CREDIT_COST}, total_used = total_used + ${AI_EXTRACT_CREDIT_COST}, last_updated = NOW()
-      WHERE user_id = ${Number(userId)}
-    `.catch(() => {});
+    // Deduct credits + log transaction. Best-effort writes — AI response already
+    // returned to user; failures surface in Sentry as revenue/audit leakage.
+    await observedSwallow(
+      () => sql`
+        UPDATE user_credits SET balance = balance - ${AI_EXTRACT_CREDIT_COST}, total_used = total_used + ${AI_EXTRACT_CREDIT_COST}, last_updated = NOW()
+        WHERE user_id = ${Number(userId)}
+      `,
+      'ai-pitch-extract.credit-deduction',
+    );
 
-    // Log credit transaction
-    // TODO(catch-swallow): bucket-B breadcrumb pending — audit trail loss if silent
-    await sql`
-      INSERT INTO credit_transactions (user_id, type, amount, description, balance_before, balance_after, usage_type, created_at)
-      VALUES (${Number(userId)}, 'usage', ${-AI_EXTRACT_CREDIT_COST}, 'AI pitch extraction', ${balance}, ${balance - AI_EXTRACT_CREDIT_COST}, 'ai_extract', NOW())
-    `.catch(() => {});
+    await observedSwallow(
+      () => sql`
+        INSERT INTO credit_transactions (user_id, type, amount, description, balance_before, balance_after, usage_type, created_at)
+        VALUES (${Number(userId)}, 'usage', ${-AI_EXTRACT_CREDIT_COST}, 'AI pitch extraction', ${balance}, ${balance - AI_EXTRACT_CREDIT_COST}, 'ai_extract', NOW())
+      `,
+      'ai-pitch-extract.transaction-log',
+    );
 
     return jsonResponse({
       success: true,

--- a/src/handlers/ai-production-autofill.ts
+++ b/src/handlers/ai-production-autofill.ts
@@ -10,6 +10,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId } from '../utils/auth-extract';
+import { observedSwallow } from '../db/safe-query';
 
 const AUTOFILL_CREDIT_COST = 5;
 
@@ -205,19 +206,23 @@ export async function aiProductionAutofill(request: Request, env: Env): Promise<
       return errorResponse('AI returned incomplete data. Please try again.', origin, 422);
     }
 
-    // Deduct credits
-    // TODO(catch-swallow): bucket-B breadcrumb pending — revenue leakage if silent
-    await sql`
-      UPDATE user_credits SET balance = balance - ${AUTOFILL_CREDIT_COST}, total_used = total_used + ${AUTOFILL_CREDIT_COST}, last_updated = NOW()
-      WHERE user_id = ${Number(userId)}
-    `.catch(() => {});
+    // Deduct credits + log transaction. Best-effort writes — AI response already
+    // returned to user; failures surface in Sentry as revenue/audit leakage.
+    await observedSwallow(
+      () => sql`
+        UPDATE user_credits SET balance = balance - ${AUTOFILL_CREDIT_COST}, total_used = total_used + ${AUTOFILL_CREDIT_COST}, last_updated = NOW()
+        WHERE user_id = ${Number(userId)}
+      `,
+      'ai-production-autofill.credit-deduction',
+    );
 
-    // Log credit transaction
-    // TODO(catch-swallow): bucket-B breadcrumb pending — audit trail loss if silent
-    await sql`
-      INSERT INTO credit_transactions (user_id, type, amount, description, balance_before, balance_after, usage_type, created_at)
-      VALUES (${Number(userId)}, 'usage', ${-AUTOFILL_CREDIT_COST}, 'AI production auto-fill', ${balance}, ${balance - AUTOFILL_CREDIT_COST}, 'ai_autofill', NOW())
-    `.catch(() => {});
+    await observedSwallow(
+      () => sql`
+        INSERT INTO credit_transactions (user_id, type, amount, description, balance_before, balance_after, usage_type, created_at)
+        VALUES (${Number(userId)}, 'usage', ${-AUTOFILL_CREDIT_COST}, 'AI production auto-fill', ${balance}, ${balance - AUTOFILL_CREDIT_COST}, 'ai_autofill', NOW())
+      `,
+      'ai-production-autofill.transaction-log',
+    );
 
     return jsonResponse({
       success: true,

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -1399,6 +1399,7 @@ class RouteRegistry {
           // Upgrade plaintext to hash on successful login
           if (passwordValid) {
             const hashed = await hashPassword(password);
+            // fire-and-forget — post-login plaintext-to-hash upgrade; non-fatal
             await this.db.query(`UPDATE users SET password = $1 WHERE id = $2`, [hashed, result.id]).catch(() => {});
           }
         }
@@ -4108,6 +4109,7 @@ class RouteRegistry {
             // Upgrade plaintext to hash on successful login
             if (passwordValid) {
               const hashed = await hashPassword(password);
+              // fire-and-forget — post-login plaintext-to-hash upgrade; non-fatal
               await this.db.query(`UPDATE users SET password = $1 WHERE id = $2`, [hashed, user.id]).catch(() => {});
             }
           }
@@ -4289,6 +4291,7 @@ class RouteRegistry {
             // Upgrade plaintext to hash on successful login
             if (passwordValid) {
               const hashed = await hashPassword(password);
+              // fire-and-forget — post-login plaintext-to-hash upgrade; non-fatal
               await this.db!.query(`UPDATE users SET password = $1 WHERE id = $2`, [hashed, user.id]).catch(() => {});
             }
           }
@@ -8734,6 +8737,7 @@ pitchey_analytics_datapoints_per_minute 1250
       `, [userId]);
 
       // 1b. Time-filtered views/likes from event tables + fallback from cumulative counters
+      // TODO(catch-swallow): migrate to safeQuery
       const periodMetricsResult = await this.db.query(`
         SELECT
           (SELECT COUNT(*) FROM pitch_views pv JOIN pitches p ON pv.pitch_id = p.id
@@ -8821,6 +8825,7 @@ pitchey_analytics_datapoints_per_minute 1250
       `, []);
 
       // 8. Views timeline from event table (for charts)
+      // TODO(catch-swallow): migrate to safeQuery
       const viewsTimelineResult = await this.db.query(`
         SELECT DATE(pv.viewed_at) as date, COUNT(*) as views
         FROM pitch_views pv
@@ -8832,6 +8837,7 @@ pitchey_analytics_datapoints_per_minute 1250
       `, [userId]).catch(() => []);
 
       // 8b. Likes timeline from event table
+      // TODO(catch-swallow): migrate to safeQuery
       const likesTimelineResult = await this.db.query(`
         SELECT DATE(pl.created_at) as date, COUNT(*) as likes
         FROM pitch_likes pl
@@ -8843,6 +8849,7 @@ pitchey_analytics_datapoints_per_minute 1250
       `, [userId]).catch(() => []);
 
       // 8c. Pitches created in period (for pitch count chart + fallback)
+      // TODO(catch-swallow): migrate to safeQuery
       const pitchTimelineResult = await this.db.query(`
         SELECT
           p.id, p.title, p.genre,
@@ -8856,6 +8863,7 @@ pitchey_analytics_datapoints_per_minute 1250
       `, [userId]).catch(() => []);
 
       // 9. Investments received over time
+      // TODO(catch-swallow): migrate to safeQuery
       const investmentTimeSeriesResult = await this.db.query(`
         SELECT
           DATE(i.created_at) as date,
@@ -8870,6 +8878,7 @@ pitchey_analytics_datapoints_per_minute 1250
       `, [userId]).catch(() => []);
 
       // 10. NDA requests over time (as engagement proxy)
+      // TODO(catch-swallow): migrate to safeQuery
       const ndaTimelineResult = await this.db.query(`
         SELECT
           DATE(nr.created_at) as date,
@@ -9694,6 +9703,7 @@ pitchey_analytics_datapoints_per_minute 1250
             WHERE id = ${paymentMethodId} AND user_id = ${authResult.user.id}
           `;
           if (rows.length > 0 && rows[0].stripe_payment_method_id) {
+            // fire-and-forget — Stripe payment-method detach cleanup
             await stripe.detachPaymentMethod(rows[0].stripe_payment_method_id).catch(() => {});
           }
         }
@@ -9970,6 +9980,7 @@ pitchey_analytics_datapoints_per_minute 1250
             const subId = session.subscription;
             let sub = null;
             if (subId) {
+              // TODO(catch-swallow): bucket-B breadcrumb pending — stripe.getSubscription, caller checks null
               sub = await stripe.getSubscription(subId).catch(() => null);
             }
 
@@ -10098,6 +10109,7 @@ pitchey_analytics_datapoints_per_minute 1250
             userId = historyRows[0].user_id;
             tierId = historyRows[0].new_tier;
           } else {
+            // TODO(catch-swallow): bucket-B breadcrumb pending — stripe.getSubscription, caller checks null
             const sub = await stripe.getSubscription(subId).catch(() => null);
             const metaUserId = parseInt(sub?.metadata?.userId || '');
             const metaTier = sub?.metadata?.tier;
@@ -12025,6 +12037,7 @@ pitchey_analytics_datapoints_per_minute 1250
     const builder = new ApiResponseBuilder(request);
     try {
       const [trends, genreList, summary] = await Promise.all([
+        // TODO(catch-swallow): migrate to safeQuery
         this.db.query(`
           SELECT p.genre, COUNT(i.*) as total_projects,
                  COALESCE(AVG(i.amount), 0) as avg_budget,
@@ -12037,7 +12050,9 @@ pitchey_analytics_datapoints_per_minute 1250
           WHERE p.genre IS NOT NULL
           GROUP BY p.genre ORDER BY total_projects DESC LIMIT 10
         `).catch(() => []),
+        // TODO(catch-swallow): migrate to safeQuery
         this.db.query(`SELECT DISTINCT genre FROM pitches WHERE genre IS NOT NULL ORDER BY genre`).catch(() => []),
+        // TODO(catch-swallow): migrate to safeQuery
         this.db.query(`
           SELECT COUNT(*) as total_opportunities,
                  (SELECT genre FROM pitches GROUP BY genre ORDER BY COUNT(*) DESC LIMIT 1) as top_genre
@@ -12068,6 +12083,7 @@ pitchey_analytics_datapoints_per_minute 1250
   private async getGenrePerformance(request: Request): Promise<Response> {
     const builder = new ApiResponseBuilder(request);
     try {
+      // TODO(catch-swallow): migrate to safeQuery
       const genres = await this.db.query(`
         SELECT p.genre,
                COALESCE(AVG(i.roi_percentage), 0) as avg_roi,
@@ -12097,6 +12113,7 @@ pitchey_analytics_datapoints_per_minute 1250
     const builder = new ApiResponseBuilder(request);
     try {
       // Monthly pitch creation + investment trends over the last 12 months
+      // TODO(catch-swallow): migrate to safeQuery
       const trends = await this.db.query(`
         SELECT
           TO_CHAR(date_trunc('month', p.created_at), 'YYYY-MM') as month,
@@ -12703,6 +12720,7 @@ pitchey_analytics_datapoints_per_minute 1250
       // Fetch multiple data sources in parallel
       const [notifications, unreadCount, dashboardStats, presenceUsers, recentMessages] = await Promise.all([
         // Get recent notifications
+        // TODO(catch-swallow): migrate to safeQuery
         this.db.query(`
           SELECT id, type, title, message, created_at, is_read
           FROM notifications
@@ -12712,6 +12730,7 @@ pitchey_analytics_datapoints_per_minute 1250
         `, [authResult.user.id]).catch(() => []),
 
         // Get unread notification count
+        // TODO(catch-swallow): migrate to safeQuery
         this.db.query(`
           SELECT COUNT(*) as count
           FROM notifications
@@ -12722,6 +12741,7 @@ pitchey_analytics_datapoints_per_minute 1250
         this.getDashboardStatsForUser(authResult.user),
 
         // Get online users
+        // TODO(catch-swallow): migrate to safeQuery
         this.db.query(`
           SELECT
             up.user_id as "userId",
@@ -12737,6 +12757,7 @@ pitchey_analytics_datapoints_per_minute 1250
         `).catch(() => []),
 
         // Get recent unread messages
+        // TODO(catch-swallow): migrate to safeQuery
         this.db.query(`
           SELECT m.id, m.sender_id, m.content, m.created_at,
                  COALESCE(u.name, u.username, u.email) as sender_name
@@ -12844,26 +12865,31 @@ pitchey_analytics_datapoints_per_minute 1250
     try {
       // Fetch real analytics data in parallel (each query resilient to missing tables)
       const [activeUsers, viewsLastHour, newPitchesToday, investmentsToday, trendingGenres] = await Promise.all([
+        // TODO(catch-swallow): migrate to safeQuery
         this.db.query(`
           SELECT COUNT(*) as count FROM user_presence
           WHERE updated_at > NOW() - INTERVAL '5 minutes' AND status != 'offline'
         `).then(([r]) => this.safeParseInt(r?.count)).catch(() => 0),
 
+        // TODO(catch-swallow): migrate to safeQuery
         this.db.query(`
           SELECT COALESCE(SUM(views), 0) as total FROM pitch_analytics
           WHERE date = CURRENT_DATE
         `).then(([r]) => this.safeParseInt(r?.total)).catch(() => 0),
 
+        // TODO(catch-swallow): migrate to safeQuery
         this.db.query(`
           SELECT COUNT(*) as count FROM pitches
           WHERE created_at >= CURRENT_DATE
         `).then(([r]) => this.safeParseInt(r?.count)).catch(() => 0),
 
+        // TODO(catch-swallow): migrate to safeQuery
         this.db.query(`
           SELECT COUNT(*) as count FROM investments
           WHERE created_at >= CURRENT_DATE
         `).then(([r]) => this.safeParseInt(r?.count)).catch(() => 0),
 
+        // TODO(catch-swallow): migrate to safeQuery
         this.db.query(`
           SELECT genre, COUNT(*) as count FROM pitches
           WHERE status = 'published' AND genre IS NOT NULL
@@ -12944,6 +12970,7 @@ pitchey_analytics_datapoints_per_minute 1250
       const { contentType, contentId, platform } = body;
 
       // Log the share event
+      // fire-and-forget — share-event analytics insert; tracker noted as fire-and-forget in caller
       await this.db.query(`
         INSERT INTO analytics_events (user_id, event_type, event_data, created_at)
         VALUES ($1, 'share', $2, NOW())
@@ -12963,6 +12990,7 @@ pitchey_analytics_datapoints_per_minute 1250
     try {
       const body = await request.json() as Record<string, unknown>;
 
+      // TODO(catch-swallow): bucket-B breadcrumb pending — INSERT scheduled_reports returning null; caller checks null
       const result = await this.db.query(`
         INSERT INTO scheduled_reports (user_id, report_type, frequency, filters, next_run, created_at)
         VALUES ($1, $2, $3, $4, NOW() + INTERVAL '1 day', NOW())
@@ -12985,6 +13013,7 @@ pitchey_analytics_datapoints_per_minute 1250
 
     const builder = new ApiResponseBuilder(request);
     try {
+      // TODO(catch-swallow): migrate to safeQuery
       const reports = await this.db.query(`
         SELECT id, report_type, frequency, filters, next_run, created_at
         FROM scheduled_reports WHERE user_id = $1 ORDER BY created_at DESC
@@ -13003,6 +13032,7 @@ pitchey_analytics_datapoints_per_minute 1250
     const builder = new ApiResponseBuilder(request);
     const params = (request as any).params;
     try {
+      // fire-and-forget — DELETE scheduled_reports; non-fatal cleanup
       await this.db.query(`DELETE FROM scheduled_reports WHERE id = $1 AND user_id = $2`, [params.id, authResult.user!.id]).catch(() => {});
       return builder.success({ success: true });
     } catch (error) {
@@ -13021,6 +13051,7 @@ pitchey_analytics_datapoints_per_minute 1250
     const limit = parseInt(url.searchParams.get('limit') || '10', 10);
 
     try {
+      // TODO(catch-swallow): migrate to safeQuery
       const history = await this.db.query(`
         SELECT id, query, filters, results_count, created_at
         FROM search_history WHERE user_id = $1
@@ -13042,6 +13073,7 @@ pitchey_analytics_datapoints_per_minute 1250
       const body = await request.json() as Record<string, unknown>;
 
       // Fire-and-forget click tracking
+      // fire-and-forget — search-click tracking insert; caller noted fire-and-forget
       await this.db.query(`
         INSERT INTO search_clicks (user_id, pitch_id, query, result_position, search_history_id, created_at)
         VALUES ($1, $2, $3, $4, $5, NOW())
@@ -13064,6 +13096,7 @@ pitchey_analytics_datapoints_per_minute 1250
   private async handleBrowseGenres(request: Request): Promise<Response> {
     const builder = new ApiResponseBuilder(request);
     try {
+      // TODO(catch-swallow): migrate to safeQuery
       const genres = await this.db.query(`
         SELECT genre, COUNT(*) as pitch_count,
                COALESCE(AVG(
@@ -13117,6 +13150,7 @@ pitchey_analytics_datapoints_per_minute 1250
       }
 
       const [pitches, countResult] = await Promise.all([
+        // TODO(catch-swallow): migrate to safeQuery
         this.db.query(`
           SELECT p.id, p.title, p.genre, p.logline, p.title_image, p.created_at,
                  COALESCE(u.name, u.first_name || ' ' || u.last_name) as creator_name,
@@ -13128,6 +13162,7 @@ pitchey_analytics_datapoints_per_minute 1250
           ORDER BY like_count DESC, view_count DESC
           LIMIT $${paramIdx++} OFFSET $${paramIdx++}
         `, [...queryParams, limit, offset]).catch(() => []),
+        // TODO(catch-swallow): migrate to safeQuery
         this.db.query(`SELECT COUNT(*) as total FROM pitches p ${whereClause}`, queryParams).catch(() => [{ total: 0 }])
       ]);
 
@@ -13152,6 +13187,7 @@ pitchey_analytics_datapoints_per_minute 1250
   private async handleBrowseTopRatedStats(request: Request): Promise<Response> {
     try {
       const [statsResult] = await Promise.all([
+        // TODO(catch-swallow): migrate to safeQuery
         this.db.query(`
           SELECT
             COUNT(*) as total_rated,
@@ -13191,6 +13227,7 @@ pitchey_analytics_datapoints_per_minute 1250
       const body = await request.json() as Record<string, unknown>;
 
       // Create a calendar event for the meeting
+      // TODO(catch-swallow): bucket-B breadcrumb pending — INSERT calendar_events returning null; caller checks null
       const result = await this.db.query(`
         INSERT INTO calendar_events (user_id, title, description, start_date, end_date, event_type, color, created_at)
         VALUES ($1, $2, $3, $4, $5, 'meeting', '#3b82f6', NOW())
@@ -13229,11 +13266,13 @@ pitchey_analytics_datapoints_per_minute 1250
       // Generate CSV export based on type
       let csvContent = '';
       if (exportType === 'pitches') {
+        // TODO(catch-swallow): migrate to safeQuery
         const pitches = await this.db.query(`
           SELECT id, title, genre, status, created_at FROM pitches WHERE user_id = $1 ORDER BY created_at DESC
         `, [authResult.user!.id]).catch(() => []);
         csvContent = 'ID,Title,Genre,Status,Created\n' + pitches.map((p: any) => `${p.id},"${p.title}",${p.genre},${p.status},${p.created_at}`).join('\n');
       } else if (exportType === 'analytics') {
+        // TODO(catch-swallow): migrate to safeQuery
         const analytics = await this.db.query(`
           SELECT pa.date, pa.views, pa.likes FROM pitch_analytics pa JOIN pitches p ON pa.pitch_id = p.id WHERE p.user_id = $1 ORDER BY pa.date DESC LIMIT 90
         `, [authResult.user!.id]).catch(() => []);
@@ -13264,6 +13303,7 @@ pitchey_analytics_datapoints_per_minute 1250
     try {
       // Store verification request
       const verificationId = `ver_${Date.now()}_${authResult.user!.id}`;
+      // fire-and-forget — verification status flip; non-fatal
       await this.db.query(`
         UPDATE users SET verification_status = 'pending', updated_at = NOW() WHERE id = $1
       `, [authResult.user!.id]).catch(() => {});
@@ -13284,6 +13324,7 @@ pitchey_analytics_datapoints_per_minute 1250
 
     const builder = new ApiResponseBuilder(request);
     try {
+      // TODO(catch-swallow): migrate to safeQuery
       const user = await this.db.query(`
         SELECT verification_status, company_name FROM users WHERE id = $1
       `, [authResult.user!.id]).catch(() => []);
@@ -13305,6 +13346,7 @@ pitchey_analytics_datapoints_per_minute 1250
     const builder = new ApiResponseBuilder(request);
     try {
       const body = await request.json() as Record<string, unknown>;
+      // fire-and-forget — company-name update; non-fatal
       await this.db.query(`
         UPDATE users SET company_name = $1, verification_status = 'pending', updated_at = NOW() WHERE id = $2
       `, [body.companyName as string | null, authResult.user!.id]).catch(() => {});
@@ -13322,12 +13364,14 @@ pitchey_analytics_datapoints_per_minute 1250
     const builder = new ApiResponseBuilder(request);
     try {
       const [incoming, outgoing] = await Promise.all([
+        // TODO(catch-swallow): migrate to safeQuery
         this.db.query(`
           SELECT ir.*, COALESCE(u.name, u.first_name || ' ' || u.last_name) as requester_name
           FROM info_requests ir
           LEFT JOIN users u ON ir.requester_id = u.id
           WHERE ir.target_user_id = $1 ORDER BY ir.created_at DESC
         `, [authResult.user!.id]).catch(() => []),
+        // TODO(catch-swallow): migrate to safeQuery
         this.db.query(`
           SELECT ir.*, COALESCE(u.name, u.first_name || ' ' || u.last_name) as target_name
           FROM info_requests ir
@@ -13349,6 +13393,7 @@ pitchey_analytics_datapoints_per_minute 1250
     const builder = new ApiResponseBuilder(request);
     try {
       const body = await request.json() as Record<string, unknown>;
+      // TODO(catch-swallow): bucket-B breadcrumb pending — INSERT info_requests returning null; caller checks null
       const result = await this.db.query(`
         INSERT INTO info_requests (requester_id, target_user_id, pitch_id, message, status, created_at)
         VALUES ($1, $2, $3, $4, 'pending', NOW()) RETURNING *
@@ -13371,6 +13416,7 @@ pitchey_analytics_datapoints_per_minute 1250
     const params = (request as any).params;
     try {
       const body = await request.json() as Record<string, unknown>;
+      // TODO(catch-swallow): bucket-B breadcrumb pending — UPDATE info_requests returning null; caller checks null
       const result = await this.db.query(`
         UPDATE info_requests SET response = $1, status = 'responded', updated_at = NOW()
         WHERE id = $2 AND target_user_id = $3 RETURNING *
@@ -13393,6 +13439,7 @@ pitchey_analytics_datapoints_per_minute 1250
     const params = (request as any).params;
     try {
       const body = await request.json() as Record<string, unknown>;
+      // TODO(catch-swallow): bucket-B breadcrumb pending — UPDATE info_requests returning null; caller checks null
       const result = await this.db.query(`
         UPDATE info_requests SET status = $1, updated_at = NOW()
         WHERE id = $2 AND (requester_id = $3 OR target_user_id = $3) RETURNING *
@@ -13413,8 +13460,10 @@ pitchey_analytics_datapoints_per_minute 1250
       const body = await request.json() as Record<string, unknown>;
 
       // Log demo request (may or may not have auth)
+      // TODO(catch-swallow): bucket-B breadcrumb pending — auth-optional fallback; auth backend errors should be visible
       const authResult = await this.requireAuth(request).catch(() => ({ authorized: false, user: null }));
 
+      // fire-and-forget — demo-request insert; non-fatal
       await this.db.query(`
         INSERT INTO demo_requests (user_id, name, email, company, request_type, message, preferred_time, created_at)
         VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
@@ -13982,6 +14031,7 @@ pitchey_analytics_datapoints_per_minute 1250
       }
 
       // Invalidate old sessions
+      // fire-and-forget — DELETE old sessions; non-fatal cleanup
       await this.db.query(`DELETE FROM sessions WHERE user_id = $1`, [user.id]).catch(() => {});
 
       // Create session
@@ -14232,6 +14282,7 @@ pitchey_analytics_datapoints_per_minute 1250
       }
 
       // Invalidate old sessions
+      // fire-and-forget — DELETE old sessions; non-fatal cleanup
       await this.db.query(`DELETE FROM sessions WHERE user_id = $1`, [user.id]).catch(() => {});
 
       // Create session
@@ -15409,6 +15460,7 @@ pitchey_analytics_datapoints_per_minute 1250
       const ndaId = parseInt(url.pathname.split('/')[3]);
 
       // Try to find the NDA document in R2
+      // TODO(catch-swallow): migrate to safeQuery
       const ndaDoc = await this.db.query(`SELECT document_url FROM ndas WHERE id = $1`, [ndaId]).catch(() => []);
       if (ndaDoc[0]?.document_url) {
         return this.jsonResponse({ success: true, data: { downloadUrl: ndaDoc[0].document_url, message: 'NDA document ready for download' }});
@@ -15431,6 +15483,7 @@ pitchey_analytics_datapoints_per_minute 1250
       const url = new URL(request.url);
       const ndaId = parseInt(url.pathname.split('/')[3]);
 
+      // TODO(catch-swallow): migrate to safeQuery
       const ndaDoc = await this.db.query(`SELECT signed_document_url FROM ndas WHERE id = $1`, [ndaId]).catch(() => []);
       if (ndaDoc[0]?.signed_document_url) {
         return this.jsonResponse({ success: true, data: { downloadUrl: ndaDoc[0].signed_document_url, message: 'Signed NDA document ready for download' }});
@@ -17941,6 +17994,7 @@ Signatures: [To be completed upon signing]
         );
 
         // Top pitches by views
+        // TODO(catch-swallow): migrate to safeQuery
         const topPitchesRes = await this.db.query(
           `SELECT id, title, COALESCE(view_count, 0) as views, COALESCE(like_count, 0) as likes
            FROM pitches WHERE user_id = $1 AND status = 'published'
@@ -17949,6 +18003,7 @@ Signatures: [To be completed upon signing]
         ).catch(() => []);
 
         // NDA counts
+        // TODO(catch-swallow): migrate to safeQuery
         const ndaRes = await this.db.query(
           `SELECT
             COUNT(*) FILTER (WHERE nr.status = 'pending') as nda_requests,
@@ -17963,6 +18018,7 @@ Signatures: [To be completed upon signing]
         const ndas = ndaRes[0] || {};
 
         // Audience breakdown from views table
+        // TODO(catch-swallow): migrate to safeQuery
         const viewerTypesRes = await this.db.query(
           `SELECT COALESCE(u.user_type, 'visitor') AS user_type, COUNT(*)::int AS count
            FROM views v
@@ -19997,6 +20053,7 @@ Signatures: [To be completed upon signing]
     if (!this.db) return builder.error(ErrorCode.INTERNAL_ERROR, 'Database unavailable');
 
     try {
+      // fire-and-forget — request body parse; empty default and parse-error treated identically
       const body = await request.json().catch(() => ({})) as { email?: string };
       const code = this.generateInviteCode();
       const userName = authResult.user?.name || authResult.user?.username || 'A producer';
@@ -20566,6 +20623,7 @@ const websocketSafeHandler = {
       const e = err instanceof Error ? err : new Error(String(err));
       // Log the error to Axiom in the background — never block the throw
       ctx.waitUntil(
+        // fire-and-forget — Axiom error-log fire-and-forget
         axiomLogger.logError(e, request, { duration }).catch(() => {})
       );
       throw err;
@@ -20575,6 +20633,7 @@ const websocketSafeHandler = {
     // AXIOM_TOKEN absence is handled inside logRequest — it returns early without throwing.
     const duration = Date.now() - startTime;
     ctx.waitUntil(
+      // fire-and-forget — Axiom request-log fire-and-forget
       axiomLogger.logRequest(request, response, duration).catch(() => {})
     );
 

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -8752,7 +8752,7 @@ pitchey_analytics_datapoints_per_minute 1250
            WHERE (p.user_id = $1 OR p.creator_id = $1) AND p.created_at >= NOW() - INTERVAL '${days} days') as fallback_views,
           (SELECT COALESCE(SUM(p.like_count), 0) FROM pitches p
            WHERE (p.user_id = $1 OR p.creator_id = $1) AND p.created_at >= NOW() - INTERVAL '${days} days') as fallback_likes
-      `, [userId]), { fallback: [{ current_views: 0, prev_views: 0, current_likes: 0, prev_likes: 0, fallback_views: 0, fallback_likes: 0 }], context: 'worker.analytics.period-metrics' });
+      `, [userId]), { fallback: [{ current_views: 0, prev_views: 0, current_likes: 0, prev_likes: 0, fallback_views: 0, fallback_likes: 0 }], context: 'worker-integrated.analytics.period-metrics' });
       const periodMetricsResult = periodMetricsQuery.rows;
 
       // 2. Follower count — total + gained in current/previous period
@@ -8834,7 +8834,7 @@ pitchey_analytics_datapoints_per_minute 1250
           AND pv.viewed_at >= NOW() - INTERVAL '${days} days'
         GROUP BY DATE(pv.viewed_at)
         ORDER BY date ASC
-      `, [userId]), { fallback: [], context: 'worker.analytics.views-timeline' });
+      `, [userId]), { fallback: [], context: 'worker-integrated.analytics.views-timeline' });
       const viewsTimelineResult = viewsTimelineQuery.rows;
 
       // 8b. Likes timeline from event table
@@ -8846,7 +8846,7 @@ pitchey_analytics_datapoints_per_minute 1250
           AND pl.created_at >= NOW() - INTERVAL '${days} days'
         GROUP BY DATE(pl.created_at)
         ORDER BY date ASC
-      `, [userId]), { fallback: [], context: 'worker.analytics.likes-timeline' });
+      `, [userId]), { fallback: [], context: 'worker-integrated.analytics.likes-timeline' });
       const likesTimelineResult = likesTimelineQuery.rows;
 
       // 8c. Pitches created in period (for pitch count chart + fallback)
@@ -8860,7 +8860,7 @@ pitchey_analytics_datapoints_per_minute 1250
         WHERE (p.user_id = $1 OR p.creator_id = $1)
           AND p.created_at >= NOW() - INTERVAL '${days} days'
         ORDER BY p.created_at ASC
-      `, [userId]), { fallback: [], context: 'worker.analytics.pitch-timeline' });
+      `, [userId]), { fallback: [], context: 'worker-integrated.analytics.pitch-timeline' });
       const pitchTimelineResult = pitchTimelineQuery.rows;
 
       // 9. Investments received over time
@@ -8875,7 +8875,7 @@ pitchey_analytics_datapoints_per_minute 1250
           AND i.created_at >= NOW() - INTERVAL '${days} days'
         GROUP BY DATE(i.created_at)
         ORDER BY date ASC
-      `, [userId]), { fallback: [], context: 'worker.analytics.investment-timeseries' });
+      `, [userId]), { fallback: [], context: 'worker-integrated.analytics.investment-timeseries' });
       const investmentTimeSeriesResult = investmentTimeSeriesQuery.rows;
 
       // 10. NDA requests over time (as engagement proxy)
@@ -8889,7 +8889,7 @@ pitchey_analytics_datapoints_per_minute 1250
           AND nr.created_at >= NOW() - INTERVAL '${days} days'
         GROUP BY DATE(nr.created_at)
         ORDER BY date ASC
-      `, [userId]), { fallback: [], context: 'worker.analytics.nda-timeline' });
+      `, [userId]), { fallback: [], context: 'worker-integrated.analytics.nda-timeline' });
       const ndaTimelineResult = ndaTimelineQuery.rows;
 
       // Normalize any date value to YYYY-MM-DD string
@@ -12055,16 +12055,16 @@ pitchey_analytics_datapoints_per_minute 1250
           LEFT JOIN investments i ON i.pitch_id = p.id
           WHERE p.genre IS NOT NULL
           GROUP BY p.genre ORDER BY total_projects DESC LIMIT 10
-        `), { fallback: [], context: 'worker.market.trends' }),
+        `), { fallback: [], context: 'worker-integrated.market.trends' }),
         safeQuery<{ genre: string }>(
           () => this.db.query(`SELECT DISTINCT genre FROM pitches WHERE genre IS NOT NULL ORDER BY genre`),
-          { fallback: [], context: 'worker.market.genres' }
+          { fallback: [], context: 'worker-integrated.market.genres' }
         ),
         safeQuery<{ total_opportunities: number; top_genre: string }>(() => this.db.query(`
           SELECT COUNT(*) as total_opportunities,
                  (SELECT genre FROM pitches GROUP BY genre ORDER BY COUNT(*) DESC LIMIT 1) as top_genre
           FROM pitches WHERE status = 'published'
-        `), { fallback: [{ total_opportunities: 0, top_genre: 'N/A' }], context: 'worker.market.summary' })
+        `), { fallback: [{ total_opportunities: 0, top_genre: 'N/A' }], context: 'worker-integrated.market.summary' })
       ]);
       const trends = trendsQ.rows;
       const genreList = genreListQ.rows;
@@ -12105,7 +12105,7 @@ pitchey_analytics_datapoints_per_minute 1250
         LEFT JOIN investments i ON i.pitch_id = p.id
         WHERE p.genre IS NOT NULL
         GROUP BY p.genre ORDER BY total_projects DESC
-      `), { fallback: [], context: 'worker.genre-performance' });
+      `), { fallback: [], context: 'worker-integrated.genre-performance' });
       const genres = genresQuery.rows;
 
       return builder.success({ genres: genres.map((g) => ({
@@ -12138,7 +12138,7 @@ pitchey_analytics_datapoints_per_minute 1250
         WHERE p.created_at >= NOW() - INTERVAL '12 months'
         GROUP BY date_trunc('month', p.created_at)
         ORDER BY month
-      `), { fallback: [], context: 'worker.market-forecast' });
+      `), { fallback: [], context: 'worker-integrated.market-forecast' });
       const trends = trendsQuery.rows;
 
       return builder.success({ forecast: trends.map((t) => ({
@@ -12735,13 +12735,13 @@ pitchey_analytics_datapoints_per_minute 1250
           WHERE user_id = $1
           ORDER BY created_at DESC
           LIMIT 10
-        `, [authResult.user.id]), { fallback: [], context: 'worker.poll-all.notifications' }),
+        `, [authResult.user.id]), { fallback: [], context: 'worker-integrated.poll-all.notifications' }),
 
         safeQuery<{ count: number }>(() => this.db.query(`
           SELECT COUNT(*) as count
           FROM notifications
           WHERE user_id = $1 AND is_read = false
-        `, [authResult.user.id]), { fallback: [{ count: 0 }], context: 'worker.poll-all.unread-count' }),
+        `, [authResult.user.id]), { fallback: [{ count: 0 }], context: 'worker-integrated.poll-all.unread-count' }),
 
         // Get basic dashboard stats based on user type
         this.getDashboardStatsForUser(authResult.user),
@@ -12758,7 +12758,7 @@ pitchey_analytics_datapoints_per_minute 1250
           WHERE up.updated_at > NOW() - INTERVAL '5 minutes'
             AND up.status != 'offline'
           ORDER BY up.updated_at DESC
-        `), { fallback: [], context: 'worker.poll-all.presence' }),
+        `), { fallback: [], context: 'worker-integrated.poll-all.presence' }),
 
         safeQuery<Record<string, unknown>>(() => this.db.query(`
           SELECT m.id, m.sender_id, m.content, m.created_at,
@@ -12768,7 +12768,7 @@ pitchey_analytics_datapoints_per_minute 1250
           WHERE m.recipient_id = $1 AND m.read_at IS NULL
           ORDER BY m.created_at DESC
           LIMIT 5
-        `, [authResult.user.id]), { fallback: [], context: 'worker.poll-all.unread-messages' })
+        `, [authResult.user.id]), { fallback: [], context: 'worker-integrated.poll-all.unread-messages' })
       ]);
       const notifications = notificationsQ.rows;
       const unreadCount = unreadCountQ.rows[0]?.count || 0;
@@ -12874,28 +12874,28 @@ pitchey_analytics_datapoints_per_minute 1250
         safeQuery<{ count: number }>(() => this.db.query(`
           SELECT COUNT(*) as count FROM user_presence
           WHERE updated_at > NOW() - INTERVAL '5 minutes' AND status != 'offline'
-        `), { fallback: [{ count: 0 }], context: 'worker.realtime.active-users' }),
+        `), { fallback: [{ count: 0 }], context: 'worker-integrated.realtime.active-users' }),
 
         safeQuery<{ total: number }>(() => this.db.query(`
           SELECT COALESCE(SUM(views), 0) as total FROM pitch_analytics
           WHERE date = CURRENT_DATE
-        `), { fallback: [{ total: 0 }], context: 'worker.realtime.views-last-hour' }),
+        `), { fallback: [{ total: 0 }], context: 'worker-integrated.realtime.views-last-hour' }),
 
         safeQuery<{ count: number }>(() => this.db.query(`
           SELECT COUNT(*) as count FROM pitches
           WHERE created_at >= CURRENT_DATE
-        `), { fallback: [{ count: 0 }], context: 'worker.realtime.new-pitches-today' }),
+        `), { fallback: [{ count: 0 }], context: 'worker-integrated.realtime.new-pitches-today' }),
 
         safeQuery<{ count: number }>(() => this.db.query(`
           SELECT COUNT(*) as count FROM investments
           WHERE created_at >= CURRENT_DATE
-        `), { fallback: [{ count: 0 }], context: 'worker.realtime.investments-today' }),
+        `), { fallback: [{ count: 0 }], context: 'worker-integrated.realtime.investments-today' }),
 
         safeQuery<{ genre: string }>(() => this.db.query(`
           SELECT genre, COUNT(*) as count FROM pitches
           WHERE status = 'published' AND genre IS NOT NULL
           GROUP BY genre ORDER BY count DESC LIMIT 3
-        `), { fallback: [{ genre: 'Action' }, { genre: 'Drama' }, { genre: 'Comedy' }], context: 'worker.realtime.trending-genres' })
+        `), { fallback: [{ genre: 'Action' }, { genre: 'Drama' }, { genre: 'Comedy' }], context: 'worker-integrated.realtime.trending-genres' })
       ]);
       const activeUsers = this.safeParseInt(activeUsersQ.rows[0]?.count);
       const viewsLastHour = this.safeParseInt(viewsLastHourQ.rows[0]?.total);
@@ -13027,7 +13027,7 @@ pitchey_analytics_datapoints_per_minute 1250
           SELECT id, report_type, frequency, filters, next_run, created_at
           FROM scheduled_reports WHERE user_id = $1 ORDER BY created_at DESC
         `, [authResult.user!.id]),
-        { fallback: [], context: 'worker.scheduled-reports.list' }
+        { fallback: [], context: 'worker-integrated.scheduled-reports.list' }
       );
 
       return builder.success({ success: true, reports: reportsQuery.rows });
@@ -13068,7 +13068,7 @@ pitchey_analytics_datapoints_per_minute 1250
           FROM search_history WHERE user_id = $1
           ORDER BY created_at DESC LIMIT $2
         `, [authResult.user!.id, limit]),
-        { fallback: [], context: 'worker.search.history' }
+        { fallback: [], context: 'worker-integrated.search.history' }
       );
 
       return builder.success({ searchHistory: historyQuery.rows });
@@ -13117,7 +13117,7 @@ pitchey_analytics_datapoints_per_minute 1250
         FROM pitches p
         WHERE status = 'published' AND genre IS NOT NULL
         GROUP BY genre ORDER BY pitch_count DESC
-      `), { fallback: [], context: 'worker.browse.genres' });
+      `), { fallback: [], context: 'worker-integrated.browse.genres' });
 
       return new Response(JSON.stringify({ genres: genresQuery.rows }), {
         headers: { 'Content-Type': 'application/json', ...getCorsHeaders(request.headers.get('Origin')) },
@@ -13172,10 +13172,10 @@ pitchey_analytics_datapoints_per_minute 1250
           ${whereClause}
           ORDER BY like_count DESC, view_count DESC
           LIMIT $${paramIdx++} OFFSET $${paramIdx++}
-        `, [...queryParams, limit, offset]), { fallback: [], context: 'worker.browse.top-rated.list' }),
+        `, [...queryParams, limit, offset]), { fallback: [], context: 'worker-integrated.browse.top-rated.list' }),
         safeQuery<{ total: number }>(
           () => this.db.query(`SELECT COUNT(*) as total FROM pitches p ${whereClause}`, queryParams),
-          { fallback: [{ total: 0 }], context: 'worker.browse.top-rated.count' }
+          { fallback: [{ total: 0 }], context: 'worker-integrated.browse.top-rated.count' }
         )
       ]);
       const pitches = pitchesQ.rows;
@@ -13208,7 +13208,7 @@ pitchey_analytics_datapoints_per_minute 1250
             COALESCE(AVG(p.like_count), 0) as avg_rating,
             COUNT(DISTINCT genre) as genre_count
           FROM pitches p WHERE status = 'published'
-        `), { fallback: [{ total_rated: 0, avg_rating: 0, genre_count: 0 }], context: 'worker.browse.top-rated.stats' })
+        `), { fallback: [{ total_rated: 0, avg_rating: 0, genre_count: 0 }], context: 'worker-integrated.browse.top-rated.stats' })
       ]);
 
       const stats = statsQuery.rows[0] || { total_rated: 0, avg_rating: 0, genre_count: 0 };
@@ -13287,7 +13287,7 @@ pitchey_analytics_datapoints_per_minute 1250
           () => this.db.query(`
             SELECT id, title, genre, status, created_at FROM pitches WHERE user_id = $1 ORDER BY created_at DESC
           `, [authResult.user!.id]),
-          { fallback: [], context: 'worker.export.pitches' }
+          { fallback: [], context: 'worker-integrated.export.pitches' }
         );
         csvContent = 'ID,Title,Genre,Status,Created\n' + pitchesQuery.rows.map((p) => `${p.id},"${p.title}",${p.genre},${p.status},${p.created_at}`).join('\n');
       } else if (exportType === 'analytics') {
@@ -13295,7 +13295,7 @@ pitchey_analytics_datapoints_per_minute 1250
           () => this.db.query(`
             SELECT pa.date, pa.views, pa.likes FROM pitch_analytics pa JOIN pitches p ON pa.pitch_id = p.id WHERE p.user_id = $1 ORDER BY pa.date DESC LIMIT 90
           `, [authResult.user!.id]),
-          { fallback: [], context: 'worker.export.analytics' }
+          { fallback: [], context: 'worker-integrated.export.analytics' }
         );
         csvContent = 'Date,Views,Likes\n' + analyticsQuery.rows.map((a) => `${a.date},${a.views},${a.likes}`).join('\n');
       } else {
@@ -13349,7 +13349,7 @@ pitchey_analytics_datapoints_per_minute 1250
         () => this.db.query(`
           SELECT verification_status, company_name FROM users WHERE id = $1
         `, [authResult.user!.id]),
-        { fallback: [], context: 'worker.company-verify.status' }
+        { fallback: [], context: 'worker-integrated.company-verify.status' }
       );
       const user = userQuery.rows;
 
@@ -13393,13 +13393,13 @@ pitchey_analytics_datapoints_per_minute 1250
           FROM info_requests ir
           LEFT JOIN users u ON ir.requester_id = u.id
           WHERE ir.target_user_id = $1 ORDER BY ir.created_at DESC
-        `, [authResult.user!.id]), { fallback: [], context: 'worker.info-requests.incoming' }),
+        `, [authResult.user!.id]), { fallback: [], context: 'worker-integrated.info-requests.incoming' }),
         safeQuery<Record<string, unknown>>(() => this.db.query(`
           SELECT ir.*, COALESCE(u.name, u.first_name || ' ' || u.last_name) as target_name
           FROM info_requests ir
           LEFT JOIN users u ON ir.target_user_id = u.id
           WHERE ir.requester_id = $1 ORDER BY ir.created_at DESC
-        `, [authResult.user!.id]), { fallback: [], context: 'worker.info-requests.outgoing' })
+        `, [authResult.user!.id]), { fallback: [], context: 'worker-integrated.info-requests.outgoing' })
       ]);
 
       return builder.success({ incoming: incomingQ.rows, outgoing: outgoingQ.rows });
@@ -15496,7 +15496,7 @@ pitchey_analytics_datapoints_per_minute 1250
       // Try to find the NDA document in R2
       const ndaDocQuery = await safeQuery<{ document_url: string | null }>(
         () => this.db.query(`SELECT document_url FROM ndas WHERE id = $1`, [ndaId]),
-        { fallback: [], context: 'worker.nda.download' }
+        { fallback: [], context: 'worker-integrated.nda.download' }
       );
       if (ndaDocQuery.rows[0]?.document_url) {
         return this.jsonResponse({ success: true, data: { downloadUrl: ndaDocQuery.rows[0].document_url, message: 'NDA document ready for download' }});
@@ -15521,7 +15521,7 @@ pitchey_analytics_datapoints_per_minute 1250
 
       const ndaDocQuery = await safeQuery<{ signed_document_url: string | null }>(
         () => this.db.query(`SELECT signed_document_url FROM ndas WHERE id = $1`, [ndaId]),
-        { fallback: [], context: 'worker.nda.download-signed' }
+        { fallback: [], context: 'worker-integrated.nda.download-signed' }
       );
       if (ndaDocQuery.rows[0]?.signed_document_url) {
         return this.jsonResponse({ success: true, data: { downloadUrl: ndaDocQuery.rows[0].signed_document_url, message: 'Signed NDA document ready for download' }});
@@ -18039,7 +18039,7 @@ Signatures: [To be completed upon signing]
              ORDER BY view_count DESC NULLS LAST LIMIT 5`,
             [userId]
           ),
-          { fallback: [], context: 'worker.creator-analytics.top-pitches' }
+          { fallback: [], context: 'worker-integrated.creator-analytics.top-pitches' }
         );
         const topPitchesRes = topPitchesQuery.rows;
 
@@ -18054,7 +18054,7 @@ Signatures: [To be completed upon signing]
              WHERE p.user_id = $1`,
             [userId]
           ),
-          { fallback: [{ nda_requests: 0, nda_signed: 0 }], context: 'worker.creator-analytics.nda-counts' }
+          { fallback: [{ nda_requests: 0, nda_signed: 0 }], context: 'worker-integrated.creator-analytics.nda-counts' }
         );
         const ndaRes = ndaQuery.rows;
 
@@ -18072,7 +18072,7 @@ Signatures: [To be completed upon signing]
              GROUP BY u.user_type`,
             [userId]
           ),
-          { fallback: [], context: 'worker.creator-analytics.viewer-types' }
+          { fallback: [], context: 'worker-integrated.creator-analytics.viewer-types' }
         );
         const viewerTypesRes = viewerTypesQuery.rows;
 

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -8737,8 +8737,8 @@ pitchey_analytics_datapoints_per_minute 1250
       `, [userId]);
 
       // 1b. Time-filtered views/likes from event tables + fallback from cumulative counters
-      // TODO(catch-swallow): migrate to safeQuery
-      const periodMetricsResult = await this.db.query(`
+      type PeriodMetricsRow = { current_views: number; prev_views: number; current_likes: number; prev_likes: number; fallback_views: number; fallback_likes: number };
+      const periodMetricsQuery = await safeQuery<PeriodMetricsRow>(() => this.db.query(`
         SELECT
           (SELECT COUNT(*) FROM pitch_views pv JOIN pitches p ON pv.pitch_id = p.id
            WHERE (p.user_id = $1 OR p.creator_id = $1) AND pv.viewed_at >= NOW() - INTERVAL '${days} days') as current_views,
@@ -8752,7 +8752,8 @@ pitchey_analytics_datapoints_per_minute 1250
            WHERE (p.user_id = $1 OR p.creator_id = $1) AND p.created_at >= NOW() - INTERVAL '${days} days') as fallback_views,
           (SELECT COALESCE(SUM(p.like_count), 0) FROM pitches p
            WHERE (p.user_id = $1 OR p.creator_id = $1) AND p.created_at >= NOW() - INTERVAL '${days} days') as fallback_likes
-      `, [userId]).catch(() => [{ current_views: 0, prev_views: 0, current_likes: 0, prev_likes: 0, fallback_views: 0, fallback_likes: 0 }]);
+      `, [userId]), { fallback: [{ current_views: 0, prev_views: 0, current_likes: 0, prev_likes: 0, fallback_views: 0, fallback_likes: 0 }], context: 'worker.analytics.period-metrics' });
+      const periodMetricsResult = periodMetricsQuery.rows;
 
       // 2. Follower count — total + gained in current/previous period
       const followerResult = await this.db.query(`
@@ -8825,8 +8826,7 @@ pitchey_analytics_datapoints_per_minute 1250
       `, []);
 
       // 8. Views timeline from event table (for charts)
-      // TODO(catch-swallow): migrate to safeQuery
-      const viewsTimelineResult = await this.db.query(`
+      const viewsTimelineQuery = await safeQuery<Record<string, unknown>>(() => this.db.query(`
         SELECT DATE(pv.viewed_at) as date, COUNT(*) as views
         FROM pitch_views pv
         JOIN pitches p ON pv.pitch_id = p.id
@@ -8834,11 +8834,11 @@ pitchey_analytics_datapoints_per_minute 1250
           AND pv.viewed_at >= NOW() - INTERVAL '${days} days'
         GROUP BY DATE(pv.viewed_at)
         ORDER BY date ASC
-      `, [userId]).catch(() => []);
+      `, [userId]), { fallback: [], context: 'worker.analytics.views-timeline' });
+      const viewsTimelineResult = viewsTimelineQuery.rows;
 
       // 8b. Likes timeline from event table
-      // TODO(catch-swallow): migrate to safeQuery
-      const likesTimelineResult = await this.db.query(`
+      const likesTimelineQuery = await safeQuery<Record<string, unknown>>(() => this.db.query(`
         SELECT DATE(pl.created_at) as date, COUNT(*) as likes
         FROM pitch_likes pl
         JOIN pitches p ON pl.pitch_id = p.id
@@ -8846,11 +8846,11 @@ pitchey_analytics_datapoints_per_minute 1250
           AND pl.created_at >= NOW() - INTERVAL '${days} days'
         GROUP BY DATE(pl.created_at)
         ORDER BY date ASC
-      `, [userId]).catch(() => []);
+      `, [userId]), { fallback: [], context: 'worker.analytics.likes-timeline' });
+      const likesTimelineResult = likesTimelineQuery.rows;
 
       // 8c. Pitches created in period (for pitch count chart + fallback)
-      // TODO(catch-swallow): migrate to safeQuery
-      const pitchTimelineResult = await this.db.query(`
+      const pitchTimelineQuery = await safeQuery<Record<string, unknown>>(() => this.db.query(`
         SELECT
           p.id, p.title, p.genre,
           DATE(p.created_at) as created_date,
@@ -8860,11 +8860,11 @@ pitchey_analytics_datapoints_per_minute 1250
         WHERE (p.user_id = $1 OR p.creator_id = $1)
           AND p.created_at >= NOW() - INTERVAL '${days} days'
         ORDER BY p.created_at ASC
-      `, [userId]).catch(() => []);
+      `, [userId]), { fallback: [], context: 'worker.analytics.pitch-timeline' });
+      const pitchTimelineResult = pitchTimelineQuery.rows;
 
       // 9. Investments received over time
-      // TODO(catch-swallow): migrate to safeQuery
-      const investmentTimeSeriesResult = await this.db.query(`
+      const investmentTimeSeriesQuery = await safeQuery<Record<string, unknown>>(() => this.db.query(`
         SELECT
           DATE(i.created_at) as date,
           COUNT(*) as count,
@@ -8875,11 +8875,11 @@ pitchey_analytics_datapoints_per_minute 1250
           AND i.created_at >= NOW() - INTERVAL '${days} days'
         GROUP BY DATE(i.created_at)
         ORDER BY date ASC
-      `, [userId]).catch(() => []);
+      `, [userId]), { fallback: [], context: 'worker.analytics.investment-timeseries' });
+      const investmentTimeSeriesResult = investmentTimeSeriesQuery.rows;
 
       // 10. NDA requests over time (as engagement proxy)
-      // TODO(catch-swallow): migrate to safeQuery
-      const ndaTimelineResult = await this.db.query(`
+      const ndaTimelineQuery = await safeQuery<Record<string, unknown>>(() => this.db.query(`
         SELECT
           DATE(nr.created_at) as date,
           COUNT(*) as count
@@ -8889,7 +8889,8 @@ pitchey_analytics_datapoints_per_minute 1250
           AND nr.created_at >= NOW() - INTERVAL '${days} days'
         GROUP BY DATE(nr.created_at)
         ORDER BY date ASC
-      `, [userId]).catch(() => []);
+      `, [userId]), { fallback: [], context: 'worker.analytics.nda-timeline' });
+      const ndaTimelineResult = ndaTimelineQuery.rows;
 
       // Normalize any date value to YYYY-MM-DD string
       const toDateStr = (d: any): string => {
@@ -12042,9 +12043,8 @@ pitchey_analytics_datapoints_per_minute 1250
   private async getMarketTrends(request: Request): Promise<Response> {
     const builder = new ApiResponseBuilder(request);
     try {
-      const [trends, genreList, summary] = await Promise.all([
-        // TODO(catch-swallow): migrate to safeQuery
-        this.db.query(`
+      const [trendsQ, genreListQ, summaryQ] = await Promise.all([
+        safeQuery<Record<string, unknown>>(() => this.db.query(`
           SELECT p.genre, COUNT(i.*) as total_projects,
                  COALESCE(AVG(i.amount), 0) as avg_budget,
                  COALESCE(AVG(i.roi_percentage), 0) as avg_roi,
@@ -12055,28 +12055,32 @@ pitchey_analytics_datapoints_per_minute 1250
           LEFT JOIN investments i ON i.pitch_id = p.id
           WHERE p.genre IS NOT NULL
           GROUP BY p.genre ORDER BY total_projects DESC LIMIT 10
-        `).catch(() => []),
-        // TODO(catch-swallow): migrate to safeQuery
-        this.db.query(`SELECT DISTINCT genre FROM pitches WHERE genre IS NOT NULL ORDER BY genre`).catch(() => []),
-        // TODO(catch-swallow): migrate to safeQuery
-        this.db.query(`
+        `), { fallback: [], context: 'worker.market.trends' }),
+        safeQuery<{ genre: string }>(
+          () => this.db.query(`SELECT DISTINCT genre FROM pitches WHERE genre IS NOT NULL ORDER BY genre`),
+          { fallback: [], context: 'worker.market.genres' }
+        ),
+        safeQuery<{ total_opportunities: number; top_genre: string }>(() => this.db.query(`
           SELECT COUNT(*) as total_opportunities,
                  (SELECT genre FROM pitches GROUP BY genre ORDER BY COUNT(*) DESC LIMIT 1) as top_genre
           FROM pitches WHERE status = 'published'
-        `).catch(() => [{ total_opportunities: 0, top_genre: 'N/A' }])
+        `), { fallback: [{ total_opportunities: 0, top_genre: 'N/A' }], context: 'worker.market.summary' })
       ]);
+      const trends = trendsQ.rows;
+      const genreList = genreListQ.rows;
+      const summary = summaryQ.rows;
 
-      const s = summary[0] || {};
+      const s = summary[0] || ({} as { total_opportunities?: number; top_genre?: string });
       return builder.success({
-        trends: (trends || []).map((t: any) => ({
+        trends: trends.map((t) => ({
           date: new Date().toISOString(), genre: t.genre,
           avgBudget: parseFloat(String(t.avg_budget || '0')), avgROI: parseFloat(parseFloat(String(t.avg_roi || '0')).toFixed(2)),
           totalProjects: parseInt(String(t.total_projects || '0'), 10), successRate: parseFloat(parseFloat(String(t.success_rate || '0')).toFixed(2))
         })),
-        genres: (genreList || []).map((g: any) => g.genre),
+        genres: genreList.map((g) => g.genre),
         summary: {
           totalInvestmentOpportunities: parseInt(String(s.total_opportunities || '0'), 10),
-          avgSuccessRate: (trends || []).length > 0 ? parseFloat(((trends as any[]).reduce((acc: number, t: any) => acc + parseFloat(String(t.success_rate || '0')), 0) / (trends as any[]).length).toFixed(2)) : 0,
+          avgSuccessRate: trends.length > 0 ? parseFloat((trends.reduce((acc: number, t) => acc + parseFloat(String(t.success_rate || '0')), 0) / trends.length).toFixed(2)) : 0,
           topPerformingGenre: s.top_genre || 'N/A',
           marketGrowth: 0
         }
@@ -12089,8 +12093,7 @@ pitchey_analytics_datapoints_per_minute 1250
   private async getGenrePerformance(request: Request): Promise<Response> {
     const builder = new ApiResponseBuilder(request);
     try {
-      // TODO(catch-swallow): migrate to safeQuery
-      const genres = await this.db.query(`
+      const genresQuery = await safeQuery<Record<string, unknown>>(() => this.db.query(`
         SELECT p.genre,
                COALESCE(AVG(i.roi_percentage), 0) as avg_roi,
                COUNT(DISTINCT p.id) as total_projects,
@@ -12102,9 +12105,10 @@ pitchey_analytics_datapoints_per_minute 1250
         LEFT JOIN investments i ON i.pitch_id = p.id
         WHERE p.genre IS NOT NULL
         GROUP BY p.genre ORDER BY total_projects DESC
-      `).catch(() => []);
+      `), { fallback: [], context: 'worker.genre-performance' });
+      const genres = genresQuery.rows;
 
-      return builder.success({ genres: (genres || []).map((g: any) => ({
+      return builder.success({ genres: genres.map((g) => ({
         genre: g.genre, avg_roi: parseFloat(parseFloat(String(g.avg_roi || '0')).toFixed(2)),
         total_projects: parseInt(String(g.total_projects || '0'), 10),
         avg_budget: parseFloat(String(g.avg_budget || '0')),
@@ -12119,8 +12123,7 @@ pitchey_analytics_datapoints_per_minute 1250
     const builder = new ApiResponseBuilder(request);
     try {
       // Monthly pitch creation + investment trends over the last 12 months
-      // TODO(catch-swallow): migrate to safeQuery
-      const trends = await this.db.query(`
+      const trendsQuery = await safeQuery<Record<string, unknown>>(() => this.db.query(`
         SELECT
           TO_CHAR(date_trunc('month', p.created_at), 'YYYY-MM') as month,
           COUNT(*)::int as pitches_created,
@@ -12135,9 +12138,10 @@ pitchey_analytics_datapoints_per_minute 1250
         WHERE p.created_at >= NOW() - INTERVAL '12 months'
         GROUP BY date_trunc('month', p.created_at)
         ORDER BY month
-      `).catch(() => []);
+      `), { fallback: [], context: 'worker.market-forecast' });
+      const trends = trendsQuery.rows;
 
-      return builder.success({ forecast: trends.map((t: any) => ({
+      return builder.success({ forecast: trends.map((t) => ({
         month: t.month,
         pitchesCreated: parseInt(String(t.pitches_created || '0'), 10),
         totalInvested: parseFloat(String(t.total_invested || '0')),
@@ -12724,31 +12728,25 @@ pitchey_analytics_datapoints_per_minute 1250
 
     try {
       // Fetch multiple data sources in parallel
-      const [notifications, unreadCount, dashboardStats, presenceUsers, recentMessages] = await Promise.all([
-        // Get recent notifications
-        // TODO(catch-swallow): migrate to safeQuery
-        this.db.query(`
+      const [notificationsQ, unreadCountQ, dashboardStats, presenceUsersQ, recentMessagesQ] = await Promise.all([
+        safeQuery<Record<string, unknown>>(() => this.db.query(`
           SELECT id, type, title, message, created_at, is_read
           FROM notifications
           WHERE user_id = $1
           ORDER BY created_at DESC
           LIMIT 10
-        `, [authResult.user.id]).catch(() => []),
+        `, [authResult.user.id]), { fallback: [], context: 'worker.poll-all.notifications' }),
 
-        // Get unread notification count
-        // TODO(catch-swallow): migrate to safeQuery
-        this.db.query(`
+        safeQuery<{ count: number }>(() => this.db.query(`
           SELECT COUNT(*) as count
           FROM notifications
           WHERE user_id = $1 AND is_read = false
-        `, [authResult.user.id]).then(([result]) => result?.count || 0).catch(() => 0),
+        `, [authResult.user.id]), { fallback: [{ count: 0 }], context: 'worker.poll-all.unread-count' }),
 
         // Get basic dashboard stats based on user type
         this.getDashboardStatsForUser(authResult.user),
 
-        // Get online users
-        // TODO(catch-swallow): migrate to safeQuery
-        this.db.query(`
+        safeQuery<Record<string, unknown>>(() => this.db.query(`
           SELECT
             up.user_id as "userId",
             COALESCE(u.name, u.username, u.email) as username,
@@ -12760,11 +12758,9 @@ pitchey_analytics_datapoints_per_minute 1250
           WHERE up.updated_at > NOW() - INTERVAL '5 minutes'
             AND up.status != 'offline'
           ORDER BY up.updated_at DESC
-        `).catch(() => []),
+        `), { fallback: [], context: 'worker.poll-all.presence' }),
 
-        // Get recent unread messages
-        // TODO(catch-swallow): migrate to safeQuery
-        this.db.query(`
+        safeQuery<Record<string, unknown>>(() => this.db.query(`
           SELECT m.id, m.sender_id, m.content, m.created_at,
                  COALESCE(u.name, u.username, u.email) as sender_name
           FROM messages m
@@ -12772,11 +12768,15 @@ pitchey_analytics_datapoints_per_minute 1250
           WHERE m.recipient_id = $1 AND m.read_at IS NULL
           ORDER BY m.created_at DESC
           LIMIT 5
-        `, [authResult.user.id]).catch(() => [])
+        `, [authResult.user.id]), { fallback: [], context: 'worker.poll-all.unread-messages' })
       ]);
+      const notifications = notificationsQ.rows;
+      const unreadCount = unreadCountQ.rows[0]?.count || 0;
+      const presenceUsers = presenceUsersQ.rows;
+      const recentMessages = recentMessagesQ.rows;
 
       // Determine next poll interval based on activity
-      const hasNewNotifications = notifications.length > 0 && notifications.some((n: any) => !n.is_read);
+      const hasNewNotifications = notifications.length > 0 && notifications.some((n) => !n.is_read);
       const nextPollIn = hasNewNotifications ? 15000 : 30000; // 15s if new notifications, 30s otherwise
 
       return builder.success({
@@ -12870,38 +12870,38 @@ pitchey_analytics_datapoints_per_minute 1250
 
     try {
       // Fetch real analytics data in parallel (each query resilient to missing tables)
-      const [activeUsers, viewsLastHour, newPitchesToday, investmentsToday, trendingGenres] = await Promise.all([
-        // TODO(catch-swallow): migrate to safeQuery
-        this.db.query(`
+      const [activeUsersQ, viewsLastHourQ, newPitchesTodayQ, investmentsTodayQ, trendingGenresQ] = await Promise.all([
+        safeQuery<{ count: number }>(() => this.db.query(`
           SELECT COUNT(*) as count FROM user_presence
           WHERE updated_at > NOW() - INTERVAL '5 minutes' AND status != 'offline'
-        `).then(([r]) => this.safeParseInt(r?.count)).catch(() => 0),
+        `), { fallback: [{ count: 0 }], context: 'worker.realtime.active-users' }),
 
-        // TODO(catch-swallow): migrate to safeQuery
-        this.db.query(`
+        safeQuery<{ total: number }>(() => this.db.query(`
           SELECT COALESCE(SUM(views), 0) as total FROM pitch_analytics
           WHERE date = CURRENT_DATE
-        `).then(([r]) => this.safeParseInt(r?.total)).catch(() => 0),
+        `), { fallback: [{ total: 0 }], context: 'worker.realtime.views-last-hour' }),
 
-        // TODO(catch-swallow): migrate to safeQuery
-        this.db.query(`
+        safeQuery<{ count: number }>(() => this.db.query(`
           SELECT COUNT(*) as count FROM pitches
           WHERE created_at >= CURRENT_DATE
-        `).then(([r]) => this.safeParseInt(r?.count)).catch(() => 0),
+        `), { fallback: [{ count: 0 }], context: 'worker.realtime.new-pitches-today' }),
 
-        // TODO(catch-swallow): migrate to safeQuery
-        this.db.query(`
+        safeQuery<{ count: number }>(() => this.db.query(`
           SELECT COUNT(*) as count FROM investments
           WHERE created_at >= CURRENT_DATE
-        `).then(([r]) => this.safeParseInt(r?.count)).catch(() => 0),
+        `), { fallback: [{ count: 0 }], context: 'worker.realtime.investments-today' }),
 
-        // TODO(catch-swallow): migrate to safeQuery
-        this.db.query(`
+        safeQuery<{ genre: string }>(() => this.db.query(`
           SELECT genre, COUNT(*) as count FROM pitches
           WHERE status = 'published' AND genre IS NOT NULL
           GROUP BY genre ORDER BY count DESC LIMIT 3
-        `).then(rows => rows.map((r: any) => r.genre)).catch(() => ['Action', 'Drama', 'Comedy'])
+        `), { fallback: [{ genre: 'Action' }, { genre: 'Drama' }, { genre: 'Comedy' }], context: 'worker.realtime.trending-genres' })
       ]);
+      const activeUsers = this.safeParseInt(activeUsersQ.rows[0]?.count);
+      const viewsLastHour = this.safeParseInt(viewsLastHourQ.rows[0]?.total);
+      const newPitchesToday = this.safeParseInt(newPitchesTodayQ.rows[0]?.count);
+      const investmentsToday = this.safeParseInt(investmentsTodayQ.rows[0]?.count);
+      const trendingGenres = trendingGenresQ.rows.map((r) => r.genre);
 
       const analytics = {
         active_users: activeUsers,
@@ -13022,13 +13022,15 @@ pitchey_analytics_datapoints_per_minute 1250
 
     const builder = new ApiResponseBuilder(request);
     try {
-      // TODO(catch-swallow): migrate to safeQuery
-      const reports = await this.db.query(`
-        SELECT id, report_type, frequency, filters, next_run, created_at
-        FROM scheduled_reports WHERE user_id = $1 ORDER BY created_at DESC
-      `, [authResult.user!.id]).catch(() => []);
+      const reportsQuery = await safeQuery<Record<string, unknown>>(
+        () => this.db.query(`
+          SELECT id, report_type, frequency, filters, next_run, created_at
+          FROM scheduled_reports WHERE user_id = $1 ORDER BY created_at DESC
+        `, [authResult.user!.id]),
+        { fallback: [], context: 'worker.scheduled-reports.list' }
+      );
 
-      return builder.success({ success: true, reports });
+      return builder.success({ success: true, reports: reportsQuery.rows });
     } catch (error) {
       return builder.success({ success: true, reports: [] });
     }
@@ -13060,14 +13062,16 @@ pitchey_analytics_datapoints_per_minute 1250
     const limit = parseInt(url.searchParams.get('limit') || '10', 10);
 
     try {
-      // TODO(catch-swallow): migrate to safeQuery
-      const history = await this.db.query(`
-        SELECT id, query, filters, results_count, created_at
-        FROM search_history WHERE user_id = $1
-        ORDER BY created_at DESC LIMIT $2
-      `, [authResult.user!.id, limit]).catch(() => []);
+      const historyQuery = await safeQuery<Record<string, unknown>>(
+        () => this.db.query(`
+          SELECT id, query, filters, results_count, created_at
+          FROM search_history WHERE user_id = $1
+          ORDER BY created_at DESC LIMIT $2
+        `, [authResult.user!.id, limit]),
+        { fallback: [], context: 'worker.search.history' }
+      );
 
-      return builder.success({ searchHistory: history });
+      return builder.success({ searchHistory: historyQuery.rows });
     } catch (error) {
       return builder.success({ searchHistory: [] });
     }
@@ -13105,8 +13109,7 @@ pitchey_analytics_datapoints_per_minute 1250
   private async handleBrowseGenres(request: Request): Promise<Response> {
     const builder = new ApiResponseBuilder(request);
     try {
-      // TODO(catch-swallow): migrate to safeQuery
-      const genres = await this.db.query(`
+      const genresQuery = await safeQuery<Record<string, unknown>>(() => this.db.query(`
         SELECT genre, COUNT(*) as pitch_count,
                COALESCE(AVG(
                  (SELECT COUNT(*) FROM views WHERE views.pitch_id = p.id)
@@ -13114,9 +13117,9 @@ pitchey_analytics_datapoints_per_minute 1250
         FROM pitches p
         WHERE status = 'published' AND genre IS NOT NULL
         GROUP BY genre ORDER BY pitch_count DESC
-      `).catch(() => []);
+      `), { fallback: [], context: 'worker.browse.genres' });
 
-      return new Response(JSON.stringify({ genres: genres || [] }), {
+      return new Response(JSON.stringify({ genres: genresQuery.rows }), {
         headers: { 'Content-Type': 'application/json', ...getCorsHeaders(request.headers.get('Origin')) },
         status: 200
       });
@@ -13158,9 +13161,8 @@ pitchey_analytics_datapoints_per_minute 1250
         queryParams.push(genre);
       }
 
-      const [pitches, countResult] = await Promise.all([
-        // TODO(catch-swallow): migrate to safeQuery
-        this.db.query(`
+      const [pitchesQ, countResultQ] = await Promise.all([
+        safeQuery<Record<string, unknown>>(() => this.db.query(`
           SELECT p.id, p.title, p.genre, p.logline, p.title_image, p.created_at,
                  COALESCE(u.name, u.first_name || ' ' || u.last_name) as creator_name,
                  COALESCE(p.view_count, 0) as view_count,
@@ -13170,12 +13172,15 @@ pitchey_analytics_datapoints_per_minute 1250
           ${whereClause}
           ORDER BY like_count DESC, view_count DESC
           LIMIT $${paramIdx++} OFFSET $${paramIdx++}
-        `, [...queryParams, limit, offset]).catch(() => []),
-        // TODO(catch-swallow): migrate to safeQuery
-        this.db.query(`SELECT COUNT(*) as total FROM pitches p ${whereClause}`, queryParams).catch(() => [{ total: 0 }])
+        `, [...queryParams, limit, offset]), { fallback: [], context: 'worker.browse.top-rated.list' }),
+        safeQuery<{ total: number }>(
+          () => this.db.query(`SELECT COUNT(*) as total FROM pitches p ${whereClause}`, queryParams),
+          { fallback: [{ total: 0 }], context: 'worker.browse.top-rated.count' }
+        )
       ]);
+      const pitches = pitchesQ.rows;
 
-      const total = parseInt(String(countResult[0]?.total || '0'), 10);
+      const total = parseInt(String(countResultQ.rows[0]?.total || '0'), 10);
       const responseBody = JSON.stringify({ items: pitches, total, totalPages: Math.ceil(total / limit) });
 
       // Cache the result for 5 minutes
@@ -13195,18 +13200,18 @@ pitchey_analytics_datapoints_per_minute 1250
 
   private async handleBrowseTopRatedStats(request: Request): Promise<Response> {
     try {
-      const [statsResult] = await Promise.all([
-        // TODO(catch-swallow): migrate to safeQuery
-        this.db.query(`
+      type TopRatedStatsRow = { total_rated: number; avg_rating: number; genre_count: number };
+      const [statsQuery] = await Promise.all([
+        safeQuery<TopRatedStatsRow>(() => this.db.query(`
           SELECT
             COUNT(*) as total_rated,
             COALESCE(AVG(p.like_count), 0) as avg_rating,
             COUNT(DISTINCT genre) as genre_count
           FROM pitches p WHERE status = 'published'
-        `).catch(() => [{ total_rated: 0, avg_rating: 0, genre_count: 0 }])
+        `), { fallback: [{ total_rated: 0, avg_rating: 0, genre_count: 0 }], context: 'worker.browse.top-rated.stats' })
       ]);
 
-      const stats = statsResult[0] || { total_rated: 0, avg_rating: 0, genre_count: 0 };
+      const stats = statsQuery.rows[0] || { total_rated: 0, avg_rating: 0, genre_count: 0 };
       return new Response(JSON.stringify({
         stats: {
           totalRated: parseInt(String(stats.total_rated || '0'), 10),
@@ -13278,17 +13283,21 @@ pitchey_analytics_datapoints_per_minute 1250
       // Generate CSV export based on type
       let csvContent = '';
       if (exportType === 'pitches') {
-        // TODO(catch-swallow): migrate to safeQuery
-        const pitches = await this.db.query(`
-          SELECT id, title, genre, status, created_at FROM pitches WHERE user_id = $1 ORDER BY created_at DESC
-        `, [authResult.user!.id]).catch(() => []);
-        csvContent = 'ID,Title,Genre,Status,Created\n' + pitches.map((p: any) => `${p.id},"${p.title}",${p.genre},${p.status},${p.created_at}`).join('\n');
+        const pitchesQuery = await safeQuery<Record<string, unknown>>(
+          () => this.db.query(`
+            SELECT id, title, genre, status, created_at FROM pitches WHERE user_id = $1 ORDER BY created_at DESC
+          `, [authResult.user!.id]),
+          { fallback: [], context: 'worker.export.pitches' }
+        );
+        csvContent = 'ID,Title,Genre,Status,Created\n' + pitchesQuery.rows.map((p) => `${p.id},"${p.title}",${p.genre},${p.status},${p.created_at}`).join('\n');
       } else if (exportType === 'analytics') {
-        // TODO(catch-swallow): migrate to safeQuery
-        const analytics = await this.db.query(`
-          SELECT pa.date, pa.views, pa.likes FROM pitch_analytics pa JOIN pitches p ON pa.pitch_id = p.id WHERE p.user_id = $1 ORDER BY pa.date DESC LIMIT 90
-        `, [authResult.user!.id]).catch(() => []);
-        csvContent = 'Date,Views,Likes\n' + analytics.map((a: any) => `${a.date},${a.views},${a.likes}`).join('\n');
+        const analyticsQuery = await safeQuery<Record<string, unknown>>(
+          () => this.db.query(`
+            SELECT pa.date, pa.views, pa.likes FROM pitch_analytics pa JOIN pitches p ON pa.pitch_id = p.id WHERE p.user_id = $1 ORDER BY pa.date DESC LIMIT 90
+          `, [authResult.user!.id]),
+          { fallback: [], context: 'worker.export.analytics' }
+        );
+        csvContent = 'Date,Views,Likes\n' + analyticsQuery.rows.map((a) => `${a.date},${a.views},${a.likes}`).join('\n');
       } else {
         csvContent = 'Export type not supported';
       }
@@ -13336,10 +13345,13 @@ pitchey_analytics_datapoints_per_minute 1250
 
     const builder = new ApiResponseBuilder(request);
     try {
-      // TODO(catch-swallow): migrate to safeQuery
-      const user = await this.db.query(`
-        SELECT verification_status, company_name FROM users WHERE id = $1
-      `, [authResult.user!.id]).catch(() => []);
+      const userQuery = await safeQuery<{ verification_status: string | null; company_name: string | null }>(
+        () => this.db.query(`
+          SELECT verification_status, company_name FROM users WHERE id = $1
+        `, [authResult.user!.id]),
+        { fallback: [], context: 'worker.company-verify.status' }
+      );
+      const user = userQuery.rows;
 
       return builder.success({
         verified: user[0]?.verification_status === 'verified',
@@ -13375,24 +13387,22 @@ pitchey_analytics_datapoints_per_minute 1250
 
     const builder = new ApiResponseBuilder(request);
     try {
-      const [incoming, outgoing] = await Promise.all([
-        // TODO(catch-swallow): migrate to safeQuery
-        this.db.query(`
+      const [incomingQ, outgoingQ] = await Promise.all([
+        safeQuery<Record<string, unknown>>(() => this.db.query(`
           SELECT ir.*, COALESCE(u.name, u.first_name || ' ' || u.last_name) as requester_name
           FROM info_requests ir
           LEFT JOIN users u ON ir.requester_id = u.id
           WHERE ir.target_user_id = $1 ORDER BY ir.created_at DESC
-        `, [authResult.user!.id]).catch(() => []),
-        // TODO(catch-swallow): migrate to safeQuery
-        this.db.query(`
+        `, [authResult.user!.id]), { fallback: [], context: 'worker.info-requests.incoming' }),
+        safeQuery<Record<string, unknown>>(() => this.db.query(`
           SELECT ir.*, COALESCE(u.name, u.first_name || ' ' || u.last_name) as target_name
           FROM info_requests ir
           LEFT JOIN users u ON ir.target_user_id = u.id
           WHERE ir.requester_id = $1 ORDER BY ir.created_at DESC
-        `, [authResult.user!.id]).catch(() => [])
+        `, [authResult.user!.id]), { fallback: [], context: 'worker.info-requests.outgoing' })
       ]);
 
-      return builder.success({ incoming, outgoing });
+      return builder.success({ incoming: incomingQ.rows, outgoing: outgoingQ.rows });
     } catch (error) {
       return builder.success({ incoming: [], outgoing: [] });
     }
@@ -15484,10 +15494,12 @@ pitchey_analytics_datapoints_per_minute 1250
       const ndaId = parseInt(url.pathname.split('/')[3]);
 
       // Try to find the NDA document in R2
-      // TODO(catch-swallow): migrate to safeQuery
-      const ndaDoc = await this.db.query(`SELECT document_url FROM ndas WHERE id = $1`, [ndaId]).catch(() => []);
-      if (ndaDoc[0]?.document_url) {
-        return this.jsonResponse({ success: true, data: { downloadUrl: ndaDoc[0].document_url, message: 'NDA document ready for download' }});
+      const ndaDocQuery = await safeQuery<{ document_url: string | null }>(
+        () => this.db.query(`SELECT document_url FROM ndas WHERE id = $1`, [ndaId]),
+        { fallback: [], context: 'worker.nda.download' }
+      );
+      if (ndaDocQuery.rows[0]?.document_url) {
+        return this.jsonResponse({ success: true, data: { downloadUrl: ndaDocQuery.rows[0].document_url, message: 'NDA document ready for download' }});
       }
       return this.jsonResponse({ success: false, error: { message: 'NDA document not yet generated. Please sign the NDA first.' }}, 404);
 
@@ -15507,10 +15519,12 @@ pitchey_analytics_datapoints_per_minute 1250
       const url = new URL(request.url);
       const ndaId = parseInt(url.pathname.split('/')[3]);
 
-      // TODO(catch-swallow): migrate to safeQuery
-      const ndaDoc = await this.db.query(`SELECT signed_document_url FROM ndas WHERE id = $1`, [ndaId]).catch(() => []);
-      if (ndaDoc[0]?.signed_document_url) {
-        return this.jsonResponse({ success: true, data: { downloadUrl: ndaDoc[0].signed_document_url, message: 'Signed NDA document ready for download' }});
+      const ndaDocQuery = await safeQuery<{ signed_document_url: string | null }>(
+        () => this.db.query(`SELECT signed_document_url FROM ndas WHERE id = $1`, [ndaId]),
+        { fallback: [], context: 'worker.nda.download-signed' }
+      );
+      if (ndaDocQuery.rows[0]?.signed_document_url) {
+        return this.jsonResponse({ success: true, data: { downloadUrl: ndaDocQuery.rows[0].signed_document_url, message: 'Signed NDA document ready for download' }});
       }
       return this.jsonResponse({ success: false, error: { message: 'Signed NDA document not available.' }}, 404);
 
@@ -18018,43 +18032,52 @@ Signatures: [To be completed upon signing]
         );
 
         // Top pitches by views
-        // TODO(catch-swallow): migrate to safeQuery
-        const topPitchesRes = await this.db.query(
-          `SELECT id, title, COALESCE(view_count, 0) as views, COALESCE(like_count, 0) as likes
-           FROM pitches WHERE user_id = $1 AND status = 'published'
-           ORDER BY view_count DESC NULLS LAST LIMIT 5`,
-          [userId]
-        ).catch(() => []);
+        const topPitchesQuery = await safeQuery<Record<string, unknown>>(
+          () => this.db.query(
+            `SELECT id, title, COALESCE(view_count, 0) as views, COALESCE(like_count, 0) as likes
+             FROM pitches WHERE user_id = $1 AND status = 'published'
+             ORDER BY view_count DESC NULLS LAST LIMIT 5`,
+            [userId]
+          ),
+          { fallback: [], context: 'worker.creator-analytics.top-pitches' }
+        );
+        const topPitchesRes = topPitchesQuery.rows;
 
         // NDA counts
-        // TODO(catch-swallow): migrate to safeQuery
-        const ndaRes = await this.db.query(
-          `SELECT
-            COUNT(*) FILTER (WHERE nr.status = 'pending') as nda_requests,
-            COUNT(*) FILTER (WHERE nr.status = 'approved') as nda_signed
-           FROM nda_requests nr
-           JOIN pitches p ON nr.pitch_id = p.id
-           WHERE p.user_id = $1`,
-          [userId]
-        ).catch(() => [{ nda_requests: 0, nda_signed: 0 }]);
+        const ndaQuery = await safeQuery<{ nda_requests: number; nda_signed: number }>(
+          () => this.db.query(
+            `SELECT
+              COUNT(*) FILTER (WHERE nr.status = 'pending') as nda_requests,
+              COUNT(*) FILTER (WHERE nr.status = 'approved') as nda_signed
+             FROM nda_requests nr
+             JOIN pitches p ON nr.pitch_id = p.id
+             WHERE p.user_id = $1`,
+            [userId]
+          ),
+          { fallback: [{ nda_requests: 0, nda_signed: 0 }], context: 'worker.creator-analytics.nda-counts' }
+        );
+        const ndaRes = ndaQuery.rows;
 
         const stats = pitchStats[0] || {};
-        const ndas = ndaRes[0] || {};
+        const ndas = ndaRes[0] || { nda_requests: 0, nda_signed: 0 };
 
         // Audience breakdown from views table
-        // TODO(catch-swallow): migrate to safeQuery
-        const viewerTypesRes = await this.db.query(
-          `SELECT COALESCE(u.user_type, 'visitor') AS user_type, COUNT(*)::int AS count
-           FROM views v
-           JOIN pitches p ON p.id = v.pitch_id
-           LEFT JOIN users u ON u.id = v.viewer_id
-           WHERE p.user_id = $1 AND v.viewer_id IS DISTINCT FROM $1
-           GROUP BY u.user_type`,
-          [userId]
-        ).catch(() => []);
+        const viewerTypesQuery = await safeQuery<{ user_type: string | null; count: number }>(
+          () => this.db.query(
+            `SELECT COALESCE(u.user_type, 'visitor') AS user_type, COUNT(*)::int AS count
+             FROM views v
+             JOIN pitches p ON p.id = v.pitch_id
+             LEFT JOIN users u ON u.id = v.viewer_id
+             WHERE p.user_id = $1 AND v.viewer_id IS DISTINCT FROM $1
+             GROUP BY u.user_type`,
+            [userId]
+          ),
+          { fallback: [], context: 'worker.creator-analytics.viewer-types' }
+        );
+        const viewerTypesRes = viewerTypesQuery.rows;
 
-        const viewerTotal = viewerTypesRes.reduce((sum: number, r: any) => sum + Number(r.count), 0);
-        const audienceBreakdown = viewerTypesRes.map((r: any) => ({
+        const viewerTotal = viewerTypesRes.reduce((sum: number, r) => sum + Number(r.count), 0);
+        const audienceBreakdown = viewerTypesRes.map((r) => ({
           userType: r.user_type || 'visitor',
           count: Number(r.count),
           percentage: viewerTotal > 0 ? Math.round((Number(r.count) / viewerTotal) * 100) : 0

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -16,7 +16,7 @@ import * as Sentry from '@sentry/cloudflare';
 import { createAxiomLogger } from './middleware/axiom-logging';
 // Per-request trace context for SQLCommenter + Axiom query correlation
 import { traceStorage } from './db/trace-context';
-import { safeQuery } from './db/safe-query';
+import { safeQuery, observedSwallowReturning } from './db/safe-query';
 
 import { createDatabase } from './db/raw-sql-connection';
 import { UserProfileRoutes } from './routes/user-profile';
@@ -9980,8 +9980,11 @@ pitchey_analytics_datapoints_per_minute 1250
             const subId = session.subscription;
             let sub = null;
             if (subId) {
-              // TODO(catch-swallow): bucket-B breadcrumb pending — stripe.getSubscription, caller checks null
-              sub = await stripe.getSubscription(subId).catch(() => null);
+              sub = await observedSwallowReturning(
+                () => stripe.getSubscription(subId),
+                'stripe-webhook.checkout-session.get-subscription',
+                null,
+              );
             }
 
             const tierId = session.metadata?.tier || 'unknown';
@@ -10109,8 +10112,11 @@ pitchey_analytics_datapoints_per_minute 1250
             userId = historyRows[0].user_id;
             tierId = historyRows[0].new_tier;
           } else {
-            // TODO(catch-swallow): bucket-B breadcrumb pending — stripe.getSubscription, caller checks null
-            const sub = await stripe.getSubscription(subId).catch(() => null);
+            const sub = await observedSwallowReturning(
+              () => stripe.getSubscription(subId),
+              'stripe-webhook.invoice-paid.get-subscription',
+              null,
+            );
             const metaUserId = parseInt(sub?.metadata?.userId || '');
             const metaTier = sub?.metadata?.tier;
             if (metaUserId && metaTier) {
@@ -12990,12 +12996,15 @@ pitchey_analytics_datapoints_per_minute 1250
     try {
       const body = await request.json() as Record<string, unknown>;
 
-      // TODO(catch-swallow): bucket-B breadcrumb pending — INSERT scheduled_reports returning null; caller checks null
-      const result = await this.db.query(`
-        INSERT INTO scheduled_reports (user_id, report_type, frequency, filters, next_run, created_at)
-        VALUES ($1, $2, $3, $4, NOW() + INTERVAL '1 day', NOW())
-        RETURNING id, next_run
-      `, [authResult.user!.id, (body.type as string) || 'analytics', (body.frequency as string) || 'weekly', JSON.stringify(body.filters || {})]).catch(() => null);
+      const result = await observedSwallowReturning(
+        () => this.db.query(`
+          INSERT INTO scheduled_reports (user_id, report_type, frequency, filters, next_run, created_at)
+          VALUES ($1, $2, $3, $4, NOW() + INTERVAL '1 day', NOW())
+          RETURNING id, next_run
+        `, [authResult.user!.id, (body.type as string) || 'analytics', (body.frequency as string) || 'weekly', JSON.stringify(body.filters || {})]),
+        'scheduled-report.insert',
+        null,
+      );
 
       if (result && result[0]) {
         return builder.success({ success: true, reportId: result[0].id, nextRun: result[0].next_run });
@@ -13227,18 +13236,21 @@ pitchey_analytics_datapoints_per_minute 1250
       const body = await request.json() as Record<string, unknown>;
 
       // Create a calendar event for the meeting
-      // TODO(catch-swallow): bucket-B breadcrumb pending — INSERT calendar_events returning null; caller checks null
-      const result = await this.db.query(`
-        INSERT INTO calendar_events (user_id, title, description, start_date, end_date, event_type, color, created_at)
-        VALUES ($1, $2, $3, $4, $5, 'meeting', '#3b82f6', NOW())
-        RETURNING id, title, start_date
-      `, [
-        authResult.user!.id,
-        `Meeting: ${body.meetingType || 'general'}`,
-        (body.message as string) || '',
-        (body.dateTime as string) || new Date().toISOString(),
-        body.dateTime ? new Date(new Date(body.dateTime as string).getTime() + ((body.duration as number) || 60) * 60000).toISOString() : new Date(Date.now() + 3600000).toISOString()
-      ]).catch(() => null);
+      const result = await observedSwallowReturning(
+        () => this.db.query(`
+          INSERT INTO calendar_events (user_id, title, description, start_date, end_date, event_type, color, created_at)
+          VALUES ($1, $2, $3, $4, $5, 'meeting', '#3b82f6', NOW())
+          RETURNING id, title, start_date
+        `, [
+          authResult.user!.id,
+          `Meeting: ${body.meetingType || 'general'}`,
+          (body.message as string) || '',
+          (body.dateTime as string) || new Date().toISOString(),
+          body.dateTime ? new Date(new Date(body.dateTime as string).getTime() + ((body.duration as number) || 60) * 60000).toISOString() : new Date(Date.now() + 3600000).toISOString()
+        ]),
+        'meeting.calendar-event-insert',
+        null,
+      );
 
       if (result && result[0]) {
         return builder.success({
@@ -13393,11 +13405,14 @@ pitchey_analytics_datapoints_per_minute 1250
     const builder = new ApiResponseBuilder(request);
     try {
       const body = await request.json() as Record<string, unknown>;
-      // TODO(catch-swallow): bucket-B breadcrumb pending — INSERT info_requests returning null; caller checks null
-      const result = await this.db.query(`
-        INSERT INTO info_requests (requester_id, target_user_id, pitch_id, message, status, created_at)
-        VALUES ($1, $2, $3, $4, 'pending', NOW()) RETURNING *
-      `, [authResult.user!.id, body.targetUserId as string | number, (body.pitchId as string | number | null) || null, (body.message as string) || '']).catch(() => null);
+      const result = await observedSwallowReturning(
+        () => this.db.query(`
+          INSERT INTO info_requests (requester_id, target_user_id, pitch_id, message, status, created_at)
+          VALUES ($1, $2, $3, $4, 'pending', NOW()) RETURNING *
+        `, [authResult.user!.id, body.targetUserId as string | number, (body.pitchId as string | number | null) || null, (body.message as string) || '']),
+        'info-request.insert',
+        null,
+      );
 
       if (result && result[0]) {
         return builder.success(result[0]);
@@ -13416,11 +13431,14 @@ pitchey_analytics_datapoints_per_minute 1250
     const params = (request as any).params;
     try {
       const body = await request.json() as Record<string, unknown>;
-      // TODO(catch-swallow): bucket-B breadcrumb pending — UPDATE info_requests returning null; caller checks null
-      const result = await this.db.query(`
-        UPDATE info_requests SET response = $1, status = 'responded', updated_at = NOW()
-        WHERE id = $2 AND target_user_id = $3 RETURNING *
-      `, [body.response, params.id, authResult.user!.id]).catch(() => null);
+      const result = await observedSwallowReturning(
+        () => this.db.query(`
+          UPDATE info_requests SET response = $1, status = 'responded', updated_at = NOW()
+          WHERE id = $2 AND target_user_id = $3 RETURNING *
+        `, [body.response, params.id, authResult.user!.id]),
+        'info-request.respond',
+        null,
+      );
 
       if (result && result[0]) {
         return builder.success(result[0]);
@@ -13439,11 +13457,14 @@ pitchey_analytics_datapoints_per_minute 1250
     const params = (request as any).params;
     try {
       const body = await request.json() as Record<string, unknown>;
-      // TODO(catch-swallow): bucket-B breadcrumb pending — UPDATE info_requests returning null; caller checks null
-      const result = await this.db.query(`
-        UPDATE info_requests SET status = $1, updated_at = NOW()
-        WHERE id = $2 AND (requester_id = $3 OR target_user_id = $3) RETURNING *
-      `, [body.status, params.id, authResult.user!.id]).catch(() => null);
+      const result = await observedSwallowReturning(
+        () => this.db.query(`
+          UPDATE info_requests SET status = $1, updated_at = NOW()
+          WHERE id = $2 AND (requester_id = $3 OR target_user_id = $3) RETURNING *
+        `, [body.status, params.id, authResult.user!.id]),
+        'info-request.update',
+        null,
+      );
 
       if (result && result[0]) {
         return builder.success(result[0]);
@@ -13460,8 +13481,11 @@ pitchey_analytics_datapoints_per_minute 1250
       const body = await request.json() as Record<string, unknown>;
 
       // Log demo request (may or may not have auth)
-      // TODO(catch-swallow): bucket-B breadcrumb pending — auth-optional fallback; auth backend errors should be visible
-      const authResult = await this.requireAuth(request).catch(() => ({ authorized: false, user: null }));
+      const authResult = await observedSwallowReturning(
+        () => this.requireAuth(request),
+        'demo-request.auth-optional',
+        { authorized: false, user: null },
+      );
 
       // fire-and-forget — demo-request insert; non-fatal
       await this.db.query(`


### PR DESCRIPTION
## Summary

Final Phase 2 sweep. Migrates the **36 bucket-C sites** in \`worker-integrated.ts\` to \`safeQuery\`. After all four Phase 2 PRs land, the gate counts **0 untagged AND 0 bucket-C** across the entire \`src/\` tree (with and without \`worker-integrated.ts\` in scope).

Stacked on **#88** (Phase 1b B-site wrap) so the prerequisite tag sweep (#87) and the 8 bucket-B wraps are in scope before this PR migrates the bucket-Cs.

## Coverage by handler block

| Block | Lines | Sites | Concern |
|---|---|---|---|
| Analytics dashboard | ~8740–8892 | 6 | period metrics + 5 timeline reads |
| Market intelligence | ~12047–12124 | 5 | trends, genres, summary, genre perf, forecast |
| \`handlePollAll\` | ~12734–12779 | 4 | notifications, unread count, presence, messages |
| \`getRealtimeAnalytics\` | ~12879–12903 | 5 | active users, views, new pitches, investments, genres |
| Misc handlers | ~13025–13287 | 8 | scheduled reports, search history, browse, export |
| Company verify + info reqs | ~13348–13400 | 3 | verify status, info requests in/out |
| NDA download | ~15497–15520 | 2 | document URL, signed URL |
| Creator analytics fallback | ~18030–18068 | 3 | top pitches, NDA counts, audience breakdown |
| **Total** | | **36** | |

## Pattern conventions (consistent with #92 + #93 + #94)

- Reads with default-shape fallbacks: default \`report: true\`
- Sentry context tags follow \`worker.<handler>.<op>\` so fingerprints cluster per handler family:
  - \`worker.analytics.period-metrics\`
  - \`worker.poll-all.notifications\`
  - \`worker.realtime.active-users\`
  - \`worker.market.trends\`
  - \`worker.browse.top-rated.list\`
  - … (36 total)

## Type discipline

- Row-consuming sites carry explicit generics (\`Record<string, unknown>\` for \`SELECT *\`, narrower for known columns).
- Several aggregate query results moved from implicit \`any\` casts to typed row shapes:
  \`PeriodMetricsRow\`, \`TopRatedStatsRow\`, \`{ count: number }\`, \`{ total: number }\`, \`{ genre: string }\`, etc.
- Removed several \`(x: any) => …\` callbacks where the new generic propagates.

## Special pattern: scalar extraction with .then chains

Several sites used \`.then([r]) => safeParseInt(r?.count)).catch(() => 0)\` to collapse a row → scalar. The migration preserves the scalar shape:

\`\`\`ts
// Before
const activeUsers = await this.db.query(\`SELECT COUNT(*) as count FROM …\`)
  .then(([r]) => this.safeParseInt(r?.count))
  .catch(() => 0);

// After
const activeUsersQ = await safeQuery<{ count: number }>(
  () => this.db.query(\`SELECT COUNT(*) as count FROM …\`),
  { fallback: [{ count: 0 }], context: 'worker.realtime.active-users' }
);
const activeUsers = this.safeParseInt(activeUsersQ.rows[0]?.count);
\`\`\`

## Verification

\`\`\`
$ node scripts/catch-swallow-gate.mjs --include-worker
Scope: src/ (incl. worker-integrated.ts)
…
  C. TODO(catch-swallow):         97  ← Phase 2.1/2.2/2.3 in other files; drops to 0 when those land
  Untagged (gate metric):         0
\`\`\`

- **Bucket C in \`worker-integrated.ts\` itself**: 36 → 0 ✓
- **tsc --noEmit**: zero new errors. Three pre-existing errors at lines 20797/20864/20928 (\`Cannot find module './db'\`) are unrelated to this migration.

## Test plan

- [x] \`grep TODO\(catch-swallow\) src/worker-integrated.ts\` → 0
- [x] tsc --noEmit clean for \`worker-integrated.ts\` (only pre-existing \`./db\` import errors remain)
- [ ] Live verification post-merge — high-traffic paths:
  - \`/api/poll-all\` — combined poll endpoint (every 15-30s while users are active)
  - \`/api/analytics/realtime\` — realtime dashboard
  - \`/api/browse/top-rated\` + \`/api/browse/top-rated/stats\`
  - \`/api/market-intelligence/*\`
- [ ] Sentry: confirm \`safe_query.context\` tags surface on any errored fingerprint, especially \`worker.poll-all.*\` (highest traffic)

## Stack

\`\`\`
main
  ← #86 observedSwallow helper
    ← #87 Phase 1b tag sweep (worker-integrated)
      ← #88 Phase 1b B-site wrap (worker-integrated)
        ← this PR: Phase 2.4 worker-integrated → safeQuery (36 sites)
\`\`\`

When #86 → #87 → #88 land, retarget this PR to \`main\`. (#92, #93, #94 are independent of this stack since they touch different files.)

## After all four Phase 2 PRs land

Bucket C residue across \`src/\` = **0**. Pillar 1 acceptance gate met:
- Untagged \`.catch(() => …)\` < 30 in \`src/\` excl. \`worker-integrated.ts\` ✓
- Including \`worker-integrated.ts\` ✓ (via this PR)

Phase D.4 (orchestrator agent / AIOps) gate (a) is now open. Gate (b) — Phase C.1 rollback drill verified end-to-end — remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)