### PR TITLE
fix(pitch+portal): media gating, per-user state hydration, window-scroll + E2E smoke guards

### DIFF
--- a/.claude/skills/wrangler-deploy/SKILL.md
+++ b/.claude/skills/wrangler-deploy/SKILL.md
@@ -22,15 +22,25 @@ triggers:
 ## Deployment Commands
 
 ### Frontend (Pages)
-**CRITICAL: Must run from `frontend/` directory, NOT repo root.**
-Running from root skips the Functions bundle (`functions/`) and breaks SPA routing (all non-root URLs 404).
+**TWO CRITICAL flags/rules — get either wrong and the deploy looks successful but isn't live:**
+
+1. **Must run from `frontend/` directory, NOT repo root.** Running from root skips the Functions bundle (`functions/`) and breaks SPA routing (all non-root URLs 404). Note: **bash cwd resets between turns** — always re-`cd` in the same command; a `cd` from a previous turn does NOT persist.
+2. **Must pass `--branch=main`.** Without it the deploy publishes a *preview* (a `<hash>.pitchey-5o8.pages.dev` alias) and the canonical `pitchey-5o8.pages.dev` keeps serving the OLD build. The CLI prints a hashed URL either way, so the printed URL does NOT tell you whether prod updated — you must verify the canonical hostname (below).
+
 ```bash
-# Build + deploy (MUST be in frontend/)
+# Build + deploy production (MUST be in frontend/, MUST pass --branch=main)
 cd frontend && npm run build
-npx wrangler pages deploy dist/ --project-name=pitchey
+npx wrangler pages deploy dist/ --project-name=pitchey --branch=main
 
 # Check deployment status
 npx wrangler pages deployment list --project-name pitchey
+```
+
+**MANDATORY verification — confirm canonical prod serves the new bundle.** The build prints the entry hash (`dist/assets/index-XXXX.js`); confirm the live canonical host serves the same hash:
+```bash
+curl -s https://pitchey-5o8.pages.dev/ | grep -oE 'assets/index-[A-Za-z0-9_]+\.js' | head -1
+# Must match the index-XXXX.js the build just emitted. If it doesn't, you shipped a preview
+# (forgot --branch=main) or deployed from the wrong dir.
 ```
 
 ### Backend (Workers)
@@ -46,13 +56,16 @@ curl -s https://pitchey-api-prod.ndlovucavelle.workers.dev/api/health | jq
 # 1. Deploy Worker API (from repo root)
 npx wrangler deploy
 
-# 2. Build + deploy frontend (MUST cd into frontend/)
-cd frontend && npm run build && npx wrangler pages deploy dist/ --project-name=pitchey
+# 2. Build + deploy frontend (MUST cd into frontend/, MUST pass --branch=main)
+cd frontend && npm run build && npx wrangler pages deploy dist/ --project-name=pitchey --branch=main
 
-# 3. Verify both
+# 3. Verify both — canonical hosts, not the printed preview alias
 curl -s https://pitchey-api-prod.ndlovucavelle.workers.dev/api/health | jq
-curl -s -o /dev/null -w "%{http_code}" https://pitchey-5o8.pages.dev
+curl -s https://pitchey-5o8.pages.dev/ | grep -oE 'assets/index-[A-Za-z0-9_]+\.js' | head -1  # match build hash
 ```
+
+### Auto-deploy topology (GitHub Actions)
+Pushing to `main` also auto-deploys via `deploy-frontend.yml` (frontend) and `deploy-worker.yml` (worker), both on Node 22. There is **NO Cloudflare Git integration** — all deploys are ad-hoc/wrangler (verified). A manual `wrangler pages deploy` and a CI run do the same thing; don't disable one believing the other is a CF-native build. Verify what's actually live via the deployments API / bundle hash, not CI history.
 
 ## Pre-Deploy Checklist
 1. Run `npm run build` - must succeed with no errors
@@ -83,10 +96,10 @@ npx wrangler deployments list
 # Rollback to specific version
 npx wrangler rollback --version VERSION_ID
 
-# Pages rollback: redeploy previous git commit (MUST be in frontend/)
+# Pages rollback: redeploy previous git commit (MUST be in frontend/, MUST pass --branch=main)
 git checkout PREVIOUS_COMMIT
 cd frontend && npm run build
-npx wrangler pages deploy dist/ --project-name=pitchey
+npx wrangler pages deploy dist/ --project-name=pitchey --branch=main
 ```
 
 ## Common Deployment Issues

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -82,8 +82,13 @@ jobs:
         run: |
           npx wrangler dev --port 8001 > /tmp/wrangler.log 2>&1 &
           (cd frontend && VITE_API_URL=http://localhost:8001 VITE_WS_URL=ws://localhost:8001 npm run dev > /tmp/vite.log 2>&1 &)
-          # Wait for both to listen (CI runner allows sleep).
-          npx wait-on -t 120000 tcp:127.0.0.1:8001 tcp:127.0.0.1:5173
+          # Wait for both to listen. On timeout, dump both logs in THIS step so the
+          # cause is visible (a later step can't reliably capture it).
+          if ! npx wait-on -t 120000 tcp:127.0.0.1:8001 tcp:127.0.0.1:5173; then
+            echo "===== wrangler.log ====="; cat /tmp/wrangler.log || true
+            echo "===== vite.log ====="; cat /tmp/vite.log || true
+            exit 1
+          fi
           echo "worker + frontend are up"
 
       - name: Run smoke-regression suite
@@ -94,7 +99,7 @@ jobs:
 
       - name: Worker log on failure
         if: failure()
-        run: tail -50 /tmp/wrangler.log /tmp/vite.log || true
+        run: tail -n 80 /tmp/wrangler.log /tmp/vite.log || true
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -66,12 +66,20 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Write local worker vars (.dev.vars is gitignored)
+        env:
+          DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
         run: |
-          cat > .dev.vars <<'EOF'
+          # The auth/session path reads env.DATABASE_URL via neon() directly (NOT the
+          # Hyperdrive binding) — without it every query throws "No database connection
+          # string was provided to neon()" and login never completes. Unquoted heredoc
+          # so $DATABASE_URL expands.
+          cat > .dev.vars <<EOF
           BETTER_AUTH_SECRET=ci-e2e-placeholder-not-a-real-secret-32chars
+          JWT_SECRET=ci-e2e-placeholder-jwt-secret-not-real-32chars
           ENVIRONMENT=development
           SENTRY_ENVIRONMENT=development
           TURNSTILE_ENABLED=false
+          DATABASE_URL=$DATABASE_URL
           EOF
 
       - name: Start worker (wrangler dev :8001) + frontend (vite :5173)

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -81,7 +81,9 @@ jobs:
           CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE: ${{ secrets.E2E_DATABASE_URL }}
         run: |
           npx wrangler dev --port 8001 > /tmp/wrangler.log 2>&1 &
-          (cd frontend && VITE_API_URL=http://localhost:8001 VITE_WS_URL=ws://localhost:8001 npm run dev > /tmp/vite.log 2>&1 &)
+          # --host 127.0.0.1 forces vite onto IPv4 — by default it binds IPv6-only
+          # ([::1]:5173), which wait-on's `tcp:127.0.0.1:5173` (IPv4) never matches.
+          (cd frontend && VITE_API_URL=http://localhost:8001 VITE_WS_URL=ws://localhost:8001 npm run dev -- --host 127.0.0.1 --port 5173 > /tmp/vite.log 2>&1 &)
           # Wait for both to listen. On timeout, dump both logs in THIS step so the
           # cause is visible (a later step can't reliably capture it).
           if ! npx wait-on -t 120000 tcp:127.0.0.1:8001 tcp:127.0.0.1:5173; then

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -35,7 +35,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # Node 22: wrangler 4.x / miniflare require >=22. Node 20 makes
+          # `wrangler dev` fail to boot (EBADENGINE) → ports never open → wait-on
+          # times out. Same reason the deploy workflows run Node 22 (#145).
+          node-version: '22'
           cache: 'npm'
 
       - name: Fail fast if DB secret missing

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -39,11 +39,17 @@ jobs:
           cache: 'npm'
 
       - name: Fail fast if DB secret missing
-        if: ${{ secrets.E2E_DATABASE_URL == '' }}
+        # NOTE: the `secrets` context is NOT allowed in `if:` — must surface it via
+        # env and test the value in the script, otherwise the workflow file is invalid.
+        env:
+          E2E_DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
         run: |
-          echo "::error::E2E_DATABASE_URL secret is not set — the login-gated smoke tests cannot reach the DB."
-          echo "Add it under Settings → Secrets → Actions (the Neon prod connection string works)."
-          exit 1
+          if [ -z "$E2E_DATABASE_URL" ]; then
+            echo "::error::E2E_DATABASE_URL secret is not set — the login-gated smoke tests cannot reach the DB."
+            echo "Add it under Settings → Secrets → Actions (the Neon prod connection string works)."
+            exit 1
+          fi
+          echo "E2E_DATABASE_URL is present."
 
       - name: Install root deps (wrangler)
         run: npm ci --no-audit --no-fund

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,0 +1,96 @@
+name: E2E Smoke (browser)
+
+# Browser-level regression guards for the SILENT-failure class — bugs that ship
+# without throwing (Sentry/Axiom miss them) and without breaking a unit test
+# (jsdom has no layout; component tests mock the server). Complements the
+# request-level scripts/smoke-test.mjs (smoke-tests.yml) which hits prod.
+#
+# This one needs a real browser + a live local stack (vite + wrangler dev) so it
+# can log in, round-trip a save, reload to check per-user state hydration, and
+# verify layout reachability. See frontend/e2e/smoke-regression.spec.ts.
+#
+# Requires repo secret E2E_DATABASE_URL — a Postgres connection string the local
+# wrangler-dev Hyperdrive binding connects to (the demo accounts must exist in it;
+# the Neon prod DB works). Without it the login-gated tests cannot reach the DB.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'frontend/src/**'
+      - 'frontend/e2e/**'
+      - 'frontend/playwright.config.ts'
+      - 'src/**'
+      - '.github/workflows/e2e-smoke.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-regression:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Fail fast if DB secret missing
+        if: ${{ secrets.E2E_DATABASE_URL == '' }}
+        run: |
+          echo "::error::E2E_DATABASE_URL secret is not set — the login-gated smoke tests cannot reach the DB."
+          echo "Add it under Settings → Secrets → Actions (the Neon prod connection string works)."
+          exit 1
+
+      - name: Install root deps (wrangler)
+        run: npm ci --no-audit --no-fund
+
+      - name: Install frontend deps
+        working-directory: frontend
+        run: npm ci --no-audit --no-fund
+
+      - name: Install Chromium (Playwright)
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Write local worker vars (.dev.vars is gitignored)
+        run: |
+          cat > .dev.vars <<'EOF'
+          BETTER_AUTH_SECRET=ci-e2e-placeholder-not-a-real-secret-32chars
+          ENVIRONMENT=development
+          SENTRY_ENVIRONMENT=development
+          TURNSTILE_ENABLED=false
+          EOF
+
+      - name: Start worker (wrangler dev :8001) + frontend (vite :5173)
+        env:
+          # Hyperdrive local emulation connects here. Strip channel_binding —
+          # the local node-postgres driver doesn't support it.
+          CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE: ${{ secrets.E2E_DATABASE_URL }}
+        run: |
+          npx wrangler dev --port 8001 > /tmp/wrangler.log 2>&1 &
+          (cd frontend && VITE_API_URL=http://localhost:8001 VITE_WS_URL=ws://localhost:8001 npm run dev > /tmp/vite.log 2>&1 &)
+          # Wait for both to listen (CI runner allows sleep).
+          npx wait-on -t 120000 tcp:127.0.0.1:8001 tcp:127.0.0.1:5173
+          echo "worker + frontend are up"
+
+      - name: Run smoke-regression suite
+        working-directory: frontend
+        # CI=true makes playwright.config skip its own webServer block, so it uses
+        # the servers started above at baseURL http://localhost:5173.
+        run: npx playwright test --project=smoke-regression --reporter=line
+
+      - name: Worker log on failure
+        if: failure()
+        run: tail -50 /tmp/wrangler.log /tmp/vite.log || true
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-smoke-report
+          path: frontend/test-results/
+          retention-days: 7

--- a/frontend/e2e/smoke-regression.spec.ts
+++ b/frontend/e2e/smoke-regression.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect, type Page } from '@playwright/test';
-import { TEST_USERS } from './fixtures/test-data';
 
 /**
  * Smoke-regression suite — the silent-failure class.
@@ -32,13 +31,15 @@ const PORTAL_LOGIN = {
 type Portal = keyof typeof PORTAL_LOGIN;
 
 async function login(page: Page, portal: Portal): Promise<void> {
-  const user = TEST_USERS[portal];
   // NOTE: route is /login/<portal>, NOT /<portal>/login — the older auth.setup.ts
   // had this backwards, which is why its .auth/*-login-failed.png artifacts exist.
   await page.goto(PORTAL_LOGIN[portal]);
-  await page.locator('input[name="email"], input[type="email"]').first().fill(user.email);
-  await page.locator('input[name="password"], input[type="password"]').first().fill(user.password);
-  await page.locator('button[type="submit"]').first().click();
+  // The normal "Sign in" submit is gated behind Turnstile (disabled with no token
+  // in headless). The "Use Demo <Portal> Account" button auto-submits demo creds
+  // and isn't gated; with the local/CI worker's TURNSTILE_ENABLED=false the empty
+  // token is accepted. (These tests are local/CI only — never against prod, where
+  // Turnstile is enforced.)
+  await page.getByRole('button', { name: /Use Demo .*Account/i }).click();
   await page.waitForURL(`**/${portal}/dashboard`, { timeout: 20000 });
 }
 

--- a/frontend/e2e/smoke-regression.spec.ts
+++ b/frontend/e2e/smoke-regression.spec.ts
@@ -64,10 +64,12 @@ test.describe('smoke-regression: silent-failure guards', () => {
     await login(page, 'creator');
     await openEdit(page);
 
+    // Capture the current value so we can restore it — this runs on every PR
+    // against a shared demo pitch; the test must leave it as it found it.
+    const original = await page.getByRole('textbox', { name: /Short Synopsis/i }).inputValue();
     const marker = `E2E persistence ${Date.now()}`;
-    const synopsis = page.getByRole('textbox', { name: /Short Synopsis/i });
-    await synopsis.fill(marker);
 
+    await page.getByRole('textbox', { name: /Short Synopsis/i }).fill(marker);
     await page.getByRole('button', { name: /Save Changes/i }).click();
     // Success path redirects to the pitch list.
     await page.waitForURL(/\/creator\/pitches/, { timeout: 20000 });
@@ -75,6 +77,11 @@ test.describe('smoke-regression: silent-failure guards', () => {
     // Re-open the edit page fresh — the value must come back from the server.
     await openEdit(page);
     await expect(page.getByRole('textbox', { name: /Short Synopsis/i })).toHaveValue(marker);
+
+    // Restore the original value so the demo pitch isn't left mutated.
+    await page.getByRole('textbox', { name: /Short Synopsis/i }).fill(original);
+    await page.getByRole('button', { name: /Save Changes/i }).click();
+    await page.waitForURL(/\/creator\/pitches/, { timeout: 20000 });
   });
 
   test('2. like state survives a reload (server hydration)', async ({ page }) => {

--- a/frontend/e2e/smoke-regression.spec.ts
+++ b/frontend/e2e/smoke-regression.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect, type Page } from '@playwright/test';
+import { TEST_USERS } from './fixtures/test-data';
+
+/**
+ * Smoke-regression suite — the silent-failure class.
+ *
+ * Every bug this file guards against shipped to production WITHOUT throwing an
+ * error (so Sentry/Axiom never saw them) and WITHOUT breaking a unit test (jsdom
+ * has no layout, and component tests mock the server, so per-user state and
+ * round-trips can't be exercised). They were each found only by driving the real
+ * app. This suite is that drive, automated.
+ *
+ *   1. Edit persistence   — Save round-trips to the DB (form → Save → reload → still there)
+ *   2. Like hydration     — per-user like state survives a reload (not reset to empty)
+ *   3. Save hydration      — per-user bookmark state survives a reload
+ *   4. Save reachability   — the edit form's Save button is reachable at a small
+ *                            viewport (regression guard for the PortalLayout
+ *                            inner-scroll clip that hid the Save button)
+ *   5. Gating              — an anonymous viewer sees no document download links
+ *
+ * Runs against local dev (default baseURL http://localhost:5173) where
+ * TURNSTILE_ENABLED is false so the login submit-gate is open. The playwright.config
+ * webServer block boots `npm run dev` + `wrangler dev` automatically.
+ */
+
+const PORTAL_LOGIN = {
+  creator: '/login/creator',
+  investor: '/login/investor',
+  production: '/login/production',
+} as const;
+
+type Portal = keyof typeof PORTAL_LOGIN;
+
+async function login(page: Page, portal: Portal): Promise<void> {
+  const user = TEST_USERS[portal];
+  // NOTE: route is /login/<portal>, NOT /<portal>/login — the older auth.setup.ts
+  // had this backwards, which is why its .auth/*-login-failed.png artifacts exist.
+  await page.goto(PORTAL_LOGIN[portal]);
+  await page.locator('input[name="email"], input[type="email"]').first().fill(user.email);
+  await page.locator('input[name="password"], input[type="password"]').first().fill(user.password);
+  await page.locator('button[type="submit"]').first().click();
+  await page.waitForURL(`**/${portal}/dashboard`, { timeout: 20000 });
+}
+
+// A stable published demo pitch owned by alex.creator (so the investor is a
+// non-owner and Like/Save render). Override with SMOKE_PITCH_ID if seed data shifts.
+const PITCH_ID = process.env.SMOKE_PITCH_ID || '229';
+
+/** Open the creator edit page for a pitch directly (auth cookie is set post-login). */
+async function openEdit(page: Page, id = PITCH_ID): Promise<void> {
+  await page.goto(`/creator/pitch/${id}/edit`);
+  await expect(page.getByRole('heading', { name: /Edit Pitch/i })).toBeVisible({ timeout: 20000 });
+}
+
+/** Open a pitch detail page. Logged-in → PitchDetail; guest → PublicPitchView. */
+async function openPitch(page: Page, id = PITCH_ID): Promise<void> {
+  await page.goto(`/pitch/${id}`);
+  await page.waitForLoadState('networkidle');
+}
+
+test.describe('smoke-regression: silent-failure guards', () => {
+  test('1. creator pitch edit persists to the DB (round-trip)', async ({ page }) => {
+    await login(page, 'creator');
+    await openEdit(page);
+
+    const marker = `E2E persistence ${Date.now()}`;
+    const synopsis = page.getByRole('textbox', { name: /Short Synopsis/i });
+    await synopsis.fill(marker);
+
+    await page.getByRole('button', { name: /Save Changes/i }).click();
+    // Success path redirects to the pitch list.
+    await page.waitForURL(/\/creator\/pitches/, { timeout: 20000 });
+
+    // Re-open the edit page fresh — the value must come back from the server.
+    await openEdit(page);
+    await expect(page.getByRole('textbox', { name: /Short Synopsis/i })).toHaveValue(marker);
+  });
+
+  test('2. like state survives a reload (server hydration)', async ({ page }) => {
+    await login(page, 'investor');
+    await openPitch(page);
+
+    const liked = page.getByRole('button', { name: /^Liked$/ });
+    const like = page.getByRole('button', { name: /^Like$/ });
+
+    if (await like.isVisible().catch(() => false)) await like.click();
+    await expect(liked).toBeVisible();
+
+    await page.reload();
+    // Regression guard: before the isLiked-hydration fix this reset to "Like".
+    await expect(liked).toBeVisible();
+
+    // Cleanup — leave the pitch unliked.
+    await liked.click();
+    await expect(like).toBeVisible();
+  });
+
+  test('3. save/bookmark state survives a reload (server hydration)', async ({ page }) => {
+    await login(page, 'investor');
+    await openPitch(page);
+
+    const saved = page.getByRole('button', { name: /^Saved$/ });
+    const save = page.getByRole('button', { name: /^Save$/ });
+
+    if (await save.isVisible().catch(() => false)) await save.click();
+    await expect(saved).toBeVisible();
+
+    await page.reload();
+    // Regression guard: before the isSaved-hydration fix this reset to "Save".
+    await expect(saved).toBeVisible();
+
+    await saved.click();
+    await expect(save).toBeVisible();
+  });
+
+  test('4. edit-page Save button is reachable at a small viewport', async ({ page }) => {
+    // Small viewport is where the PortalLayout inner-scroll clip hid the bottom of
+    // long forms — the Save button became unreachable. Window-scroll must reach it.
+    await page.setViewportSize({ width: 1024, height: 640 });
+    await login(page, 'creator');
+    await openEdit(page);
+
+    const save = page.getByRole('button', { name: /Save Changes/i });
+    await save.scrollIntoViewIfNeeded();
+    await expect(save).toBeInViewport();
+  });
+
+  test('5. anonymous viewer sees no document download links', async ({ page }) => {
+    // Gating guard: PitchDocuments (script/deck/treatment download links) must not
+    // render for an unauthenticated, non-NDA viewer. Image files must never appear
+    // as download rows at all.
+    await openPitch(page); // no login → anonymous
+
+    // The Media & Assets download list links to /api/media/file/*. None should be
+    // visible to anon. (Cover image renders as an <img>, which is allowed.)
+    const downloadLinks = page.locator('a[href*="/api/media/file/"]:visible');
+    await expect(downloadLinks).toHaveCount(0);
+  });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -261,10 +261,15 @@ export default defineConfig({
         }
       },
       {
-        command: 'cd .. && npx wrangler dev',
+        // --port 8001 is required: vite (above) calls the API at :8001, but
+        // `wrangler dev` defaults to :8787, so without this the API is unreachable
+        // and Playwright times out waiting for :8001. Hyperdrive needs a local
+        // Postgres conn string — set CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE
+        // (see e2e README) so the worker can reach the DB during local E2E.
+        command: 'cd .. && npx wrangler dev --port 8001',
         port: 8001,
         reuseExistingServer: true,
-        timeout: 60000,
+        timeout: 90000,
       },
     ],
   }),

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -57,6 +57,20 @@ export default defineConfig({
       timeout: 120000, // Extended timeout for setup
     },
 
+    // Smoke-regression: fast guards for silent-failure bugs (persistence, per-user
+    // state hydration, layout reachability, gating). Runs against local dev where
+    // Turnstile is disabled. No setup dependency — logs in inline per test.
+    {
+      name: 'smoke-regression',
+      testMatch: /smoke-regression\.spec\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1400, height: 900 },
+        trace: 'on-first-retry',
+      },
+      timeout: 60000,
+    },
+
     // PRIORITY 1: Critical User Journey Tests (run first)
     {
       name: 'critical-user-journeys',
@@ -225,7 +239,7 @@ export default defineConfig({
       testMatch: /pitch-upload-with-media\.spec\.ts/,
       use: {
         ...devices['Desktop Chrome'],
-        baseURL: 'https://pitchey.pages.dev',
+        baseURL: 'https://pitchey-5o8.pages.dev', // pitchey.pages.dev was deleted 2026-04-21 (NXDOMAIN)
         viewport: { width: 1400, height: 900 },
         video: 'on',
         trace: 'on'

--- a/frontend/src/features/pitches/components/PitchDocuments.tsx
+++ b/frontend/src/features/pitches/components/PitchDocuments.tsx
@@ -43,6 +43,26 @@ function DocRow({ url, label }: { url?: string; label: string }) {
   );
 }
 
+// Image files (covers, stills, posters) are visual assets — they render as the
+// cover-image preview, not as downloadable "document" rows. Filter them out of
+// the attachment list so e.g. a `test-upload.png` never surfaces as a download
+// link under the cover image.
+const IMAGE_EXT = /\.(png|jpe?g|gif|webp|heic|heif|bmp|svg|avif|tiff?)$/i;
+function isImageDoc(d: PitchDocumentRow): boolean {
+  const name = d.original_file_name || d.file_name || '';
+  // file_url may carry ?token=…&filename=… query params — test the path only.
+  const urlPath = (d.file_url || d.url || '').split('?')[0];
+  const type = (d.document_type || '').toLowerCase();
+  return (
+    IMAGE_EXT.test(name) ||
+    IMAGE_EXT.test(decodeURIComponent(urlPath)) ||
+    type.includes('image') ||
+    type.includes('cover') ||
+    type.includes('poster') ||
+    type.includes('still')
+  );
+}
+
 export default function PitchDocuments({
   documents = [],
   script,
@@ -50,7 +70,7 @@ export default function PitchDocuments({
   trailer,
   className = '',
 }: PitchDocumentsProps) {
-  const docs = Array.isArray(documents) ? documents : [];
+  const docs = (Array.isArray(documents) ? documents : []).filter((d) => !isImageDoc(d));
   const legacy = [
     script ? { label: 'Script', url: script } : null,
     pitchDeck ? { label: 'Pitch Deck', url: pitchDeck } : null,

--- a/frontend/src/pages/PitchDetail.tsx
+++ b/frontend/src/pages/PitchDetail.tsx
@@ -798,28 +798,46 @@ export default function PitchDetail() {
               ) : null
             )}
 
-            {/* Media */}
-            {(pitch.titleImage || (pitch as any).documents?.length || (pitch as any).script || (pitch as any).pitchDeck || (pitch as any).trailer || pitch.scriptUrl || pitch.trailerUrl) && (
-              <div className="bg-white rounded-xl shadow-sm p-6">
-                <h3 className="text-lg font-semibold text-gray-900 mb-4">Media & Assets</h3>
-                {pitch.titleImage && (
-                  <div className="border rounded-lg p-4 mb-4 max-w-md">
-                    <h4 className="font-medium text-gray-900 mb-2">Cover Image</h4>
-                    <img
-                      src={pitch.titleImage}
-                      alt="Pitch cover"
-                      className="w-full h-48 object-cover rounded-lg"
+            {/* Media. Cover image is a public asset (shown on marketplace +
+                public pitch pages); document downloads (script/deck/trailer/
+                attachments) are gated to owner + NDA-signed viewers — they
+                were previously rendered to anyone, leaking downloadable files
+                to anonymous / press viewers. */}
+            {(() => {
+              const canViewDocuments = isOwner || hasSignedNDA;
+              const hasDocuments = !!(
+                (pitch as any).documents?.length ||
+                (pitch as any).script ||
+                (pitch as any).pitchDeck ||
+                (pitch as any).trailer ||
+                pitch.scriptUrl ||
+                pitch.trailerUrl
+              );
+              if (!pitch.titleImage && !(hasDocuments && canViewDocuments)) return null;
+              return (
+                <div className="bg-white rounded-xl shadow-sm p-6">
+                  <h3 className="text-lg font-semibold text-gray-900 mb-4">Media & Assets</h3>
+                  {pitch.titleImage && (
+                    <div className="border rounded-lg p-4 mb-4 max-w-md">
+                      <h4 className="font-medium text-gray-900 mb-2">Cover Image</h4>
+                      <img
+                        src={pitch.titleImage}
+                        alt="Pitch cover"
+                        className="w-full h-48 object-cover rounded-lg"
+                      />
+                    </div>
+                  )}
+                  {canViewDocuments && (
+                    <PitchDocuments
+                      documents={(pitch as any).documents}
+                      script={(pitch as any).script ?? pitch.scriptUrl}
+                      pitchDeck={(pitch as any).pitchDeck ?? (pitch as any).pitchDeckUrl}
+                      trailer={(pitch as any).trailer ?? pitch.trailerUrl}
                     />
-                  </div>
-                )}
-                <PitchDocuments
-                  documents={(pitch as any).documents}
-                  script={(pitch as any).script ?? pitch.scriptUrl}
-                  pitchDeck={(pitch as any).pitchDeck ?? (pitch as any).pitchDeckUrl}
-                  trailer={(pitch as any).trailer ?? pitch.trailerUrl}
-                />
-              </div>
-            )}
+                  )}
+                </div>
+              );
+            })()}
 
             {/* Feedback & Ratings — visible to all viewers (anon included).
                 Quick-rate (1-5 stars) is open to anyone except the owner;

--- a/frontend/src/pages/PitchDetail.tsx
+++ b/frontend/src/pages/PitchDetail.tsx
@@ -148,6 +148,7 @@ export default function PitchDetail() {
       // this the heart always renders empty ("Like") on load even when the
       // viewer already liked the pitch, only flipping after a click this session.
       setIsLiked(!!(pitch as any).isLiked);
+      setIsSaved(!!(pitch as any).isSaved);
       const ndaStatus = pitch.hasSignedNDA || pitch.hasNDA || hasProtectedFields;
       setHasSignedNDA(ndaStatus);
       

--- a/frontend/src/pages/PitchDetail.tsx
+++ b/frontend/src/pages/PitchDetail.tsx
@@ -144,6 +144,10 @@ export default function PitchDetail() {
       }
 
       setPitch(pitch);
+      // Hydrate the per-user like state from the server's isLiked flag — without
+      // this the heart always renders empty ("Like") on load even when the
+      // viewer already liked the pitch, only flipping after a click this session.
+      setIsLiked(!!(pitch as any).isLiked);
       const ndaStatus = pitch.hasSignedNDA || pitch.hasNDA || hasProtectedFields;
       setHasSignedNDA(ndaStatus);
       

--- a/frontend/src/shared/components/layout/PortalLayout.tsx
+++ b/frontend/src/shared/components/layout/PortalLayout.tsx
@@ -55,10 +55,18 @@ export function PortalLayout({ userType }: PortalLayoutProps) {
         userType={userType}
       />
 
-      <div className="flex h-[calc(100vh-4rem)]">
-        {/* Sidebar - Desktop */}
+      {/* min-h (not fixed h) so the row grows with content and the WINDOW scrolls.
+          A fixed h-[calc(100vh-4rem)] + overflow-y-auto on <main> made content scroll
+          inside an inner pane — on shorter/mobile viewports 100vh overshoots the visible
+          area, leaving the bottom of long forms (the Save button) unreachable, plus
+          blank-strip repaint while scrolling. The sticky header (top-0) + sticky sidebar
+          (top-16) keep the chrome pinned during natural window scroll. */}
+      <div className="flex min-h-[calc(100vh-4rem)]">
+        {/* Sidebar - Desktop. sticky + self-start so it stays pinned beside the
+            scrolling content; own height + overflow so a long nav scrolls internally. */}
         <aside className={`
           hidden lg:block transition-all duration-300 ease-in-out
+          sticky top-16 self-start h-[calc(100vh-4rem)] overflow-y-auto
           ${isDesktopSidebarCollapsed ? 'w-16' : 'w-64'}
         `}>
           {renderSidebar()}
@@ -84,8 +92,9 @@ export function PortalLayout({ userType }: PortalLayoutProps) {
           </>
         )}
 
-        {/* Main Content Area */}
-        <main className="flex-1 overflow-y-auto">
+        {/* Main Content Area — flows naturally; the window scrolls (min-w-0 keeps
+            flex children from forcing horizontal overflow). */}
+        <main className="flex-1 min-w-0">
           {/* Persistent portal identity strip — 3px colored bar that stays visible
               across every route inside this portal. Primary "you are in Watcher"
               signal when page chrome is otherwise shared/neutral. */}

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -5824,6 +5824,7 @@ pitchey_analytics_datapoints_per_minute 1250
 
       // Check if the authenticated user has liked this pitch and if they own it
       let isLiked = false;
+      let isSaved = false;
       let isOwner = false;
       let authUserId: number | null = null;
       let viewerUserType: string | null = null;
@@ -5838,6 +5839,17 @@ pitchey_analytics_datapoints_per_minute 1250
             SELECT 1 FROM likes WHERE user_id = ${authResult.user.id} AND pitch_id = ${pitchId} LIMIT 1
           `;
           isLiked = likeResult.length > 0;
+          // Per-user save state. saved_pitches uses user_id::text comparison to
+          // tolerate id-type drift (matches checkPitchSaved). Wrapped so a missing
+          // table in older envs can't 500 the whole pitch view.
+          try {
+            const saveResult = await sql`
+              SELECT 1 FROM saved_pitches
+              WHERE user_id::text = ${String(authResult.user.id)} AND pitch_id = ${pitchId}
+              LIMIT 1
+            `;
+            isSaved = saveResult.length > 0;
+          } catch { /* saved_pitches may not exist in all envs */ }
           // NDA access — primary check via signer_id (matches engagement handler).
           // Fallback to requester_id / user_id / pitch_access for legacy
           // records from older schemas.
@@ -5944,6 +5956,7 @@ pitchey_analytics_datapoints_per_minute 1250
         longSynopsis: longSynopsisOut,
         synopsisTruncated,
         isLiked,
+        isSaved,
         isOwner,
         hasSignedNDA: hasNDAAccess,
         hasNDA: hasNDAAccess,


### PR DESCRIPTION
Six commits closing a cluster of **silent-failure** bugs (no exceptions, no failing unit test — found by driving the real app) plus an E2E suite that guards the whole class going forward.

## Fixes

**Media gating** (`b8547163`)
- Image files (e.g. a stray `test-upload.png`) no longer render as downloadable links under the cover image — images belong as the cover preview, not the document list.
- Remaining document downloads (script/deck/treatment/trailer) gated to owner + NDA-signed; cover image stays public. (Also deleted the leftover test doc row + R2 object.)

**Per-user state hydration** (`eff75adb`, `98a11573`)
- `PitchDetail` ignored the server's per-user `isLiked`/`isSaved` flags — the heart/bookmark always rendered empty on load until clicked. `getPitch` now returns `isSaved` (it already returned `isLiked`); the frontend seeds both from the response. This is the "Karl sees a different like" report.

**Portal layout — window scroll** (`503bb850`)
- `PortalLayout` scrolled page content inside a fixed-height `overflow-y-auto` pane, so on shorter viewports the bottom of long forms (the edit page's **Save Changes** button) was unreachable. Switched to natural window scroll with a sticky header + sticky sidebar. Affects all three portals.

## Tests

**Smoke-regression E2E** (`09bdea29`, `432a7c9a`)
- New `frontend/e2e/smoke-regression.spec.ts` — 5 browser guards mapping 1:1 to the fixes above (persistence round-trip, like/save hydration across reload, Save-button reachability, anon document-gating). **All 5 verified green locally** against vite + `wrangler dev` → Neon.
- New `.github/workflows/e2e-smoke.yml` runs them on PRs. ⚠️ **Requires repo secret `E2E_DATABASE_URL`** (Neon prod conn works) — fails fast with a clear message if unset. Pending first run on the GH runner.
- Fixed harness bit-rot found along the way: legacy login URL (`/<portal>/login` → `/login/<portal>`), `wrangler dev --port 8001` (vite calls :8001, wrangler defaulted :8787), demo-account Turnstile bypass for headless login, and the `production` project's dead `pitchey.pages.dev` baseURL.

## Verification
- Media gating, like/save hydration, and the scroll fix were each confirmed live in the browser this session; the scroll fix verified via `wrangler` deploy + DOM probe (Save button reachable).
- E2E: 5/5 pass locally. Merges cleanly into main (no conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)