### PR TITLE
fix(frontend): de-silence dangerous catch-swallows + tag fire-and-forget

### DIFF
--- a/frontend/src/components/EnhancedNavigationShadcn.tsx
+++ b/frontend/src/components/EnhancedNavigationShadcn.tsx
@@ -60,6 +60,7 @@ export function EnhancedNavigationShadcn({
 
   useEffect(() => {
     if (userType === 'creator') {
+      // fire-and-forget: cosmetic credit pill; defaults to 0 if it fails
       paymentsAPI.getCreditBalance().then((data: any) => {
         if (data) {
           setCreditBalance(data.balance?.credits ?? data.credits ?? 0);

--- a/frontend/src/features/notifications/services/notification.service.ts
+++ b/frontend/src/features/notifications/services/notification.service.ts
@@ -164,7 +164,8 @@ export class NotificationService {
     const sound = this.sounds[soundType];
     if (sound) {
       sound.currentTime = 0;
-      sound.play().catch(() => { /* Audio autoplay may be blocked */ });
+      // fire-and-forget: browser autoplay policy may block this; non-actionable
+      sound.play().catch(() => {});
     }
   }
 

--- a/frontend/src/features/notifications/services/presence-fallback.service.ts
+++ b/frontend/src/features/notifications/services/presence-fallback.service.ts
@@ -77,9 +77,8 @@ class PresenceFallbackService {
     // Only try to send offline status if the service was running successfully
     // (i.e. not stopped due to endpoint failures)
     if (wasPolling && this.consecutiveFailures < this.MAX_CONSECUTIVE_FAILURES) {
-      this.updatePresence({ status: 'offline' }).catch(() => {
-        // Ignore — we're stopping anyway
-      });
+      // fire-and-forget: best-effort offline ping while tearing down
+      this.updatePresence({ status: 'offline' }).catch(() => {});
     }
   }
 

--- a/frontend/src/pages/InviteLanding.tsx
+++ b/frontend/src/pages/InviteLanding.tsx
@@ -56,11 +56,20 @@ export default function InviteLanding() {
     void loadInvite();
   }, [code]);
 
-  // If already authenticated, try to redeem and redirect
+  // If already authenticated, redeem THEN redirect — only navigate on success.
+  // (Previously the redeem was fire-and-forgotten and we navigated regardless, so a
+  // failed redeem sent the user to the dashboard as if they'd joined the team.)
   useEffect(() => {
     if (isAuthenticated && code && invite?.valid) {
-      apiClient.post(`/api/invites/${code}/redeem`, {}).catch(() => {});
-      navigate('/creator/dashboard', { replace: true });
+      void (async () => {
+        try {
+          await apiClient.post(`/api/invites/${code}/redeem`, {});
+          navigate('/creator/dashboard', { replace: true });
+        } catch (err) {
+          const e = err instanceof Error ? err : new Error(String(err));
+          setError(`Could not redeem this invite: ${e.message}`);
+        }
+      })();
     }
   }, [isAuthenticated, code, invite, navigate]);
 

--- a/frontend/src/portals/production/pages/ProductionPitchView.tsx
+++ b/frontend/src/portals/production/pages/ProductionPitchView.tsx
@@ -486,7 +486,8 @@ const ProductionPitchView: React.FC = () => {
       if (result.checklist) {
         const merged = { ...productionChecklist, ...result.checklist };
         setProductionChecklist(merged);
-        await ProductionService.updatePitchChecklist(pitchId, merged).catch(() => {});
+        await ProductionService.updatePitchChecklist(pitchId, merged).catch(() =>
+          toast.error('Checklist filled on screen but failed to save — it will not persist on reload.'));
       }
 
       // Apply team (preserve existing names if AI returns empty ones)
@@ -500,7 +501,8 @@ const ProductionPitchView: React.FC = () => {
           };
         });
         setTeamMembers(newTeam);
-        await ProductionService.updatePitchTeam(pitchId, newTeam).catch(() => {});
+        await ProductionService.updatePitchTeam(pitchId, newTeam).catch(() =>
+          toast.error('Team filled on screen but failed to save — it will not persist on reload.'));
       }
 
       // Apply notes — create each via API

--- a/frontend/src/services/feedback.service.ts
+++ b/frontend/src/services/feedback.service.ts
@@ -135,7 +135,8 @@ export class FeedbackService {
       // (the api-client wrapper flag, true on any 2xx) instead.
       const res = await apiClient.post<{ rating: number }>(`/api/pitches/${pitchId}/rate`, { rating });
       return res.success;
-    } catch {
+    } catch (e) {
+      console.error('[feedback] submitRating failed', e);
       return false;
     }
   }
@@ -169,7 +170,8 @@ export class FeedbackService {
       // broken even though they saved). Use res.success (the wrapper flag).
       const res = await apiClient.post<{ id: number }>(`/api/pitches/${pitchId}/comments`, { content });
       return res.success;
-    } catch {
+    } catch (e) {
+      console.error('[feedback] submitComment failed', e);
       return false;
     }
   }

--- a/frontend/src/services/slate.service.ts
+++ b/frontend/src/services/slate.service.ts
@@ -63,7 +63,8 @@ export class SlateService {
     try {
       const res = await apiClient.post<Slate>('/api/slates', data);
       return (res as any)?.data ?? res ?? null;
-    } catch {
+    } catch (e) {
+      console.error('[slate] create failed', e);
       return null;
     }
   }
@@ -72,7 +73,8 @@ export class SlateService {
     try {
       const res = await apiClient.put<Slate>(`/api/slates/${id}`, data);
       return (res as any)?.data ?? res ?? null;
-    } catch {
+    } catch (e) {
+      console.error('[slate] update failed', e);
       return null;
     }
   }
@@ -81,7 +83,8 @@ export class SlateService {
     try {
       await apiClient.delete(`/api/slates/${id}`);
       return true;
-    } catch {
+    } catch (e) {
+      console.error('[slate] remove failed', e);
       return false;
     }
   }
@@ -90,7 +93,8 @@ export class SlateService {
     try {
       await apiClient.post(`/api/slates/${slateId}/pitches`, { pitch_id: pitchId });
       return true;
-    } catch {
+    } catch (e) {
+      console.error('[slate] addPitch failed', e);
       return false;
     }
   }
@@ -99,7 +103,8 @@ export class SlateService {
     try {
       await apiClient.delete(`/api/slates/${slateId}/pitches/${pitchId}`);
       return true;
-    } catch {
+    } catch (e) {
+      console.error('[slate] removePitch failed', e);
       return false;
     }
   }
@@ -108,7 +113,8 @@ export class SlateService {
     try {
       await apiClient.put(`/api/slates/${slateId}/pitches/reorder`, { pitch_ids: pitchIds });
       return true;
-    } catch {
+    } catch (e) {
+      console.error('[slate] reorderPitches failed', e);
       return false;
     }
   }


### PR DESCRIPTION
Audited the 63 silent `.catch(() => …)` / `catch {}` frontend sites and fixed the ~11 genuinely-dangerous ones. Most of the 63 are legitimate (`!response.ok` JSON-parse guards that throw afterward, or reads returning a safe default the caller handles).

**Fixed:**
- **`InviteLanding`** — redeem was fire-and-forgotten *and* navigated to the dashboard regardless, so a failed redeem looked like a successful team join. Now awaits, navigates only on success, surfaces the error.
- **`ProductionPitchView`** — the two post-AI-autofill persists (checklist + team) swallowed save failures, leaving AI data on screen that never persisted. Now `toast.error` on failure.
- **`slate.service`** (6 mutations) + **`feedback.service`** (submitRating/submitComment) — silent no-ops on failure; added `console.error` (→ Sentry breadcrumb) so failures stop being invisible. Return contract unchanged (caller toasts are a follow-up).
- Tagged 3 genuine fire-and-forget sites (`// fire-and-forget`): offline presence ping, blocked audio autoplay, cosmetic credit pill.

**Hydration audit (separate ask, no code needed):** `FeedbackSection` already hydrates the viewer's rating (value + done flag) and structured feedback on load; follow + NDA hydrate too. The only per-user hydration gaps were like/save — already fixed. No new gap found.

tsc + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)