### PR TITLE
feat(observability): /debug self-check route + Sentry user/portal tagging

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -52,6 +52,9 @@ jobs:
           VITE_WS_URL: 'wss://pitchey-api-prod.ndlovucavelle.workers.dev'
           VITE_DISABLE_WEBSOCKET: 'false'
           VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN || 'https://fd5664ae577039ccb7cce31e91f54533@o4510137537396736.ingest.de.sentry.io/4510138308755536' }}
+          # Commit SHA becomes the Sentry `release` + the /debug "Client build" so a
+          # user's screenshot/events identify exactly which deploy they're on.
+          VITE_APP_VERSION: ${{ github.sha }}
           NODE_ENV: production
 
       - name: 🚀 Deploy to Cloudflare Pages (using Wrangler)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -164,6 +164,7 @@ const Contact = lazyRetry(() => import('./pages/Contact'));
 const Terms = lazyRetry(() => import('./pages/Terms'));
 const Privacy = lazyRetry(() => import('./pages/Privacy'));
 const StandardNDA = lazyRetry(() => import('./pages/StandardNDA'));
+const Debug = lazyRetry(() => import('./pages/Debug'));
 const ForgotPassword = lazyRetry(() => import('./pages/ForgotPassword'));
 const ResetPassword = lazyRetry(() => import('./pages/ResetPassword'));
 
@@ -439,6 +440,7 @@ function App() {
           <Route path="/terms" element={<Terms />} />
           <Route path="/privacy" element={<Privacy />} />
           <Route path="/legal/standard-nda" element={<StandardNDA />} />
+          <Route path="/debug" element={<Debug />} />
           <Route path="/forgot-password" element={<ForgotPassword />} />
           <Route path="/reset-password" element={<ResetPassword />} />
           

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -24,10 +24,25 @@ import { createRoot } from 'react-dom/client';
 import './index.css'
 import './lib/fix-all-apis.ts' // Fix all API URLs globally
 import App from './App.tsx'
-import { initSentry } from './monitoring/sentry-config'
+import { initSentry, setSentryUser } from './monitoring/sentry-config'
+import { useBetterAuthStore } from './store/betterAuthStore'
 
 // Initialize Sentry for production error tracking
 initSentry()
+
+// Keep Sentry's user/portal tags in sync with auth state so any user's errors
+// are filterable by who they are and which portal they're on. Fires on login,
+// session restore, and logout. (initSentry's one-shot setUser runs before async
+// login resolves, so it usually catches nobody.)
+let _lastSentryUserId: string | number | null = null
+setSentryUser(useBetterAuthStore.getState().user)
+_lastSentryUserId = useBetterAuthStore.getState().user?.id ?? null
+useBetterAuthStore.subscribe((state) => {
+  const id = state.user?.id ?? null
+  if (id === _lastSentryUserId) return // only re-tag when the user actually changes
+  _lastSentryUserId = id
+  setSentryUser(state.user)
+})
 
 // Handle stale chunk errors after deployment — Vite fires this when a
 // lazy-loaded module can't be fetched (e.g. old hash no longer on CDN).

--- a/frontend/src/monitoring/sentry-config.ts
+++ b/frontend/src/monitoring/sentry-config.ts
@@ -188,6 +188,34 @@ export function initSentry() {
   }
 }
 
+/**
+ * Attach the authenticated user to all subsequent Sentry events so a specific
+ * user's errors are filterable by who they are AND which portal/code-path they
+ * are on. Call on every auth change (wired via a store subscription in main.tsx);
+ * pass null on logout to clear. The init-time setUser above only runs once,
+ * before async login resolves — this keeps the user in sync afterwards.
+ */
+export function setSentryUser(
+  user: { id: string | number; email?: string; username?: string; userType?: string } | null,
+): void {
+  if (!user) {
+    Sentry.setUser(null)
+    Sentry.setTag('portal', undefined)
+    Sentry.setTag('segment', undefined)
+    return
+  }
+  Sentry.setUser({
+    id: String(user.id),
+    email: user.email,
+    username: user.username,
+    ip_address: '{{auto}}',
+  })
+  // userType (creator/investor/production/watcher) is the highest-signal tag —
+  // it tells you whether the user is on a code path you never hit yourself.
+  Sentry.setTag('portal', user.userType ?? 'unknown')
+  Sentry.setTag('segment', user.userType ?? 'unknown')
+}
+
 // Performance monitoring utilities
 export const SentryPerformance = {
   // Start a span (Sentry v8 API)

--- a/frontend/src/pages/Debug.tsx
+++ b/frontend/src/pages/Debug.tsx
@@ -1,0 +1,139 @@
+// Self-service diagnostics page — a route a user can open and screenshot so we
+// never need them in DevTools. Reports build versions, session/role/tier, edge
+// colo, and live reachability of the third parties the app depends on. A red row
+// on a third party = CSP / ad-blocker / network block; a stale client build =
+// they're on an old deploy. Public route (no auth) so it always loads.
+import { useEffect, useState } from 'react';
+import { WS_URL } from '../config';
+
+type Status = 'pending' | 'ok' | 'fail';
+const SENTRY_DSN = (import.meta.env as Record<string, string>)['VITE_SENTRY_DSN'] || '';
+const CLIENT_BUILD = (import.meta.env as Record<string, string>)['VITE_APP_VERSION'] || 'unknown';
+
+// Load a <script> and resolve whether it loaded — tests script-src CSP + network
+// + extension blocking for Stripe / Turnstile (the things that actually break).
+function probeScript(src: string, timeoutMs = 8000): Promise<boolean> {
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = (ok: boolean) => { if (!done) { done = true; el.remove(); resolve(ok); } };
+    const el = document.createElement('script');
+    el.src = src;
+    el.async = true;
+    el.onload = () => finish(true);
+    el.onerror = () => finish(false);
+    document.head.appendChild(el);
+    setTimeout(() => finish(false), timeoutMs);
+  });
+}
+
+function probeWebSocket(url: string, timeoutMs = 6000): Promise<boolean> {
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = (ok: boolean) => { if (!done) { done = true; try { ws.close(); } catch { /* noop */ } resolve(ok); } };
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(url);
+    } catch {
+      resolve(false);
+      return;
+    }
+    // onopen = the wss upgrade succeeded → network path is NOT blocked (the server
+    // may close afterwards for missing auth; that's fine, we only probe reachability).
+    ws.onopen = () => finish(true);
+    ws.onerror = () => finish(false);
+    setTimeout(() => finish(false), timeoutMs);
+  });
+}
+
+export default function Debug() {
+  const [meta, setMeta] = useState<Record<string, string>>({
+    clientBuild: CLIENT_BUILD,
+  });
+  const [checks, setChecks] = useState<Record<string, Status>>({
+    Session: 'pending',
+    'Stripe JS': 'pending',
+    'Turnstile JS': 'pending',
+    WebSocket: 'pending',
+  });
+
+  useEffect(() => {
+    let alive = true;
+    const setCheck = (k: string, s: Status) => alive && setChecks((c) => ({ ...c, [k]: s }));
+    const setM = (patch: Record<string, string>) => alive && setMeta((m) => ({ ...m, ...patch }));
+
+    // Server (worker) build + edge colo, from a same-origin no-store probe.
+    fetch('/api/version', { cache: 'no-store' })
+      .then(async (r) => {
+        const ray = r.headers.get('cf-ray') || '';
+        const colo = ray.includes('-') ? ray.split('-')[1] : '';
+        const body = await r.json().catch(() => ({}));
+        setM({ workerVersion: body.version || 'unknown', colo: colo || 'unknown' });
+      })
+      .catch(() => setM({ workerVersion: 'unreachable', colo: 'unknown' }));
+
+    // Session validity + who they are.
+    fetch('/api/auth/session', { credentials: 'include', cache: 'no-store' })
+      .then(async (r) => {
+        if (!r.ok) { setCheck('Session', 'fail'); return; }
+        const b = await r.json().catch(() => ({}));
+        const u = b?.user || b?.data?.user || {};
+        setM({
+          userType: u.userType || u.user_type || 'none',
+          tier: u.subscriptionTier || u.subscription_tier || 'free',
+          username: u.username || u.name || u.email || '—',
+        });
+        setCheck('Session', u && (u.id || u.userType) ? 'ok' : 'fail');
+      })
+      .catch(() => setCheck('Session', 'fail'));
+
+    probeScript('https://js.stripe.com/v3/').then((ok) => setCheck('Stripe JS', ok ? 'ok' : 'fail'));
+    probeScript('https://challenges.cloudflare.com/turnstile/v0/api.js').then((ok) => setCheck('Turnstile JS', ok ? 'ok' : 'fail'));
+    probeWebSocket(WS_URL).then((ok) => setCheck('WebSocket', ok ? 'ok' : 'fail'));
+
+    return () => { alive = false; };
+  }, []);
+
+  const icon = (s: Status) => (s === 'ok' ? '✅' : s === 'fail' ? '❌' : '…');
+  const rowStyle: React.CSSProperties = { fontFamily: 'monospace', fontSize: 16, padding: '6px 0', borderBottom: '1px solid #eee' };
+
+  const infoRow = (label: string, value: string) => (
+    <div style={rowStyle} key={label}>
+      <span style={{ color: '#666' }}>{label}:</span> <strong>{value || '…'}</strong>
+    </div>
+  );
+  const checkRow = (label: string, s: Status) => (
+    <div style={rowStyle} key={label}>
+      {icon(s)} <span>{label}</span>
+    </div>
+  );
+
+  return (
+    <div style={{ padding: 24, maxWidth: 560, margin: '0 auto', color: '#111' }}>
+      <h1 style={{ fontSize: 22, marginBottom: 4 }}>Pitchey self-check</h1>
+      <p style={{ color: '#666', marginTop: 0 }}>Screenshot this whole screen and send it over.</p>
+
+      <h3 style={{ marginBottom: 4 }}>Build</h3>
+      {infoRow('Client build', meta.clientBuild)}
+      {infoRow('Worker version', meta.workerVersion)}
+      {infoRow('Edge colo', meta.colo)}
+
+      <h3 style={{ marginBottom: 4, marginTop: 20 }}>Account</h3>
+      {infoRow('Role', meta.userType)}
+      {infoRow('Tier', meta.tier)}
+      {infoRow('User', meta.username)}
+
+      <h3 style={{ marginBottom: 4, marginTop: 20 }}>Connectivity</h3>
+      {checkRow('Session valid', checks.Session)}
+      {checkRow('Stripe', checks['Stripe JS'])}
+      {checkRow('Turnstile', checks['Turnstile JS'])}
+      {checkRow('WebSocket', checks.WebSocket)}
+      {infoRow('Sentry', SENTRY_DSN ? 'configured' : 'NOT configured')}
+
+      <p style={{ marginTop: 20, color: '#888', fontSize: 13 }}>
+        ❌ on Stripe / Turnstile / WebSocket = a CSP, ad-blocker, or network block (often only on one
+        person's machine). A "Client build" that doesn't match the current deploy = stale cached app —
+        hard-refresh or try a private window.
+      </p>
+    </div>
+  );
+}

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -1799,6 +1799,7 @@ class RouteRegistry {
   private registerRoutes() {
     // Health check route
     this.register('GET', '/api/health', this.handleHealth.bind(this));
+    this.register('GET', '/api/version', this.handleVersion.bind(this));
     this.register('GET', '/api/health/database', this.handleDatabaseHealth.bind(this));
 
     // Monitoring endpoints for synthetic monitoring and dashboard
@@ -3850,6 +3851,7 @@ class RouteRegistry {
     // Define public endpoints that don't require authentication
     const publicEndpoints = [
       '/api/health',
+      '/api/version',
       '/api/auth/login',
       '/api/auth/register',
       '/api/auth/sign-in',
@@ -4521,6 +4523,28 @@ class RouteRegistry {
     // Always clear the session cookie, even if Better Auth isn't available
     // This ensures logout always works
     return this.handleLogoutSimple(request);
+  }
+
+  // Lightweight, public, no-store version probe. Returns the deployed Worker
+  // version (CF_VERSION_METADATA) so the /debug page can compare client build vs
+  // server build and surface frontend/worker deploy skew. No DB, no auth.
+  private handleVersion(request: Request): Response {
+    const v = this.env.CF_VERSION_METADATA;
+    return new Response(
+      JSON.stringify({
+        version: v?.id ?? 'unknown',
+        tag: v?.tag ?? null,
+        timestamp: v?.timestamp ?? null,
+      }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store',
+          ...getCorsHeaders(request.headers.get('Origin')),
+        },
+      },
+    );
   }
 
   private async handleHealth(request: Request): Promise<Response> {


### PR DESCRIPTION
Implements the two self-service diagnostics from the "works on my screen" playbook so a user's session reports on itself — no DevTools needed.

## Sentry — know who hit the error
- `setSentryUser(user)` tags every event with `id`/`email`/`username` + `portal`/`segment` (userType). Wired via a `betterAuthStore` subscription in `main.tsx`, so it stays in sync across login / session-restore / logout. (The old init-time `setUser` ran before async login resolved → caught nobody.)
- `VITE_APP_VERSION = ${{ github.sha }}` in `deploy-frontend.yml` → Sentry `release` is a real build id (was `'unknown'`). Filter Sentry to a user → see their exact deploy + role instantly.

## `/debug` — a page the user can screenshot
Public route. Reports:
- **Build**: client build (frontend SHA), worker version (new `GET /api/version` — public, no-store, from `CF_VERSION_METADATA`), edge colo (from `cf-ray`).
- **Account**: session valid, role, tier, user.
- **Connectivity**: live probes of Stripe JS, Turnstile JS, WebSocket (script-load + ws-open → catch CSP / ad-blocker / network blocks that hit one person).

A red third-party row = a block on their machine; a client build ≠ current deploy = stale cache (hard-refresh).

> Pitchey nuance: client build (git SHA) and worker version (CF id) are different identifier spaces, so they're shown as separate rows to compare against current — not a bogus boolean "match".

## Verification
Typecheck clean; frontend build (`Debug` chunk compiles) + worker bundle both pass. On merge: worker auto-deploys (`/api/version`), frontend auto-deploys (`/debug` + Sentry). Smoke runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)