### PR TITLE
Phase 2.3: creator + grab-bag → safeQuery (33 sites — replaces #94)

### DIFF
--- a/src/handlers/ai-pitch-extract.ts
+++ b/src/handlers/ai-pitch-extract.ts
@@ -8,7 +8,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId } from '../utils/auth-extract';
-import { observedSwallow } from '../db/safe-query';
+import { observedSwallow, safeQuery } from '../db/safe-query';
 
 const AI_EXTRACT_CREDIT_COST = 5;
 
@@ -67,12 +67,15 @@ export async function aiPitchExtract(request: Request, env: Env): Promise<Respon
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
   try {
-    // Credit check
-    // TODO(catch-swallow): migrate to safeQuery — gate-feeding, fail-closed but operator-blind on credit table outage
-    const creditRows = await sql`
+    // Credit check — gate-feeding. Fail closed on credit-table outage AND surface to Sentry.
+    const creditRows = await safeQuery<{ balance: number | string }>(() => sql`
       SELECT balance FROM user_credits WHERE user_id = ${Number(userId)}
-    `.catch(() => []);
-    const balance = Number(creditRows[0]?.balance) || 0;
+    `, { fallback: [], context: 'ai-pitch-extract.credit-check' });
+
+    if (!creditRows.ok) {
+      return errorResponse('Credit check temporarily unavailable. Please retry.', origin, 503);
+    }
+    const balance = Number(creditRows.rows[0]?.balance) || 0;
 
     if (balance < AI_EXTRACT_CREDIT_COST) {
       return errorResponse(`Insufficient credits. AI extraction costs ${AI_EXTRACT_CREDIT_COST} credits. You have ${balance}.`, origin, 402);

--- a/src/handlers/ai-production-autofill.ts
+++ b/src/handlers/ai-production-autofill.ts
@@ -10,7 +10,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId } from '../utils/auth-extract';
-import { observedSwallow } from '../db/safe-query';
+import { observedSwallow, safeQuery } from '../db/safe-query';
 
 const AUTOFILL_CREDIT_COST = 5;
 
@@ -86,12 +86,16 @@ export async function aiProductionAutofill(request: Request, env: Env): Promise<
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
   try {
-    // Credit check
-    // TODO(catch-swallow): migrate to safeQuery — gate-feeding, fail-closed but operator-blind on credit table outage
-    const creditRows = await sql`
+    // Credit check — gate-feeding. Fail closed on credit-table outage (don't grant
+    // access on a query exception) AND surface the failure to Sentry so we know.
+    const creditRows = await safeQuery<{ balance: number | string }>(() => sql`
       SELECT balance FROM user_credits WHERE user_id = ${Number(userId)}
-    `.catch(() => []);
-    const balance = Number(creditRows[0]?.balance) || 0;
+    `, { fallback: [], context: 'ai-production-autofill.credit-check' });
+
+    if (!creditRows.ok) {
+      return errorResponse('Credit check temporarily unavailable. Please retry.', origin, 503);
+    }
+    const balance = Number(creditRows.rows[0]?.balance) || 0;
 
     if (balance < AUTOFILL_CREDIT_COST) {
       return errorResponse(`Insufficient credits. Auto-fill costs ${AUTOFILL_CREDIT_COST} credits. You have ${balance}.`, origin, 402);

--- a/src/handlers/collaborator.ts
+++ b/src/handlers/collaborator.ts
@@ -8,6 +8,7 @@ import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getAuthenticatedUser, getUserId } from '../utils/auth-extract';
 import { sendCollaboratorInviteEmail, sendCollaboratorAcceptedEmail } from '../services/email/index';
+import { safeQuery } from '../db/safe-query';
 
 const VALID_ROLES = ['director', 'line_producer', 'dp', 'production_designer', 'editor', 'sound_designer', 'custom'] as const;
 const VALID_NOTE_CATEGORIES = ['casting', 'location', 'budget', 'schedule', 'team', 'general'] as const;
@@ -660,13 +661,12 @@ export async function getCollaborationChecklist(request: Request, env: Env): Pro
     `;
     if (pipeline.length === 0) return errorResponse('Project not found', origin, 404);
 
-    // TODO(catch-swallow): migrate to safeQuery — empty result hides schema drift on production_checklists
-    const result = await sql`
+    const result = await safeQuery<{ checklist: Record<string, unknown> }>(() => sql`
       SELECT checklist FROM production_checklists
       WHERE user_id = ${pipeline[0].production_company_id} AND pitch_id = ${projectId}
-    `.catch(() => []);
+    `, { fallback: [], context: 'collaborator.checklist.read' });
 
-    const checklist = result.length > 0 ? result[0].checklist : {};
+    const checklist = result.rows.length > 0 ? result.rows[0].checklist : {};
 
     return jsonResponse({ success: true, data: { checklist, my_role: collab.role } }, origin);
   } catch (err) {
@@ -765,15 +765,14 @@ export async function getCollaborationNotes(request: Request, env: Env): Promise
 
     // Get notes from production_notes (owner's notes) + collaborator-created notes
     const pitchId = pipeline[0].pitch_id || projectId;
-    // TODO(catch-swallow): migrate to safeQuery — empty result hides schema drift on production_notes
-    const notes = await sql`
+    const notesResult = await safeQuery(() => sql`
       SELECT id, content, category, author, created_at, updated_at
       FROM production_notes
       WHERE pitch_id = ${pitchId}
       ORDER BY created_at ASC
-    `.catch(() => []);
+    `, { fallback: [], context: 'collaborator.notes.read' });
 
-    return jsonResponse({ success: true, data: { notes } }, origin);
+    return jsonResponse({ success: true, data: { notes: notesResult.rows } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('getCollaborationNotes error:', e.message);

--- a/src/handlers/creator-dashboard-extended.ts
+++ b/src/handlers/creator-dashboard-extended.ts
@@ -7,6 +7,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { ApiResponseBuilder, ErrorCode } from '../utils/api-response';
 import { requireRole } from '../utils/auth-extract';
+import { safeQuery } from '../db/safe-query';
 
 // ---------------------------------------------------------------------------
 // Revenue
@@ -25,8 +26,7 @@ export async function creatorRevenueTrendsHandler(request: Request, env: Env): P
     const url = new URL(request.url);
     const months = Math.min(24, Math.max(1, Number(url.searchParams.get('months')) || 12));
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const trends = await sql`
+    const trendsResult = await safeQuery(() => sql`
       SELECT
         TO_CHAR(transaction_date, 'YYYY-MM') AS month,
         SUM(amount)::numeric AS total,
@@ -36,9 +36,9 @@ export async function creatorRevenueTrendsHandler(request: Request, env: Env): P
         AND transaction_date >= NOW() - (${months} || ' months')::interval
       GROUP BY TO_CHAR(transaction_date, 'YYYY-MM')
       ORDER BY month ASC
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.revenue.trends' });
 
-    return ApiResponseBuilder.success({ trends });
+    return ApiResponseBuilder.success({ trends: trendsResult.rows });
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('creatorRevenueTrendsHandler error:', e.message);
@@ -57,8 +57,7 @@ export async function creatorRevenueBreakdownHandler(request: Request, env: Env)
   try {
     const userId = Number(roleCheck.user.id);
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const breakdown = await sql`
+    const breakdownResult = await safeQuery(() => sql`
       SELECT
         revenue_type AS type,
         SUM(amount)::numeric AS total,
@@ -67,18 +66,17 @@ export async function creatorRevenueBreakdownHandler(request: Request, env: Env)
       WHERE creator_id = ${userId}
       GROUP BY revenue_type
       ORDER BY total DESC
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.revenue.breakdown' });
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const totalResult = await sql`
+    const totalResult = await safeQuery<{ grand_total: number }>(() => sql`
       SELECT COALESCE(SUM(amount), 0)::numeric AS grand_total
       FROM creator_revenue
       WHERE creator_id = ${userId}
-    `.catch(() => [{ grand_total: 0 }]);
+    `, { fallback: [{ grand_total: 0 }], context: 'creator-dashboard.revenue.total' });
 
     return ApiResponseBuilder.success({
-      breakdown,
-      total: Number(totalResult[0]?.grand_total) || 0,
+      breakdown: breakdownResult.rows,
+      total: Number(totalResult.rows[0]?.grand_total) || 0,
     });
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
@@ -106,20 +104,20 @@ export async function creatorContractDetailsHandler(request: Request, env: Env):
   try {
     const userId = Number(roleCheck.user.id);
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const result = await sql`
+    const result = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT c.*,
              COALESCE(u.name, u.first_name || ' ' || u.last_name) AS counterparty_display_name
       FROM contracts c
       LEFT JOIN users u ON c.counterparty_id = u.id
       WHERE c.id = ${contractId} AND c.creator_id = ${userId}
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.contract.details' });
 
-    if (result.length === 0) {
+    if (!result.ok) return ApiResponseBuilder.error(ErrorCode.INTERNAL_ERROR, 'Failed to fetch contract');
+    if (result.rows.length === 0) {
       return ApiResponseBuilder.error(ErrorCode.NOT_FOUND, 'Contract not found');
     }
 
-    return ApiResponseBuilder.success({ contract: result[0] });
+    return ApiResponseBuilder.success({ contract: result.rows[0] });
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('creatorContractDetailsHandler error:', e.message);
@@ -147,8 +145,7 @@ export async function creatorContractUpdateHandler(request: Request, env: Env): 
     const status = typeof body.status === 'string' ? body.status : undefined;
     const notes = typeof body.notes === 'string' ? body.notes : undefined;
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const result = await sql`
+    const result = await safeQuery<Record<string, unknown>>(() => sql`
       UPDATE contracts
       SET
         title = COALESCE(${title ?? null}, title),
@@ -157,13 +154,14 @@ export async function creatorContractUpdateHandler(request: Request, env: Env): 
         updated_at = NOW()
       WHERE id = ${contractId} AND creator_id = ${userId}
       RETURNING *
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.contract.update' });
 
-    if (result.length === 0) {
+    if (!result.ok) return ApiResponseBuilder.error(ErrorCode.INTERNAL_ERROR, 'Failed to update contract');
+    if (result.rows.length === 0) {
       return ApiResponseBuilder.error(ErrorCode.NOT_FOUND, 'Contract not found');
     }
 
-    return ApiResponseBuilder.success({ contract: result[0] });
+    return ApiResponseBuilder.success({ contract: result.rows[0] });
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('creatorContractUpdateHandler error:', e.message);
@@ -187,8 +185,8 @@ export async function creatorEngagementHandler(request: Request, env: Env): Prom
     const userId = Number(roleCheck.user.id);
 
     // Aggregate views and likes across all creator's pitches
-    // TODO(catch-swallow): migrate to safeQuery
-    const viewStats = await sql`
+    type ViewStatsRow = { total_views: number; unique_viewers: number; avg_view_duration: number };
+    const viewStats = await safeQuery<ViewStatsRow>(() => sql`
       SELECT
         COUNT(*)::int AS total_views,
         COUNT(DISTINCT pv.viewer_id)::int AS unique_viewers,
@@ -196,19 +194,17 @@ export async function creatorEngagementHandler(request: Request, env: Env): Prom
       FROM pitch_views pv
       JOIN pitches p ON pv.pitch_id = p.id
       WHERE p.user_id = ${userId}
-    `.catch(() => [{ total_views: 0, unique_viewers: 0, avg_view_duration: 0 }]);
+    `, { fallback: [{ total_views: 0, unique_viewers: 0, avg_view_duration: 0 }], context: 'creator-dashboard.engagement.views' });
 
-    // TODO(catch-swallow): migrate to safeQuery
-    const likeStats = await sql`
+    const likeStats = await safeQuery<{ total_likes: number }>(() => sql`
       SELECT COUNT(*)::int AS total_likes
       FROM pitch_likes pl
       JOIN pitches p ON pl.pitch_id = p.id
       WHERE p.user_id = ${userId}
-    `.catch(() => [{ total_likes: 0 }]);
+    `, { fallback: [{ total_likes: 0 }], context: 'creator-dashboard.engagement.likes' });
 
     // Per-pitch breakdown
-    // TODO(catch-swallow): migrate to safeQuery
-    const pitchEngagement = await sql`
+    const pitchEngagement = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT
         p.id, p.title,
         COUNT(DISTINCT pv.id)::int AS views,
@@ -220,19 +216,19 @@ export async function creatorEngagementHandler(request: Request, env: Env): Prom
       GROUP BY p.id, p.title
       ORDER BY views DESC
       LIMIT 20
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.engagement.per-pitch' });
 
-    const totalViews = Number(viewStats[0]?.total_views) || 0;
-    const totalLikes = Number(likeStats[0]?.total_likes) || 0;
+    const totalViews = Number(viewStats.rows[0]?.total_views) || 0;
+    const totalLikes = Number(likeStats.rows[0]?.total_likes) || 0;
 
     return ApiResponseBuilder.success({
       engagement: {
         totalViews,
-        uniqueViewers: Number(viewStats[0]?.unique_viewers) || 0,
+        uniqueViewers: Number(viewStats.rows[0]?.unique_viewers) || 0,
         totalLikes,
-        avgViewDuration: Number(viewStats[0]?.avg_view_duration) || 0,
+        avgViewDuration: Number(viewStats.rows[0]?.avg_view_duration) || 0,
         engagementRate: totalViews > 0 ? Math.round((totalLikes / totalViews) * 100) : 0,
-        pitchBreakdown: pitchEngagement,
+        pitchBreakdown: pitchEngagement.rows,
       },
     });
   } catch (err) {
@@ -258,8 +254,7 @@ export async function creatorDemographicsHandler(request: Request, env: Env): Pr
     const userId = Number(roleCheck.user.id);
 
     // Viewer types (creator, investor, production)
-    // TODO(catch-swallow): migrate to safeQuery
-    const viewerTypes = await sql`
+    const viewerTypes = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT
         COALESCE(u.user_type, 'anonymous') AS viewer_type,
         COUNT(*)::int AS count
@@ -269,11 +264,10 @@ export async function creatorDemographicsHandler(request: Request, env: Env): Pr
       WHERE p.user_id = ${userId}
       GROUP BY COALESCE(u.user_type, 'anonymous')
       ORDER BY count DESC
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.demographics.viewer-types' });
 
     // View types (direct, browse, search, etc.)
-    // TODO(catch-swallow): migrate to safeQuery
-    const viewSources = await sql`
+    const viewSources = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT
         COALESCE(pv.view_type, 'direct') AS source,
         COUNT(*)::int AS count
@@ -282,12 +276,12 @@ export async function creatorDemographicsHandler(request: Request, env: Env): Pr
       WHERE p.user_id = ${userId}
       GROUP BY COALESCE(pv.view_type, 'direct')
       ORDER BY count DESC
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.demographics.view-sources' });
 
     return ApiResponseBuilder.success({
       demographics: {
-        viewerTypes,
-        viewSources,
+        viewerTypes: viewerTypes.rows,
+        viewSources: viewSources.rows,
       },
     });
   } catch (err) {
@@ -318,23 +312,21 @@ export async function creatorInvestorCommunicationHandler(request: Request, env:
     const userId = Number(roleCheck.user.id);
 
     // Find conversations where both users are participants
-    // TODO(catch-swallow): migrate to safeQuery
-    const conversations = await sql`
+    const conversationsResult = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT DISTINCT c.id, c.title, c.type, c.created_at, c.updated_at
       FROM conversations c
       JOIN conversation_participants cp1 ON cp1.conversation_id = c.id AND cp1.user_id = ${userId}
       JOIN conversation_participants cp2 ON cp2.conversation_id = c.id AND cp2.user_id = ${investorId}
       ORDER BY c.updated_at DESC
       LIMIT 10
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.communication.conversations' });
 
     // Fetch recent messages from those conversations
-    const conversationIds = conversations.map((c: Record<string, unknown>) => Number(c.id));
+    const conversationIds = conversationsResult.rows.map((c) => Number(c.id));
     let messages: unknown[] = [];
 
     if (conversationIds.length > 0) {
-      // TODO(catch-swallow): migrate to safeQuery
-      messages = await sql`
+      const messagesResult = await safeQuery<Record<string, unknown>>(() => sql`
         SELECT m.id, m.conversation_id, m.sender_id, m.content, m.message_type,
                m.created_at, m.is_edited,
                COALESCE(u.name, u.first_name || ' ' || u.last_name) AS sender_name
@@ -344,11 +336,12 @@ export async function creatorInvestorCommunicationHandler(request: Request, env:
           AND m.is_deleted = false
         ORDER BY m.created_at DESC
         LIMIT 50
-      `.catch(() => []);
+      `, { fallback: [], context: 'creator-dashboard.communication.messages' });
+      messages = messagesResult.rows;
     }
 
     return ApiResponseBuilder.success({
-      communications: conversations,
+      communications: conversationsResult.rows,
       messages,
     });
   } catch (err) {
@@ -380,8 +373,7 @@ export async function creatorMessageInvestorHandler(request: Request, env: Env):
     if (!content) return ApiResponseBuilder.error(ErrorCode.VALIDATION_ERROR, 'Message content is required');
 
     // Check if an existing conversation exists between the two users
-    // TODO(catch-swallow): migrate to safeQuery
-    const existing = await sql`
+    const existing = await safeQuery<{ id: number }>(() => sql`
       SELECT c.id
       FROM conversations c
       JOIN conversation_participants cp1 ON cp1.conversation_id = c.id AND cp1.user_id = ${userId}
@@ -389,15 +381,15 @@ export async function creatorMessageInvestorHandler(request: Request, env: Env):
       WHERE c.type = 'direct'
       ORDER BY c.updated_at DESC
       LIMIT 1
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.message.existing-conversation' });
 
     let conversationId: number;
 
-    if (existing.length > 0) {
-      conversationId = Number(existing[0].id);
-      // Update conversation timestamp
-      // TODO(catch-swallow): migrate to safeQuery
-      await sql`UPDATE conversations SET updated_at = NOW() WHERE id = ${conversationId}`.catch(() => []);
+    if (existing.rows.length > 0) {
+      conversationId = Number(existing.rows[0].id);
+      // Update conversation timestamp — best-effort
+      await safeQuery(() => sql`UPDATE conversations SET updated_at = NOW() WHERE id = ${conversationId}`,
+        { fallback: [], context: 'creator-dashboard.message.touch-conversation' });
     } else {
       // Create new conversation
       const conv = await sql`
@@ -407,13 +399,12 @@ export async function creatorMessageInvestorHandler(request: Request, env: Env):
       `;
       conversationId = Number(conv[0].id);
 
-      // Add both participants
-      // TODO(catch-swallow): migrate to safeQuery
-      await sql`
+      // Add both participants — best-effort (Sentry-reported via safeQuery)
+      await safeQuery(() => sql`
         INSERT INTO conversation_participants (conversation_id, user_id, joined_at, is_admin)
         VALUES (${conversationId}, ${userId}, NOW(), true),
                (${conversationId}, ${investorId}, NOW(), false)
-      `.catch(() => []);
+      `, { fallback: [], context: 'creator-dashboard.message.add-participants' });
     }
 
     // Insert the message
@@ -423,16 +414,15 @@ export async function creatorMessageInvestorHandler(request: Request, env: Env):
       RETURNING id, conversation_id, sender_id, content, created_at
     `;
 
-    // Notify the investor
-    // TODO(catch-swallow): migrate to safeQuery
-    await sql`
+    // Notify the investor — best-effort (Sentry-reported via safeQuery)
+    await safeQuery(() => sql`
       INSERT INTO notifications (user_id, type, title, message, related_user_id, created_at)
       VALUES (
         ${investorId}, 'new_message', 'New Message',
         ${'You have a new message from a creator'},
         ${userId}, NOW()
       )
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.message.notify' });
 
     return ApiResponseBuilder.success({
       messageSent: true,

--- a/src/handlers/creator-dashboard.ts
+++ b/src/handlers/creator-dashboard.ts
@@ -478,8 +478,7 @@ export async function creatorPitchAnalyticsHandler(request: Request, env: Env): 
 
     if (isAllPitches) {
       // Get analytics for all creator pitches
-      // TODO(catch-swallow): migrate to safeQuery
-      const pitchesAnalytics = await sql`
+      const pitchesAnalytics = await safeQuery<Record<string, unknown>>(() => sql`
         SELECT
           p.id,
           p.title,
@@ -515,11 +514,11 @@ export async function creatorPitchAnalyticsHandler(request: Request, env: Env): 
         ) inv_count ON p.id = inv_count.pitch_id
         WHERE p.user_id::text = ${userId}
         ORDER BY p.created_at DESC
-      `.catch(() => []);
+      `, { fallback: [], context: 'creator-dashboard.analytics.all-pitches' });
 
       // Get overall analytics summary
-      // TODO(catch-swallow): migrate to safeQuery
-      const summary = await sql`
+      type SummaryRow = { total_views: number; unique_viewers: number; total_saves: number; total_nda_requests: number };
+      const summary = await safeQuery<SummaryRow>(() => sql`
         SELECT
           COALESCE(SUM(pv.view_count), 0) as total_views,
           COALESCE(COUNT(DISTINCT pv.viewer_id), 0) as unique_viewers,
@@ -530,13 +529,13 @@ export async function creatorPitchAnalyticsHandler(request: Request, env: Env): 
         LEFT JOIN saved_pitches sp ON p.id = sp.pitch_id
         LEFT JOIN nda_requests nr ON p.id = nr.pitch_id
         WHERE p.user_id::text = ${userId}
-      `.catch(() => [{ total_views: 0, unique_viewers: 0, total_saves: 0, total_nda_requests: 0 }]);
+      `, { fallback: [{ total_views: 0, unique_viewers: 0, total_saves: 0, total_nda_requests: 0 }], context: 'creator-dashboard.analytics.summary' });
 
       return new Response(JSON.stringify({
         success: true,
         data: {
-          pitches: pitchesAnalytics || [],
-          overview: summary[0] || emptyAnalytics.data.overview,
+          pitches: pitchesAnalytics.rows,
+          overview: summary.rows[0] || emptyAnalytics.data.overview,
           viewHistory: [],
           recommendations: []
         }
@@ -561,17 +560,16 @@ export async function creatorPitchAnalyticsHandler(request: Request, env: Env): 
 
     if (!tableCheck[0]?.exists) {
       // Return basic pitch info without analytics
-      // TODO(catch-swallow): migrate to safeQuery
-      const pitchInfo = await sql`
+      const pitchInfo = await safeQuery<Record<string, unknown>>(() => sql`
         SELECT id, title, genre, status, created_at
         FROM pitches WHERE id::text = ${pitchId}
-      `.catch(() => []);
+      `, { fallback: [], context: 'creator-dashboard.analytics.pitch-info' });
 
       return new Response(JSON.stringify({
         success: true,
         data: {
           ...emptyAnalytics.data,
-          pitch: pitchInfo[0] || null
+          pitch: pitchInfo.rows[0] || null
         }
       }), {
         status: 200,
@@ -580,8 +578,7 @@ export async function creatorPitchAnalyticsHandler(request: Request, env: Env): 
     }
 
     // Get view history
-    // TODO(catch-swallow): migrate to safeQuery
-    const viewHistory = await sql`
+    const viewHistory = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT
         DATE_TRUNC('day', viewed_at) as date,
         COUNT(*) as views,
@@ -591,24 +588,24 @@ export async function creatorPitchAnalyticsHandler(request: Request, env: Env): 
         AND viewed_at >= ${startDate}
       GROUP BY DATE_TRUNC('day', viewed_at)
       ORDER BY date ASC
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.analytics.view-history' });
 
     // Get basic analytics
-    // TODO(catch-swallow): migrate to safeQuery
-    const overview = await sql`
+    type OverviewRow = { total_views: number; unique_viewers: number; avg_view_duration: number };
+    const overview = await safeQuery<OverviewRow>(() => sql`
       SELECT
         COALESCE(SUM(view_count), 0) as total_views,
         COUNT(DISTINCT user_id) as unique_viewers,
         0 as avg_view_duration
       FROM pitch_views
       WHERE pitch_id::text = ${pitchId}
-    `.catch(() => [{ total_views: 0, unique_viewers: 0, avg_view_duration: 0 }]);
+    `, { fallback: [{ total_views: 0, unique_viewers: 0, avg_view_duration: 0 }], context: 'creator-dashboard.analytics.overview' });
 
     return new Response(JSON.stringify({
       success: true,
       data: {
-        overview: overview[0] || emptyAnalytics.data.overview,
-        viewHistory: viewHistory || [],
+        overview: overview.rows[0] || emptyAnalytics.data.overview,
+        viewHistory: viewHistory.rows,
         investment: { total_invested: 0, investor_count: 0 },
         documents: { total: 0, signed: 0 },
         audience: [],
@@ -666,16 +663,15 @@ export async function creatorInvestorsHandler(request: Request, env: Env): Promi
   }
 
   try {
-    // Check if investments table exists
-    // TODO(catch-swallow): migrate to safeQuery
-    const investmentsExist = await sql`
+    // Check if investments table exists — schema probe; don't report to Sentry
+    const investmentsExist = await safeQuery<{ exists: boolean }>(() => sql`
       SELECT EXISTS (
         SELECT FROM information_schema.tables
         WHERE table_schema = 'public' AND table_name = 'investments'
       ) as exists
-    `.catch(() => [{ exists: false }]);
+    `, { fallback: [{ exists: false }], context: 'creator-dashboard.investors.table-probe', report: false });
 
-    if (!investmentsExist[0]?.exists) {
+    if (!investmentsExist.rows[0]?.exists) {
       return new Response(JSON.stringify(emptyResponse), {
         status: 200,
         headers: { 'Content-Type': 'application/json', ...corsHeaders }
@@ -683,8 +679,7 @@ export async function creatorInvestorsHandler(request: Request, env: Env): Promi
     }
 
     // Get investors who have invested in creator's pitches - simplified query
-    // TODO(catch-swallow): migrate to safeQuery
-    const investors = await sql`
+    const investorsResult = await safeQuery<Record<string, unknown>>(() => sql`
       SELECT
         u.id,
         COALESCE(u.name, CONCAT(u.first_name, ' ', u.last_name), u.email) as name,
@@ -710,17 +705,18 @@ export async function creatorInvestorsHandler(request: Request, env: Env): Promi
       GROUP BY u.id, u.name, u.first_name, u.last_name, u.email, u.company_name, u.profile_image, u.location, u.bio
       ORDER BY total_invested DESC
       LIMIT 100
-    `.catch(() => []);
+    `, { fallback: [], context: 'creator-dashboard.investors.list' });
+    const investors = investorsResult.rows;
 
     return new Response(JSON.stringify({
       success: true,
       data: {
-        investors: investors || [],
+        investors,
         communicationSummary: [],
         stats: {
-          totalInvestors: investors?.length || 0,
-          activeInvestors: (investors || []).filter((i: any) => i.activity_status === 'active' || i.activity_status === 'highly_active').length,
-          totalRaised: (investors || []).reduce((sum: number, i: any) => sum + Number(i.total_invested || 0), 0)
+          totalInvestors: investors.length,
+          activeInvestors: investors.filter((i) => i.activity_status === 'active' || i.activity_status === 'highly_active').length,
+          totalRaised: investors.reduce((sum: number, i) => sum + Number(i.total_invested || 0), 0)
         }
       }
     }), {

--- a/src/handlers/investor-pitch-data.ts
+++ b/src/handlers/investor-pitch-data.ts
@@ -8,6 +8,7 @@ import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { getCorsHeaders } from '../utils/response';
 import { getUserId } from '../utils/auth-extract';
+import { safeQuery } from '../db/safe-query';
 
 function jsonResponse(data: unknown, origin: string | null, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -46,15 +47,14 @@ export async function getInvestorNotes(request: Request, env: Env): Promise<Resp
   if (!sql) return jsonResponse({ success: true, data: { notes: [] } }, origin);
 
   try {
-    // TODO(catch-swallow): migrate to safeQuery
-    const notes = await sql`
+    const notesResult = await safeQuery(() => sql`
       SELECT id, content, category, is_private, created_at, updated_at
       FROM investor_notes
       WHERE user_id = ${Number(userId)} AND pitch_id = ${pitchId}
       ORDER BY created_at ASC
-    `.catch(() => []);
+    `, { fallback: [], context: 'investor-pitch-data.notes.list' });
 
-    return jsonResponse({ success: true, data: { notes } }, origin);
+    return jsonResponse({ success: true, data: { notes: notesResult.rows } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error('getInvestorNotes error:', e.message);
@@ -149,14 +149,13 @@ export async function getInvestorDiligence(request: Request, env: Env): Promise<
   if (!sql) return jsonResponse({ success: true, data: { checklist: {} } }, origin);
 
   try {
-    // TODO(catch-swallow): migrate to safeQuery
-    const rows = await sql`
+    const rows = await safeQuery<{ checklist: Record<string, unknown> }>(() => sql`
       SELECT checklist
       FROM investor_diligence_checklists
       WHERE user_id = ${Number(userId)} AND pitch_id = ${pitchId}
-    `.catch(() => []);
+    `, { fallback: [], context: 'investor-pitch-data.diligence.read' });
 
-    const checklist = rows[0]?.checklist || {};
+    const checklist = rows.rows[0]?.checklist || {};
     return jsonResponse({ success: true, data: { checklist } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));

--- a/src/handlers/status-dashboard.ts
+++ b/src/handlers/status-dashboard.ts
@@ -5,6 +5,7 @@
 
 import { WorkerDatabase } from '../services/worker-database';
 import { getCorsHeaders } from '../utils/response';
+import { safeQuery } from '../db/safe-query';
 
 interface ServiceStatus {
   name: string;
@@ -124,31 +125,36 @@ export async function statusDashboardHandler(
     });
 
     // Get request/error counts
-    // TODO(catch-swallow): migrate to safeQuery
-    const metricsQuery = await db.query(`
-      SELECT
-        COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '24 hours') as requests_24h,
-        COUNT(*) FILTER (WHERE status_code >= 500 AND created_at > NOW() - INTERVAL '24 hours') as errors_24h,
-        AVG(response_time) FILTER (WHERE created_at > NOW() - INTERVAL '1 hour') as avg_response_time,
-        PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY response_time)
-          FILTER (WHERE created_at > NOW() - INTERVAL '1 hour') as p95_response_time
-      FROM request_logs
-    `).catch(() => [{ requests_24h: 0, errors_24h: 0, avg_response_time: 0, p95_response_time: 0 }]);
+    type MetricsRow = { requests_24h: number; errors_24h: number; avg_response_time: number; p95_response_time: number };
+    const metricsQuery = await safeQuery<MetricsRow>(
+      () => db.query(`
+        SELECT
+          COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '24 hours') as requests_24h,
+          COUNT(*) FILTER (WHERE status_code >= 500 AND created_at > NOW() - INTERVAL '24 hours') as errors_24h,
+          AVG(response_time) FILTER (WHERE created_at > NOW() - INTERVAL '1 hour') as avg_response_time,
+          PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY response_time)
+            FILTER (WHERE created_at > NOW() - INTERVAL '1 hour') as p95_response_time
+        FROM request_logs
+      `),
+      { fallback: [{ requests_24h: 0, errors_24h: 0, avg_response_time: 0, p95_response_time: 0 }], context: 'status-dashboard.metrics.request-logs' }
+    );
 
     // Get active users
-    // TODO(catch-swallow): migrate to safeQuery
-    const activeUsersQuery = await db.query(`
-      SELECT COUNT(DISTINCT user_id) as active_users
-      FROM sessions
-      WHERE expires_at > NOW()
-    `).catch(() => [{ active_users: 0 }]);
+    const activeUsersQuery = await safeQuery<{ active_users: number }>(
+      () => db.query(`
+        SELECT COUNT(DISTINCT user_id) as active_users
+        FROM sessions
+        WHERE expires_at > NOW()
+      `),
+      { fallback: [{ active_users: 0 }], context: 'status-dashboard.metrics.active-users' }
+    );
 
-    if (metricsQuery && metricsQuery[0]) {
-      const m = metricsQuery[0] as any;
-      dashboard.metrics.requestsLast24h = parseInt(m.requests_24h) || 0;
-      dashboard.metrics.errorsLast24h = parseInt(m.errors_24h) || 0;
-      dashboard.metrics.avgResponseTime = Math.round(parseFloat(m.avg_response_time) || 0);
-      dashboard.metrics.p95ResponseTime = Math.round(parseFloat(m.p95_response_time) || 0);
+    if (metricsQuery.rows[0]) {
+      const m = metricsQuery.rows[0] as Record<string, unknown>;
+      dashboard.metrics.requestsLast24h = parseInt(String(m.requests_24h)) || 0;
+      dashboard.metrics.errorsLast24h = parseInt(String(m.errors_24h)) || 0;
+      dashboard.metrics.avgResponseTime = Math.round(parseFloat(String(m.avg_response_time)) || 0);
+      dashboard.metrics.p95ResponseTime = Math.round(parseFloat(String(m.p95_response_time)) || 0);
 
       const errorRate = dashboard.metrics.requestsLast24h > 0
         ? (dashboard.metrics.errorsLast24h / dashboard.metrics.requestsLast24h * 100).toFixed(2)
@@ -156,8 +162,8 @@ export async function statusDashboardHandler(
       dashboard.metrics.errorRate = `${errorRate}%`;
     }
 
-    if (activeUsersQuery && activeUsersQuery[0]) {
-      dashboard.metrics.activeUsers = parseInt((activeUsersQuery[0] as any).active_users) || 0;
+    if (activeUsersQuery.rows[0]) {
+      dashboard.metrics.activeUsers = parseInt(String(activeUsersQuery.rows[0].active_users)) || 0;
     }
 
   } catch (error) {

--- a/src/services/file-validation.service.ts
+++ b/src/services/file-validation.service.ts
@@ -1,3 +1,5 @@
+import { safeQuery } from '../db/safe-query';
+
 export interface FileValidationResult {
   isValid: boolean;
   errors: string[];
@@ -384,25 +386,33 @@ export class FileValidationService {
 
     let currentUsage = 0;
     let tier = 'free';
+    let quotaLookupFailed = false;
 
     if (db) {
-      try {
-        const [usageResult, userResult] = await Promise.all([
-          // TODO(catch-swallow): migrate to safeQuery — fail-open quota bypass; '0' on error lets user upload past quota
-          db.query(
+      const [usageResult, userResult] = await Promise.all([
+        safeQuery<{ total_bytes: string }>(
+          () => db.query(
             `SELECT COALESCE(SUM(file_size), 0)::bigint AS total_bytes FROM file_storage WHERE user_id = $1`,
             [userId]
-          ).catch(() => [{ total_bytes: '0' }]),
-          // TODO(catch-swallow): migrate to safeQuery
-          db.query(
+          ),
+          { fallback: [{ total_bytes: '0' }], context: 'file-validation.quota.usage' }
+        ),
+        safeQuery<{ subscription_tier: string | null }>(
+          () => db.query(
             `SELECT subscription_tier FROM users WHERE id = $1`,
             [userId]
-          ).catch(() => []),
-        ]);
-        currentUsage = Number(usageResult[0]?.total_bytes) || 0;
-        tier = userResult[0]?.subscription_tier || 'free';
-      } catch {
-        // DB unavailable — allow upload with default quota
+          ),
+          { fallback: [], context: 'file-validation.quota.tier' }
+        ),
+      ]);
+
+      // Fail closed on quota lookup failure — previously this was fail-open (currentUsage=0,
+      // tier=free), which let users upload past quota during a DB outage.
+      if (!usageResult.ok || !userResult.ok) {
+        quotaLookupFailed = true;
+      } else {
+        currentUsage = Number(usageResult.rows[0]?.total_bytes) || 0;
+        tier = userResult.rows[0]?.subscription_tier || 'free';
       }
     }
 
@@ -410,7 +420,7 @@ export class FileValidationService {
     const remainingQuota = maxQuota - currentUsage;
 
     return {
-      allowed: currentUsage + fileSize <= maxQuota,
+      allowed: !quotaLookupFailed && currentUsage + fileSize <= maxQuota,
       currentUsage,
       maxQuota,
       remainingQuota,


### PR DESCRIPTION
Replaces **#94** which was auto-closed when its base branch was deleted. Branch rebased onto main; merged `observedSwallow` and `safeQuery` imports in ai-pitch-extract.ts and ai-production-autofill.ts (both now needed: bucket-B writes use observedSwallow, credit gates use safeQuery). See #94 for full discussion incl. `checkUserQuota` orphan-router clarification.