### PR TITLE
feat: Karl testing pass — follow/messaging/role-gating/subscription fixes

### DIFF
--- a/frontend/src/components/feedback/FeedbackDisplay.tsx
+++ b/frontend/src/components/feedback/FeedbackDisplay.tsx
@@ -25,7 +25,7 @@ function FeedbackCard({ entry }: { entry: FeedbackEntry }) {
     <div className="border border-gray-100 rounded-xl p-4 space-y-3">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <span className="font-medium text-gray-900 text-sm">{entry.reviewer_name}</span>
+          <span className="font-medium text-gray-900 text-sm">{entry.is_anonymous ? 'Anonymous' : entry.reviewer_name}</span>
           <ReviewerBadge type={entry.reviewer_type} />
           {entry.is_interested && (
             <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-700">

--- a/frontend/src/config/subscription-plans.ts
+++ b/frontend/src/config/subscription-plans.ts
@@ -67,6 +67,11 @@ export const CREDIT_COSTS: CreditCost[] = [
     description: 'NDA request to access pitch details'
   },
   {
+    action: 'contact_recipient',
+    credits: 1,
+    description: 'Start a conversation with a new person (1 credit per person, then free)'
+  },
+  {
     action: 'ai_extract',
     credits: 5,
     description: 'AI auto-fill pitch from uploaded document'

--- a/frontend/src/features/billing/components/SubscriptionCard.tsx
+++ b/frontend/src/features/billing/components/SubscriptionCard.tsx
@@ -222,6 +222,10 @@ export default function SubscriptionCard({ subscription, onRefresh }: Subscripti
           const annualSavings = !isFree && monthly > 0
             ? Math.max(0, monthly * 12 - annual)
             : 0;
+          // A paid tier priced below the current tier is a downgrade, not an upgrade
+          // (e.g. Karl on the unlimited/top plan sees "Downgrade" for cheaper tiers).
+          const currentMonthly = currentTierDef?.price?.monthly ?? 0;
+          const isDowngrade = !isCurrentPlan && !isFree && monthly < currentMonthly;
 
           return (
             <div
@@ -300,6 +304,8 @@ export default function SubscriptionCard({ subscription, onRefresh }: Subscripti
                 className={`w-full py-3 px-4 rounded-lg font-medium text-sm transition-colors ${
                   isCurrentPlan || isFree
                     ? 'bg-gray-100 text-gray-500 cursor-not-allowed'
+                    : isDowngrade
+                    ? 'border-2 border-gray-300 text-gray-700 hover:bg-gray-50'
                     : isPopular
                     ? 'bg-gradient-to-r from-purple-600 to-indigo-600 text-white hover:shadow-lg'
                     : 'bg-purple-600 text-white hover:bg-purple-700'
@@ -311,6 +317,8 @@ export default function SubscriptionCard({ subscription, onRefresh }: Subscripti
                   ? 'Current Plan'
                   : isFree
                   ? 'Free Forever'
+                  : isDowngrade
+                  ? `Downgrade to ${plan.name}`
                   : `Upgrade to ${plan.name}`}
               </button>
             </div>

--- a/frontend/src/pages/Messages.tsx
+++ b/frontend/src/pages/Messages.tsx
@@ -47,10 +47,9 @@ export default function Messages() {
   const { user } = useBetterAuthStore();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  // Get messaging cost for creators
-  const messageCost = getCreditCost('send_message');
-  const isCreator = user?.userType === 'creator';
-  const isFreeForUser = !isCreator;
+  // 1 credit per NEW person contacted (charged when a conversation is created);
+  // messaging within an existing conversation is free. Unlimited plans skip it.
+  const messageCost = getCreditCost('contact_recipient');
   
   // State management
   const [selectedConversation, setSelectedConversation] = useState<number | null>(null);
@@ -1225,24 +1224,12 @@ export default function Messages() {
                       </div>
                     )}
                     
-                    {/* Cost information for creators */}
-                    {isCreator && (
-                      <div className="p-3 bg-yellow-50 border-b border-yellow-200">
-                        <p className="text-xs text-yellow-800">
-                          💬 <strong>Messaging Cost:</strong> {messageCost} credits per message
-                          {isFreeForUser && <span className="text-green-600 ml-1">(Free for you!)</span>}
-                        </p>
-                      </div>
-                    )}
-                    
-                    {/* Free messaging notice for investors/production */}
-                    {isFreeForUser && (
-                      <div className="p-3 bg-green-50 border-b border-green-200">
-                        <p className="text-xs text-green-800">
-                          ✨ <strong>Free Messaging:</strong> You can send messages at no cost!
-                        </p>
-                      </div>
-                    )}
+                    {/* Messaging cost notice — per new person, then free */}
+                    <div className="p-3 bg-yellow-50 border-b border-yellow-200">
+                      <p className="text-xs text-yellow-800">
+                        💬 <strong>Messaging:</strong> {messageCost} credit to start a conversation with a new person — then messaging them is free.
+                      </p>
+                    </div>
                     
                     <div className="p-4">
                       <div className="flex items-end gap-2">

--- a/frontend/src/pages/PitchDetail.tsx
+++ b/frontend/src/pages/PitchDetail.tsx
@@ -53,7 +53,13 @@ export default function PitchDetail() {
   };
   
   const currentUserId = getUserId();
-  
+
+  // Only investors and production companies may request enhanced/NDA access.
+  // Creators (and watchers) are excluded — a creator viewing another creator's
+  // pitch should not be requesting access.
+  const viewerType = ((user as any)?.userType || (user as any)?.user_type || '').toLowerCase();
+  const canRequestNDA = viewerType === 'investor' || viewerType === 'production';
+
   // Secure owner check - only return true if IDs are valid and match
   const isOwner = (() => {
     // First check the backend-provided isOwner flag (most reliable)
@@ -462,7 +468,7 @@ export default function PitchDetail() {
                 </button>
               ) : (
                 <>
-                  {!hasSignedNDA && !isOwner && (
+                  {!hasSignedNDA && !isOwner && canRequestNDA && (
                     <button
                       onClick={() => setShowEnhancedNDARequest(true)}
                       className="flex items-center gap-2 px-5 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition font-medium shadow-sm"

--- a/frontend/src/pages/PitchDetail.tsx
+++ b/frontend/src/pages/PitchDetail.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useOnlineStatus } from '@/shared/hooks/useOnlineStatus';
 import { useNavigate, useParams, useLocation, Link } from 'react-router-dom';
-import { ArrowLeft, Share2, Eye, Calendar, User, UserCircle, Clock, Tag, Film, LogIn, FileText, Lock, Shield, Briefcase, DollarSign, WifiOff, RefreshCw, Bookmark, Heart } from 'lucide-react';
+import { ArrowLeft, Share2, Eye, Calendar, User, UserCircle, Clock, Tag, Film, LogIn, FileText, Lock, Shield, Briefcase, DollarSign, WifiOff, RefreshCw, Bookmark, Heart, MessageSquare } from 'lucide-react';
 import PitcheyRating from '../components/PitcheyRating';
 import { pitchService } from '@features/pitches/services/pitch.service';
 import PitchDocuments from '@features/pitches/components/PitchDocuments';
@@ -1007,19 +1007,33 @@ export default function PitchDetail() {
                         </button>
                       </>
                     ) : (
-                      // Viewer actions (non-owner)
-                      <button
-                        onClick={() => setShowEnhancedNDARequest(true)}
-                        disabled={hasSignedNDA}
-                        className={`w-full flex items-center gap-2 px-4 py-2 rounded-lg transition ${
-                          hasSignedNDA 
-                            ? 'bg-green-100 text-green-700 cursor-not-allowed' 
-                            : 'bg-blue-100 text-blue-700 hover:bg-blue-200'
-                        }`}
-                      >
-                        <FileText className="w-4 h-4" />
-                        {hasSignedNDA ? 'NDA Signed' : 'Request NDA Access'}
-                      </button>
+                      // Viewer actions (non-owner): Message for everyone; Request NDA
+                      // only for investors/production (creators get Message only).
+                      <div className="space-y-2">
+                        {canRequestNDA && (
+                          <button
+                            onClick={() => setShowEnhancedNDARequest(true)}
+                            disabled={hasSignedNDA}
+                            className={`w-full flex items-center gap-2 px-4 py-2 rounded-lg transition ${
+                              hasSignedNDA
+                                ? 'bg-green-100 text-green-700 cursor-not-allowed'
+                                : 'bg-blue-100 text-blue-700 hover:bg-blue-200'
+                            }`}
+                          >
+                            <FileText className="w-4 h-4" />
+                            {hasSignedNDA ? 'NDA Signed' : 'Request NDA Access'}
+                          </button>
+                        )}
+                        {pitch.creator?.id && (
+                          <button
+                            onClick={() => navigate(`/messages?recipient=${pitch.creator?.id}&pitch=${pitch.id}`)}
+                            className="w-full flex items-center gap-2 px-4 py-2 rounded-lg bg-purple-100 text-purple-700 hover:bg-purple-200 transition"
+                          >
+                            <MessageSquare className="w-4 h-4" />
+                            Message
+                          </button>
+                        )}
+                      </div>
                     )}
                   </>
                 ) : (

--- a/frontend/src/pages/PublicPitchView.tsx
+++ b/frontend/src/pages/PublicPitchView.tsx
@@ -717,10 +717,10 @@ export default function PublicPitchView() {
             {!isAuthenticated && (
               <div className="bg-white rounded-xl shadow-sm p-6">
                 <h3 className="text-lg font-semibold text-gray-900 mb-3">Interested?</h3>
-                <p className="text-sm text-gray-500 mb-4">Create a free account to engage with this pitch and its creator.</p>
+                <p className="text-sm text-gray-500 mb-4">Sign in to engage with this pitch and its creator. New here? You can create an account on the sign-in page.</p>
                 <div className="space-y-2">
                   <button
-                    onClick={() => { void navigate(`/register?redirect=/pitch/${id}&action=like`); }}
+                    onClick={() => { void navigate('/login', { state: { from: `/pitch/${id}` } }); }}
                     className="w-full flex items-center gap-3 px-4 py-2.5 bg-gray-50 hover:bg-red-50 text-gray-700 hover:text-red-600 rounded-lg transition group"
                   >
                     <Heart className="w-4 h-4 group-hover:fill-red-200" />
@@ -728,7 +728,7 @@ export default function PublicPitchView() {
                     <span className="text-xs text-gray-400">Free</span>
                   </button>
                   <button
-                    onClick={() => { void navigate(`/register?redirect=/pitch/${id}&action=follow`); }}
+                    onClick={() => { void navigate('/login', { state: { from: `/pitch/${id}` } }); }}
                     className="w-full flex items-center gap-3 px-4 py-2.5 bg-gray-50 hover:bg-purple-50 text-gray-700 hover:text-purple-600 rounded-lg transition group"
                   >
                     <UserPlus className="w-4 h-4" />
@@ -736,7 +736,7 @@ export default function PublicPitchView() {
                     <span className="text-xs text-gray-400">Free</span>
                   </button>
                   <button
-                    onClick={() => { void navigate(`/register?redirect=/pitch/${id}&action=save`); }}
+                    onClick={() => { void navigate('/login', { state: { from: `/pitch/${id}` } }); }}
                     className="w-full flex items-center gap-3 px-4 py-2.5 bg-gray-50 hover:bg-blue-50 text-gray-700 hover:text-blue-600 rounded-lg transition group"
                   >
                     <Bookmark className="w-4 h-4" />

--- a/frontend/src/portals/creator/pages/CreatorPitchView.tsx
+++ b/frontend/src/portals/creator/pages/CreatorPitchView.tsx
@@ -11,6 +11,7 @@ import apiClient from '@/lib/api-client';
 import { useBetterAuthStore } from '@/store/betterAuthStore';
 import FormatDisplay from '@/components/FormatDisplay';
 import FeedbackDisplay from '@/components/feedback/FeedbackDisplay';
+import FollowButton from '@features/browse/components/FollowButton';
 
 interface Pitch {
   id: string;
@@ -283,6 +284,14 @@ const CreatorPitchView: React.FC = () => {
                   Delete
                 </button>
               </div>
+            )}
+
+            {/* Follow the creator — only when viewing someone else's pitch. Without
+                this, a signed-in creator viewing another creator's pitch had no way
+                to follow (the option exists logged-out on PublicPitchView, then
+                vanished after sign-in because this portal view lacked it). */}
+            {!isOwner && pitch.userId && (
+              <FollowButton creatorId={parseInt(pitch.userId)} />
             )}
           </div>
         </div>

--- a/frontend/src/portals/creator/pages/CreatorPitchView.tsx
+++ b/frontend/src/portals/creator/pages/CreatorPitchView.tsx
@@ -286,12 +286,20 @@ const CreatorPitchView: React.FC = () => {
               </div>
             )}
 
-            {/* Follow the creator — only when viewing someone else's pitch. Without
-                this, a signed-in creator viewing another creator's pitch had no way
-                to follow (the option exists logged-out on PublicPitchView, then
-                vanished after sign-in because this portal view lacked it). */}
+            {/* Viewing someone else's pitch: a creator can Follow + Message the
+                creator (no NDA request for creators). Message starts a conversation
+                (1 credit per new person). Follow previously vanished after sign-in
+                because this portal view lacked it. */}
             {!isOwner && pitch.userId && (
-              <FollowButton creatorId={parseInt(pitch.userId)} />
+              <div className="flex items-center gap-3">
+                <FollowButton creatorId={parseInt(pitch.userId)} />
+                <button
+                  onClick={() => navigate(`/creator/messages?recipient=${pitch.userId}&pitch=${id}`)}
+                  className="flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700"
+                >
+                  <MessageSquare className="h-4 w-4 mr-1" /> Message
+                </button>
+              </div>
             )}
           </div>
         </div>

--- a/frontend/src/portals/investor/pages/InvestorPitchView.tsx
+++ b/frontend/src/portals/investor/pages/InvestorPitchView.tsx
@@ -14,6 +14,7 @@ import { apiClient } from '@/lib/api-client';
 import { InvestorService } from '@features/deals/services/investor.service';
 import FormatDisplay from '@/components/FormatDisplay';
 import PitchDocuments from '@features/pitches/components/PitchDocuments';
+import FollowButton from '@features/browse/components/FollowButton';
 import { getCreditCost } from '@config/subscription-plans';
 
 interface Pitch {
@@ -590,6 +591,14 @@ const InvestorPitchView: React.FC = () => {
                     by {pitch.creatorName || pitch.creatorCompany}
                     {pitch.creatorName && pitch.creatorCompany && ` • ${pitch.creatorCompany}`}
                   </p>
+                )}
+
+                {/* Follow the creator — investors had no follow option once signed in
+                    (it existed logged-out on PublicPitchView, then vanished). */}
+                {pitch.userId && (
+                  <div className="mb-4">
+                    <FollowButton creatorId={parseInt(pitch.userId)} />
+                  </div>
                 )}
 
                 <div className="flex flex-wrap gap-2 mb-6">

--- a/frontend/src/portals/production/pages/ProductionPitchView.tsx
+++ b/frontend/src/portals/production/pages/ProductionPitchView.tsx
@@ -1119,13 +1119,6 @@ const ProductionPitchView: React.FC = () => {
                     </button>
                   )}
                   <button
-                    onClick={() => setShowScheduleModal(true)}
-                    className="w-full flex items-center justify-between px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
-                  >
-                    <span>Schedule Meeting</span>
-                    <ChevronRight className="h-4 w-4" />
-                  </button>
-                  <button
                     onClick={() => {
                       navigate(`/production/messages?recipient=${pitch?.userId}&pitch=${id}`);
                       toast('Start your negotiation discussion');
@@ -1196,8 +1189,10 @@ const ProductionPitchView: React.FC = () => {
               </div>
             </div>
 
-            {/* AI Auto-fill — only for pitches the user owns or has a project for */}
-            {(isOwner || hasExistingProject) && <div className="bg-white rounded-xl shadow-lg p-6">
+            {/* AI Assessment — owner only. Removed when viewing someone else's pitch
+                (a production user assessing another creator's pitch shouldn't see the
+                owner-side auto-fill toolkit). */}
+            {isOwner && <div className="bg-white rounded-xl shadow-lg p-6">
               <h3 className="text-lg font-semibold text-gray-900 mb-3">AI Assessment</h3>
               <p className="text-sm text-gray-500 mb-4">
                 Upload a script, treatment, or pitch deck to auto-fill the feasibility checklist, team priorities, and production notes.

--- a/src/handlers/messaging-simple.ts
+++ b/src/handlers/messaging-simple.ts
@@ -26,6 +26,23 @@ export class SimpleMessagingHandler {
     }
   }
 
+  // Eligibility to START a conversation: a follow relationship in either direction
+  // OR a shared signed NDA. ("Everybody can message everybody through the following
+  // system" + preserves the existing NDA → message flow.)
+  async canStartConversation(userId: number, recipientId: number): Promise<boolean> {
+    try {
+      const follow = await this.db.query(
+        `SELECT 1 FROM follows
+         WHERE (follower_id = $1 AND following_id = $2)
+            OR (follower_id = $2 AND following_id = $1)
+         LIMIT 1`,
+        [userId, recipientId]
+      );
+      if (follow.length > 0) return true;
+    } catch { /* follows table may differ across envs — fall through to NDA */ }
+    return this.hasSignedNDA(userId, recipientId);
+  }
+
   // Get all messages for a user
   async getMessages(userId: number, limit: number = 50, offset: number = 0) {
     try {
@@ -220,10 +237,10 @@ export class SimpleMessagingHandler {
       if (existing.length > 0) {
         conversationId = existing[0].id;
       } else {
-        // NDA required to start a new conversation
-        const hasNDA = await this.hasSignedNDA(userId, recipientId);
-        if (!hasNDA) {
-          return { success: false, error: 'A signed NDA is required to start a conversation with this user' };
+        // Must follow the person (either direction) or share a signed NDA.
+        const allowed = await this.canStartConversation(userId, recipientId);
+        if (!allowed) {
+          return { success: false, error: 'Follow this user (or sign their NDA) to start a conversation' };
         }
 
         // Create new direct conversation

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -19654,10 +19654,37 @@ Signatures: [To be completed upon signing]
       }
 
       const handler = new (await import('./handlers/messaging-simple')).SimpleMessagingHandler(this.db);
+
+      // Messaging model: 1 credit per NEW person contacted. Re-opening an existing
+      // conversation is free. Gate (follow-either-direction OR shared NDA) and charge
+      // BEFORE creation so a 0-credit user can't get a free conversation.
+      const existingConv = await this.db.query(
+        `SELECT c.id FROM conversations c
+         JOIN conversation_participants cp1 ON cp1.conversation_id = c.id AND cp1.user_id = $1
+         JOIN conversation_participants cp2 ON cp2.conversation_id = c.id AND cp2.user_id = $2
+         WHERE c.is_group = FALSE LIMIT 1`,
+        [authCheck.user.id, recipientId]
+      );
+      if (!existingConv || existingConv.length === 0) {
+        const origin = request.headers.get('Origin');
+        const allowed = await handler.canStartConversation(authCheck.user.id, recipientId);
+        if (!allowed) {
+          return new Response(JSON.stringify({ success: false, error: 'Follow this user (or sign their NDA) to start a conversation' }), {
+            headers: { 'Content-Type': 'application/json', ...getCorsHeaders(origin) }, status: 403
+          });
+        }
+        const charge = await this.deductCreditsInternal(authCheck.user.id, 1, 'Start conversation', 'contact_recipient', pitchId);
+        if (!charge.success) {
+          return new Response(JSON.stringify({ success: false, error: charge.error }), {
+            headers: { 'Content-Type': 'application/json', ...getCorsHeaders(origin) }, status: 402
+          });
+        }
+      }
+
       const result = await handler.findOrCreateConversation(authCheck.user.id, recipientId, pitchId);
 
       const origin = request.headers.get('Origin');
-      const httpStatus = result.success ? 200 : (typeof result.error === 'string' && result.error.includes('NDA') ? 403 : 400);
+      const httpStatus = result.success ? 200 : (typeof result.error === 'string' && (result.error.includes('NDA') || result.error.includes('Follow')) ? 403 : 400);
       return new Response(JSON.stringify(result), {
         headers: { 'Content-Type': 'application/json', ...getCorsHeaders(origin) },
         status: httpStatus


### PR DESCRIPTION
Batch of fixes + one feature from Karl's testing pass. **Already deployed to prod** (worker `45f6c6df`, frontend `index-x21P9tBC.js`); this PR lands them in main.

**Pitch-view actions (context-appropriate by role):**
- Follow the creator restored on Creator/Investor portal views (vanished after sign-in).
- Signed-out Like/Follow/Save → sign-in (not create-account).
- Production: removed "Schedule Meeting"; AI Assessment owner-only (was leaking).
- "Request NDA / Enhanced Access" gated to investor/production; creators get **Message** only.
- Message buttons added (PitchDetail sidebar, CreatorPitchView).

**Messaging feature (new model):**
- Everybody can message everybody **through the following system**: `canStartConversation` = follow (either direction) OR shared signed NDA.
- **1 credit per new person contacted** (charged on conversation creation, gated+charged before create; re-contact is free). Config `contact_recipient = 1`; Messages page copy updated.

**Billing:** subscription tiers below the current plan now show **"Downgrade"** (e.g. unlimited-plan users) instead of "Upgrade".

**Feedback:** feed renders **"Anonymous"** for `is_anonymous` entries (defensive; backend already masks names via `canSeeReviewerNames`). Likes stay named.

Not in this PR: reposition overall feedback (needs steer on which view); legacy `POST /api/messages` per-message charge left as-is (unused by UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)