### PR TITLE
ci: auto-deploy the Worker on push to main (close manual-deploy drift gap)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: 'frontend/package-lock.json'
           
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           
       - name: Install dependencies
@@ -118,7 +118,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           
       - name: Install dependencies

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,68 @@
+name: Deploy Worker to Cloudflare
+
+# Auto-deploys the API Worker (pitchey-api-prod) on push to main.
+#
+# Why this exists: the Worker has historically been deployed BY HAND, so it
+# silently drifted behind main. On 2026-05-31 that drift caused a live 500 on
+# /api/views/track — the ON CONFLICT fix had been on main for a day but the last
+# manual deploy was from a stale local checkout. Frontend auto-deploys via CF
+# Pages Git integration; this gives the Worker the same guarantee.
+#
+# Deliberately SAFE: it runs `wrangler deploy` only. It does NOT re-sync Worker
+# secrets (DATABASE_URL/JWT/etc.) — a plain deploy preserves existing prod
+# secrets, and re-pushing them from GitHub secrets is an outage risk if any are
+# stale (see the disabled ci-cd.yml deploy-production job). It does NOT deploy
+# the frontend (CF Pages Git integration owns that).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'wrangler.toml'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/deploy-worker.yml'
+  workflow_dispatch: # manual trigger
+
+# Never interrupt an in-flight deploy; queue pushes so the latest commit wins.
+concurrency:
+  group: deploy-worker-production
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: '22' # wrangler >=4 requires Node >=22
+
+jobs:
+  deploy:
+    name: Build & Deploy Worker
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+
+      - name: ⚙️ Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+
+      - name: 📦 Install dependencies
+        run: npm ci
+
+      # Build gate — esbuild bundles the Worker exactly as Cloudflare will.
+      # Fails the job on import/syntax/bundling breakage BEFORE we ship to prod.
+      - name: 🏗️ Build Worker (bundle check)
+        run: npm run build:worker
+
+      - name: 🚀 Deploy Worker to production
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: ✅ Done
+        run: |
+          echo "Worker deployed: pitchey-api-prod"
+          echo "Commit: ${{ github.sha }}"


### PR DESCRIPTION
## Why
The API Worker (`pitchey-api-prod`) had **no auto-deploy** — deployed by hand, so it silently drifted behind `main`. That caused today's live **500 on `/api/views/track`**: the `ON CONFLICT` fix (`6af12159`) sat on `main` for a day while prod ran pre-fix code from a stale manual deploy. The frontend already auto-deploys (CF Pages Git integration); this gives the Worker the same guarantee.

## What
New `deploy-worker.yml` — push to `main` (worker paths) + `workflow_dispatch`:
1. Node 22 + `npm ci`
2. `npm run build:worker` (esbuild bundle = build gate; fails on import/syntax breakage before shipping)
3. `npx wrangler deploy`

## Deliberately safe (learned from the disabled `ci-cd.yml` deploy-production)
- **No Worker secret re-sync.** A plain `wrangler deploy` preserves existing prod secrets; re-pushing them from GitHub secrets is the outage risk (stale rotated secret → down) that got the old job disabled.
- **No frontend deploy.** CF Pages Git integration owns that.
- **Concurrency-guarded** — an in-flight deploy is never interrupted; latest commit wins.

Also bumps `deploy-production.yml` (manual break-glass) Node 20→22 so the wrangler fallback actually runs.

## Net deploy topology after this
- Frontend → CF Pages Git integration (auto)
- Worker → `deploy-worker.yml` (auto, this PR)
- Manual fallbacks → `deploy-frontend.yml` + `deploy-production.yml` (both `workflow_dispatch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)