### PR TITLE
fix(pitch-docs): defensive decode guard + self-healing E2E cleanup

### DIFF
--- a/frontend/e2e/smoke-regression.spec.ts
+++ b/frontend/e2e/smoke-regression.spec.ts
@@ -65,8 +65,13 @@ test.describe('smoke-regression: silent-failure guards', () => {
     await openEdit(page);
 
     // Capture the current value so we can restore it — this runs on every PR
-    // against a shared demo pitch; the test must leave it as it found it.
-    const original = await page.getByRole('textbox', { name: /Short Synopsis/i }).inputValue();
+    // against a shared demo pitch; the test must leave it as it found it. If a
+    // prior run died before its restore step (leaving a marker), DON'T propagate
+    // that marker — reset to a clean placeholder so the demo pitch self-heals.
+    const current = await page.getByRole('textbox', { name: /Short Synopsis/i }).inputValue();
+    const restoreTo = /^E2E persistence \d+/.test(current)
+      ? 'A gripping story — full synopsis available to verified viewers.'
+      : current;
     const marker = `E2E persistence ${Date.now()}`;
 
     await page.getByRole('textbox', { name: /Short Synopsis/i }).fill(marker);
@@ -78,8 +83,9 @@ test.describe('smoke-regression: silent-failure guards', () => {
     await openEdit(page);
     await expect(page.getByRole('textbox', { name: /Short Synopsis/i })).toHaveValue(marker);
 
-    // Restore the original value so the demo pitch isn't left mutated.
-    await page.getByRole('textbox', { name: /Short Synopsis/i }).fill(original);
+    // Restore so the demo pitch isn't left mutated (clean value if the incoming
+    // state was itself a leftover marker).
+    await page.getByRole('textbox', { name: /Short Synopsis/i }).fill(restoreTo);
     await page.getByRole('button', { name: /Save Changes/i }).click();
     await page.waitForURL(/\/creator\/pitches/, { timeout: 20000 });
   });

--- a/frontend/src/features/pitches/components/PitchDocuments.tsx
+++ b/frontend/src/features/pitches/components/PitchDocuments.tsx
@@ -48,6 +48,11 @@ function DocRow({ url, label }: { url?: string; label: string }) {
 // the attachment list so e.g. a `test-upload.png` never surfaces as a download
 // link under the cover image.
 const IMAGE_EXT = /\.(png|jpe?g|gif|webp|heic|heif|bmp|svg|avif|tiff?)$/i;
+// decodeURIComponent throws on a malformed % sequence; a bad URL must never crash
+// the whole document list render. Fall back to the raw string.
+function safeDecode(s: string): string {
+  try { return decodeURIComponent(s); } catch { return s; }
+}
 function isImageDoc(d: PitchDocumentRow): boolean {
   const name = d.original_file_name || d.file_name || '';
   // file_url may carry ?token=…&filename=… query params — test the path only.
@@ -55,7 +60,7 @@ function isImageDoc(d: PitchDocumentRow): boolean {
   const type = (d.document_type || '').toLowerCase();
   return (
     IMAGE_EXT.test(name) ||
-    IMAGE_EXT.test(decodeURIComponent(urlPath)) ||
+    IMAGE_EXT.test(safeDecode(urlPath)) ||
     type.includes('image') ||
     type.includes('cover') ||
     type.includes('poster') ||


### PR DESCRIPTION
Follow-up to #153.

- **`isImageDoc` defensive guard** — `decodeURIComponent` throws on a malformed `%` sequence; wrapped in `safeDecode()` so a bad file URL can't crash the document-list render. (The review nit from #153.)
- **Self-healing E2E persistence cleanup** — the smoke test restored the captured synopsis, but a run that died before its restore left an `E2E persistence <ts>` marker that the next run propagated. Now resets to a clean placeholder when the incoming value is a marker. Demo pitch 229 also reset to its clean synopsis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)