### PR TITLE
fix(ci): bump deploy Node 20→22 — unfreezes production frontend

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,7 +10,7 @@ on:
     - cron: '0 2 * * *'
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'  # wrangler >=4 requires Node >=22 (see deploy-frontend.yml)
   FRONTEND_DIR: './frontend'
   WORKER_DIR: './src'
   

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -10,7 +10,9 @@ on:
   workflow_dispatch: # Allow manual trigger
 
 env:
-  NODE_VERSION: '20'
+  # wrangler >=4 requires Node >=22; Node 20 made `wrangler pages deploy` exit 1
+  # *after* a successful Vite build, silently freezing prod at the 2026-05-05 build.
+  NODE_VERSION: '22'
 
 jobs:
   deploy:


### PR DESCRIPTION
## Root cause
Every **Deploy Frontend to Cloudflare Pages** run has failed since **2026-05-05**. `deploy-frontend.yml` pinned `NODE_VERSION: '20'`, but current `wrangler` requires Node ≥22. The Vite build (Node-20-compatible) succeeded, then `wrangler pages deploy` exited 1 — so the run went red *after* building, *before* uploading.

**Impact:** production frontend frozen at the `index-BHLq6MmU.js` (2026-05-05) build for ~4 weeks. Every client fix since — creator-name toggle, follow-button visibility, credits pill, doc-upload/NDA create-flow, AI disclosure, standard-NDA page, Stripe `SubscriptionCard`/`StripePortalCard` — never reached users. This is the root cause of the "works on my screen, Karl sees the old bugs" reports (deployment skew, not caching).

## Fix
Bump `NODE_VERSION` 20→22 in `deploy-frontend.yml` and `ci-cd.yml` (both run `wrangler pages deploy`).

## Why merging ships it
`deploy-frontend.yml` is in its own `paths:` trigger, so merging this re-runs the deploy on Node 22 and ships current `main`.

## Verify after merge
- `gh run list --workflow="Deploy Frontend to Cloudflare Pages" --limit 1` → success
- `curl -s https://pitchey-5o8.pages.dev/ | grep -oE 'assets/index-[A-Za-z0-9_-]+\.js'` → hash changes from `index-BHLq6MmU.js`

Backend unaffected (no CI deploy — shipped manually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)