### PR TITLE
Fix admin login 403 (Turnstile token forwarding) + deploy-skill correction

### DIFF
--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -26,8 +26,10 @@ Ask user for deployment target (staging/production):
 
 #### For Production:
 1. Deploy Worker: `CLOUDFLARE_API_TOKEN=$CLOUDFLARE_API_TOKEN npx wrangler deploy`
-2. Deploy Pages (MUST run from frontend/ dir): `cd frontend && CLOUDFLARE_API_TOKEN=$CLOUDFLARE_API_TOKEN npx wrangler pages deploy dist/ --project-name=pitchey`
-3. Report deployment URLs
+2. Deploy Pages (MUST run from frontend/ dir, MUST pass --branch=main or it publishes a PREVIEW, not canonical pitchey-5o8.pages.dev): `cd frontend && CLOUDFLARE_API_TOKEN=$CLOUDFLARE_API_TOKEN npx wrangler pages deploy dist/ --project-name=pitchey --branch=main`
+3. Report deployment URLs (verify canonical by diffing the live index-*.js asset hash, not just the per-deploy *.pages.dev URL)
+
+NOTE: Do NOT override VITE_API_URL at build time. Production uses VITE_API_URL='' (same-origin via the Pages Functions proxy); pointing it at the worker URL breaks the cookie/CORS model.
 
 #### For Staging:
 1. Deploy Worker: `CLOUDFLARE_API_TOKEN=$CLOUDFLARE_API_TOKEN npx wrangler deploy --env staging`

--- a/src/utils/turnstile.ts
+++ b/src/utils/turnstile.ts
@@ -27,6 +27,7 @@ export async function verifyTurnstileToken(
 
   // Reject if token is missing when Turnstile is configured
   if (!token) {
+    console.error('[turnstile] missing token (secret configured, no response token sent)');
     return { success: false, error: 'Turnstile verification required' };
   }
 
@@ -48,6 +49,10 @@ export async function verifyTurnstileToken(
     const result = await response.json() as TurnstileVerifyResponse;
 
     if (!result.success) {
+      console.error('[turnstile] verify failed', JSON.stringify({
+        codes: result['error-codes'],
+        hostname: result.hostname,
+      }));
       return {
         success: false,
         error: `Turnstile verification failed: ${result['error-codes']?.join(', ') || 'unknown error'}`,

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -1835,22 +1835,11 @@ class RouteRegistry {
       // Route Better Auth sign-in to our portal login handler
       const body = await request.json() as { email?: string; password?: string; userType?: string; turnstileToken?: string };
 
-      // Verify Turnstile token (skip for known demo accounts — password is fixed, no sensitive data)
-      const DEMO_EMAILS = new Set([
-        'alex.creator@demo.com',
-        'sarah.investor@demo.com',
-        'stellar.production@demo.com',
-        'jamie.watcher@demo.com',
-      ]);
-      if (!DEMO_EMAILS.has(String(body.email || '').toLowerCase())) {
-        const turnstileResult = await verifyTurnstileToken(body.turnstileToken, this.env.TURNSTILE_SECRET_KEY, clientIP !== 'unknown' ? clientIP : undefined);
-        if (!turnstileResult.success) {
-          return new Response(JSON.stringify({
-            success: false,
-            error: { code: 'TURNSTILE_FAILED', message: turnstileResult.error || 'Bot verification failed' }
-          }), { status: 403, headers: { 'Content-Type': 'application/json', ...getCorsHeaders(request.headers.get('Origin')) } });
-        }
-      }
+      // NOTE: Turnstile is verified once, inside handlePortalLogin (same as the direct
+      // /api/auth/{portal}/login endpoints). Do NOT verify here too — the token is
+      // single-use, so a second siteverify would fail as timeout-or-duplicate. The
+      // transformedRequest below MUST forward turnstileToken or handlePortalLogin 403s
+      // with "missing token".
 
       // Validate input
       try {
@@ -1892,7 +1881,8 @@ class RouteRegistry {
         body: JSON.stringify({
           email: body.email,
           password: body.password,
-          userType: portal
+          userType: portal,
+          turnstileToken: body.turnstileToken
         })
       });
 


### PR DESCRIPTION
Follow-up fixes after PR #109.

- **Admin login 403 (root cause):** `/api/auth/sign-in` rebuilt the request body for `handlePortalLogin` but dropped `turnstileToken`, so the token-less body failed Turnstile with "missing token". Now forwards the token and verifies once (matching the direct portal-login endpoints). Confirmed working live.
- Concise `[turnstile]` failure logging for future diagnosability.
- Deploy skill (`.claude/commands/deploy.md`): require `--branch=main`, warn against `VITE_API_URL` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)