### PR TITLE
chore(ci): single prod deployer — disable redundant GH Actions deploys

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -165,7 +165,13 @@ jobs:
   deploy-production:
     name: 🚀 Deploy to Production
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    # DISABLED — redundant + hazardous. Frontend is owned by Cloudflare Pages' Git
+    # integration; the worker is deployed manually via deploy-production.yml
+    # (workflow_dispatch). This job also re-synced Worker secrets from GitHub secrets
+    # on every push, which would silently overwrite prod secrets with anything stale
+    # (e.g. a rotated NEON URL → outage). Kept in-file (not deleted) so the manual
+    # deploy reference stays visible. Re-enable only behind a deliberate decision.
+    if: false && github.ref == 'refs/heads/main'
     needs: [security-scan, frontend-test, worker-test, database-test]
     environment: production
 

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,18 +1,16 @@
 name: Deploy Frontend to Cloudflare Pages
 
-# This workflow automatically deploys the frontend when you push to main
+# MANUAL break-glass frontend deployer only.
+# Production frontend is deployed by Cloudflare Pages' Git integration (auto-build
+# on push to main) — that is the single source of truth. This workflow used to also
+# auto-deploy on push, which meant two pipelines racing to deploy the same commit to
+# the same Pages project. Trigger reduced to workflow_dispatch so it only runs when
+# someone deliberately needs a wrangler-based deploy (e.g. CF Git integration outage).
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/deploy-frontend.yml'
-  workflow_dispatch: # Allow manual trigger
+  workflow_dispatch: # Manual trigger only
 
 env:
-  # wrangler >=4 requires Node >=22; Node 20 made `wrangler pages deploy` exit 1
-  # *after* a successful Vite build, silently freezing prod at the 2026-05-05 build.
-  NODE_VERSION: '22'
+  NODE_VERSION: '22' # wrangler >=4 requires Node >=22
 
 jobs:
   deploy:


### PR DESCRIPTION
## Context
Follow-up to #144. While verifying that fix, the actual production deployment record (`wrangler pages deployment list`) showed **Cloudflare Pages' Git integration** has been auto-deploying every push to Production all along — it is the real, working frontend deployer. The GitHub Actions deploy paths were redundant *second* deployers hitting the same `pitchey` Pages project.

## Changes
- **`deploy-frontend.yml`** — removed the `push:[main]` trigger; now `workflow_dispatch` only. Manual break-glass wrangler deploy for when CF Git integration is unavailable.
- **`ci-cd.yml` `deploy-production` job** — disabled (`if: false`). It redundantly redeployed the worker + frontend and, more importantly, **re-synced Worker secrets from GitHub secrets on every push** — a latent outage risk (a stale rotated secret would silently overwrite prod). The worker is deployed manually via `deploy-production.yml` (workflow_dispatch).

## Why this is safe
- Live frontend is unchanged (CF Git integration keeps deploying main).
- ci-cd `deploy-production` has been failing on every main push anyway (Node-20 wrangler wall, then worker-deploy step) — its secret-sync step always **skipped**, so no secrets were ever pushed by it.
- `e2e-test` (`needs: deploy-production`) already only ran after a *successful* deploy-production, which never happened — so no regression.

## Net result
One auto-deployer for prod frontend: Cloudflare Pages Git integration. GH Actions retains test/security/quality gates + two manual (`workflow_dispatch`) deploy escape hatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)