### PR TITLE
perf(frontend): stop dashboards + view-tracking double-firing on load

### DIFF
--- a/frontend/src/features/analytics/services/__tests__/view.service.test.ts
+++ b/frontend/src/features/analytics/services/__tests__/view.service.test.ts
@@ -92,6 +92,20 @@ describe('viewService', () => {
       );
     });
 
+    it('is idempotent — a second start for the same pitch fires no extra initial view', () => {
+      mockAxiosPost.mockResolvedValue({ data: { success: true } });
+
+      viewService.startViewTracking('idem-pitch');
+      const callsAfterFirst = mockAxiosPost.mock.calls.length;
+      // PitchDetail's effect can invoke this twice on mount; the guard must not
+      // fire a second concurrent POST /api/views/track (the views/track 500 race).
+      viewService.startViewTracking('idem-pitch');
+
+      expect(mockAxiosPost.mock.calls.length).toBe(callsAfterFirst);
+
+      viewService.stopViewTracking('idem-pitch'); // cleanup interval
+    });
+
     it('records start time for the pitch', () => {
       mockAxiosPost.mockResolvedValue({ data: {} });
 

--- a/frontend/src/features/analytics/services/view.service.ts
+++ b/frontend/src/features/analytics/services/view.service.ts
@@ -108,9 +108,17 @@ class ViewService {
    * Start tracking view duration for a pitch
    */
   startViewTracking(pitchId: string): void {
+    // Idempotent: if we're already tracking this pitch, don't fire a second
+    // initial view or leak a second interval. PitchDetail's effect can invoke
+    // this twice on mount (prod has no StrictMode cleanup between the calls),
+    // which previously sent two concurrent POST /api/views/track — the losing
+    // insert raced on the (user_id,pitch_id) unique index. stopViewTracking
+    // deletes the interval, so re-visiting the same pitch tracks again cleanly.
+    if (this.viewInterval.has(pitchId)) return;
+
     // Record start time
     this.viewStartTime.set(pitchId, Date.now());
-    
+
     // Send initial view
     this.trackView({ pitchId }).catch(console.error);
     

--- a/frontend/src/pages/CreatorDashboard.tsx
+++ b/frontend/src/pages/CreatorDashboard.tsx
@@ -103,7 +103,10 @@ function CreatorDashboard() {
 
     void fetchDashboardData();
     void fetchFundingData(); // Fetch funding data in parallel
-  }, [authUser, sessionChecked, isAuthenticated]);
+    // Depend on the stable user id, not the authUser object reference — the auth
+    // store swaps authUser (cache → server-validated) during checkSession, and
+    // depending on the object ref re-ran this whole load (8 calls) a second time.
+  }, [authUser?.id, sessionChecked, isAuthenticated]);
 
   const fetchFundingData = async () => {
     setSectionStatus(prev => ({ ...prev, funding: { loaded: false, error: null } }));

--- a/frontend/src/pages/ProductionDashboard.tsx
+++ b/frontend/src/pages/ProductionDashboard.tsx
@@ -439,7 +439,13 @@ function ProductionDashboard() {
     return () => {
       if (fetchCleanup) fetchCleanup();
     };
-  }, [fetchData, sessionChecked, isAuthenticated]);
+    // Trigger on the stable user id, not the fetchData callback ref. fetchData's
+    // deps include user?.username/companyName, which populate after session
+    // validation (cache → server), changing its ref and re-running this whole
+    // load 2–3×. The data keys off the auth cookie, not those display fields, so
+    // firing once when the user id is ready is correct.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionChecked, isAuthenticated, user?.id]);
 
   const handleViewTerms = (nda: any) => {
     setSelectedNDA(nda);


### PR DESCRIPTION
## What
Post-deploy sweep found redundant requests on load — all 200s, no breakage, but wasteful, and the views/track one was the trigger for today's prod 500.

| Fix | Cause | Effect |
|---|---|---|
| `view.service.startViewTracking` idempotency guard | PitchDetail's effect invokes it twice on mount (no StrictMode cleanup in prod) → two concurrent `POST /api/views/track` | removes the double-fire **and** a leaked `setInterval`; +1 regression test |
| `CreatorDashboard` dep `authUser` → `authUser?.id` | auth store swaps the `authUser` object ref (cache → server) during `checkSession` → whole 8-call load ran twice | load fires once |
| `ProductionDashboard` dep `fetchData` → `user?.id` | `fetchData` callback ref changes when `user.username`/`companyName` populate → 2–3× reload | load fires once |

`InvestorDashboard` already keyed off `user?.id` — left as-is.

## Why it's safe
- Standard "depend on the stable primitive id, not the object/callback ref" fix.
- Dashboard data keys off the auth cookie + user id, not the display fields dropped from deps.
- The view-tracking guard is reset by `stopViewTracking`, so revisiting a pitch tracks again.

## Tests
84 dashboard tests + 19 view-service tests (incl. new idempotency test) green; `tsc` clean. Smoke runs on this PR (touches `frontend/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)