### PR TITLE
test(smoke): cover pitch-detail page + guard views/track double-fire

### DIFF
--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -355,6 +355,26 @@ const ACTION_CHECKS = [
       await ctx.delete(`${BASE_URL}/api/pitches/${pitch.id}/save`).catch(() => {});
     },
   },
+
+  // ── ANY VIEWER — regression guard for the 2026-05-31 views/track 500 ───────
+  {
+    name: 'viewer: pitch-detail view tracking survives the double-fire (no 5xx)', // WRITES TO PROD (idempotent: one view row per user+pitch via ON CONFLICT upsert)
+    as: 'investor',
+    async run(ctx) {
+      const pitch = await pickActionablePitch(ctx, null);
+      // PitchDetail fires POST /api/views/track twice on mount. Before the
+      // ON CONFLICT fix (commit 6af12159), the losing concurrent insert 500'd
+      // on the (user_id, pitch_id) unique index — invisible to users (background
+      // call) but a real prod error. Fire two concurrently; assert NEITHER 5xxes.
+      const fire = () => ctx.post(`${BASE_URL}/api/views/track`, { data: { pitchId: String(pitch.id) } });
+      const [r1, r2] = await Promise.all([fire(), fire()]);
+      for (const r of [r1, r2]) {
+        if (r.status() >= 500) {
+          throw new Error(`views/track ${r.status()} — ${(await r.text()).slice(0, 200)}`);
+        }
+      }
+    },
+  },
 ];
 
 // Run a single action check with a one-shot retry to absorb cold-start / transient
@@ -517,7 +537,25 @@ async function main() {
   const actionResults = [];
   const started = Date.now();
 
-  for (const route of (runRoutes ? filteredRoutes : [])) {
+  // Inject a real pitch-detail route. The static ROUTES list never visited
+  // /pitch/:id, so the whole pitch-detail page — and the /api/views/track call
+  // that 500'd on 2026-05-31 — went unexercised. Resolve a published pitch and
+  // let the existing per-route 5xx + console listeners cover feedback,
+  // engagement, comments, rating, consumption-status and follow-stats too.
+  // Skipped under --filter to keep filtered runs predictable.
+  const routesToRun = [...filteredRoutes];
+  if (runRoutes && !FILTER) {
+    try {
+      const ctx = await requestContextFor(browser, 'investor');
+      const pitch = await pickActionablePitch(ctx, null);
+      routesToRun.push({ path: `/pitch/${pitch.id}`, as: 'investor' });
+      console.log(`(+ pitch-detail route /pitch/${pitch.id})\n`);
+    } catch (err) {
+      console.log(`(skipped pitch-detail route — could not resolve a pitch: ${err.message})\n`);
+    }
+  }
+
+  for (const route of (runRoutes ? routesToRun : [])) {
     let storageState;
     try {
       storageState = await getStorageStateFor(browser, route.as);


### PR DESCRIPTION
## Why
Today's `/api/views/track` 500 stayed **green** in the production smoke test. The 5xx listener was already present (it fails a route on any ≥500 response) — but the static `ROUTES` list **never visits `/pitch/:id`**, so the entire pitch-detail page and its calls (`views/track`, `feedback`, `engagement`, `comments`, `rating`, `consumption-status`, `follow-stats`) went unexercised. No page → no call → no 500 to catch.

## What
- **`main()`**: inject a dynamic `/pitch/:id` route (resolved from a published pitch) so the existing per-route 5xx + console listeners now cover the pitch-detail page across both viewports.
- **`ACTION_CHECKS`**: add a deterministic guard — double-fire `POST /api/views/track` concurrently and assert neither returns 5xx. A named regression test for the exact `(user_id, pitch_id)` unique-violation race fixed in `6af12159`.

Both skipped under `--filter` to keep filtered runs predictable. Idempotent against prod (views/track upserts one row per user+pitch).

## Validation
This PR touches `scripts/smoke-test.mjs`, so `smoke-tests.yml` runs the hardened suite against prod on this PR — green here proves both additions pass against the now-fixed worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)