### PR TITLE
feat(activity-feed): land 4-phase Following/Saved pivot — reconcile split-brain prod

### DIFF
--- a/frontend/src/components/DashboardHeader.tsx
+++ b/frontend/src/components/DashboardHeader.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import {
   Menu, X, LogOut, Plus, Eye, Coins, CreditCard,
   Users, Home, Film, Search, Shield, BarChart3,
-  Settings, ChevronDown
+  Settings, ChevronDown, Activity
 } from 'lucide-react';
 import { NotificationBell } from '@features/notifications/components/NotificationBell';
 import { NDANotificationBadge } from '@features/ndas/components/NDANotifications';
@@ -109,7 +109,7 @@ export default function DashboardHeader({
         return [
           ...commonItems,
           { label: 'Projects', href: '/production/projects', icon: Film },
-          { label: 'Submissions', href: '/production/submissions', icon: Eye },
+          { label: 'Activity', href: '/production/activity', icon: Activity },
           { label: 'Team', href: '/production/team', icon: Users },
           { label: 'Analytics', href: '/production/analytics', icon: BarChart3 },
           { label: 'Settings', href: '/settings', icon: Settings },

--- a/frontend/src/components/Onboarding/ProductionOnboarding.tsx
+++ b/frontend/src/components/Onboarding/ProductionOnboarding.tsx
@@ -409,11 +409,11 @@ const SubmissionProcessStep: React.FC<{
         <Button 
           className="flex-1" 
           onClick={() => {
-            navigate(PRODUCTION_ROUTES.submissions);
+            navigate(PRODUCTION_ROUTES.activity);
             onComplete();
           }}
         >
-          View Submissions
+          View Activity
         </Button>
         <Button variant="outline" onClick={onStartTour}>
           Take Tour First

--- a/frontend/src/components/feedback/FeedbackSection.tsx
+++ b/frontend/src/components/feedback/FeedbackSection.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
-import { MessageSquare, ChevronDown, ChevronUp, Clock, Send } from 'lucide-react';
+import { MessageSquare, ChevronDown, ChevronUp, Clock, Send, TrendingUp, Pencil } from 'lucide-react';
 import { FeedbackService } from '../../services/feedback.service';
-import type { FeedbackEntry, ConsumptionStatus, CommentEntry } from '../../services/feedback.service';
+import type { FeedbackEntry, ConsumptionStatus, CommentEntry, FeedbackProgress } from '../../services/feedback.service';
 import StructuredFeedbackForm from './StructuredFeedbackForm';
 import FeedbackDisplay from './FeedbackDisplay';
 import PitcheyRating from '../PitcheyRating';
@@ -17,6 +17,7 @@ interface Props {
 
 export default function FeedbackSection({ pitchId, isOwner, isAuthenticated, userType, showScoreSummary = true }: Props) {
   const [myFeedback, setMyFeedback] = useState<FeedbackEntry | null>(null);
+  const [feedbackProgress, setFeedbackProgress] = useState<FeedbackProgress | null>(null);
   const [showForm, setShowForm] = useState(false);
   const [loadingMine, setLoadingMine] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -47,6 +48,13 @@ export default function FeedbackSection({ pitchId, isOwner, isAuthenticated, use
       setMyFeedback(fb);
       setConsumption(cs);
       setLoadingMine(false);
+      // If the viewer has left feedback, surface whether the pitch has moved since.
+      if (fb) {
+        const progress = await FeedbackService.getFeedbackProgress(pitchId);
+        setFeedbackProgress(progress);
+      } else {
+        setFeedbackProgress(null);
+      }
     }
     // Load existing rating status for quick-rate
     if (canRate) {
@@ -172,6 +180,35 @@ export default function FeedbackSection({ pitchId, isOwner, isAuthenticated, use
                   />
                 </div>
                 <p className="text-xs text-gray-400">{consumption.viewDuration}s / {consumption.threshold}s</p>
+              </div>
+            )}
+
+            {/* Progress from feedback (WS-5): show the reviewer that the pitch moved
+                since they weighed in — edits made and/or score delta. */}
+            {feedbackProgress && (feedbackProgress.editedSinceFeedback || feedbackProgress.scoreDelta != null) && (
+              <div className="mb-4 rounded-lg border border-emerald-200 bg-emerald-50 p-4">
+                <div className="flex items-center gap-2 text-sm font-medium text-emerald-800 mb-1">
+                  <TrendingUp className="w-4 h-4" />
+                  Progress since your feedback
+                </div>
+                <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-emerald-700">
+                  {feedbackProgress.editedSinceFeedback && (
+                    <span className="flex items-center gap-1">
+                      <Pencil className="w-3.5 h-3.5" />
+                      {feedbackProgress.editCount > 0
+                        ? `Updated ${feedbackProgress.editCount} time${feedbackProgress.editCount === 1 ? '' : 's'}`
+                        : 'Updated'} since your feedback
+                    </span>
+                  )}
+                  {feedbackProgress.scoreDelta != null && feedbackProgress.scoreDelta !== 0 && (
+                    <span className="font-semibold">
+                      Pitchey Score {feedbackProgress.scoreAtFeedback?.toFixed(1)} → {feedbackProgress.scoreNow?.toFixed(1)}
+                      <span className={feedbackProgress.scoreDelta > 0 ? 'text-emerald-600' : 'text-red-600'}>
+                        {' '}({feedbackProgress.scoreDelta > 0 ? '+' : ''}{feedbackProgress.scoreDelta.toFixed(1)})
+                      </span>
+                    </span>
+                  )}
+                </div>
               </div>
             )}
 

--- a/frontend/src/config/navigation.routes.ts
+++ b/frontend/src/config/navigation.routes.ts
@@ -120,7 +120,10 @@ export const PRODUCTION_ROUTES = {
   projectsCompleted: '/production/projects/completed',
   pipeline: '/production/pipeline',
   
-  // Submissions
+  // Submissions — PARKED 2026-06-01 (activity-feed pivot, Phase 3). The review
+  // pipeline (shortlist/accept/reject) is retired from nav but kept reachable by
+  // direct URL so the code can be revived. Do not delete; see issue #158.
+  // Routes + ProductionSubmissions* pages + productionSubmissionsHandler stay live.
   submissions: '/production/submissions',
   submissionsNew: '/production/submissions/new',
   submissionsReview: '/production/submissions/review',

--- a/frontend/src/features/billing/components/CreditPurchase.tsx
+++ b/frontend/src/features/billing/components/CreditPurchase.tsx
@@ -1,40 +1,58 @@
 import { useState } from 'react';
-import { 
-  Coins, 
-  Zap, 
-  Star, 
-  Crown, 
+import {
+  Coins,
+  Zap,
+  Star,
+  Crown,
   TrendingUp,
   Upload,
   MessageSquare,
   Eye,
-  BarChart3,
-  ExternalLink
+  FileText,
+  Image,
+  Film,
+  Lock
 } from 'lucide-react';
 import { paymentsAPI } from '@/lib/apiServices';
-import { CREDIT_PACKAGES } from '@config/subscription-plans';
+import { CREDIT_PACKAGES, CREDIT_COSTS } from '@config/subscription-plans';
 
 interface CreditPurchaseProps {
   credits: any;
   onRefresh: () => void;
 }
 
+// Map an ISO currency code to its display symbol. Packages are priced in EUR
+// (matching the live Stripe price IDs), so the symbol is derived from each
+// package's `currency` field rather than hardcoded — keeps the displayed
+// symbol in lockstep with what Stripe actually charges.
+const CURRENCY_SYMBOLS: Record<string, string> = {
+  EUR: '€',
+  USD: '$',
+  GBP: '£',
+};
+
+const currencySymbol = (currency?: string) =>
+  CURRENCY_SYMBOLS[(currency || 'EUR').toUpperCase()] ?? (currency || 'EUR');
+
 // Adapt centralized credit packages for UI display
 const UI_CREDIT_PACKAGES = CREDIT_PACKAGES.map((pkg, index) => {
   const icons = [Zap, TrendingUp, Star, Crown];
   const descriptions = [
     'Perfect for getting started',
-    'Great for growing creators', 
+    'Great for growing creators',
     'Best value for professionals',
     'Maximum value for power users'
   ];
-  
+
+  const symbol = currencySymbol(pkg.currency);
+
   return {
     id: `package_${index}`,
     name: `${pkg.credits} Credit${pkg.credits === 1 ? '' : 's'}${pkg.bonus ? ` + ${pkg.bonus} Bonus` : ''}`,
     credits: pkg.credits,
     price: pkg.price,
-    value: `€${(pkg.price / pkg.credits).toFixed(3)} per credit`,
+    symbol,
+    value: `${symbol}${(pkg.price / pkg.credits).toFixed(3)} per credit`,
     icon: icons[index] || Coins,
     description: pkg.description || descriptions[index] || 'Credit package',
     popular: index === 1, // Make second package popular
@@ -42,32 +60,31 @@ const UI_CREDIT_PACKAGES = CREDIT_PACKAGES.map((pkg, index) => {
   };
 });
 
-const CREDIT_USAGE = [
-  {
-    action: 'Upload Content',
-    cost: 5,
-    icon: Upload,
-    description: 'Upload pitch materials, trailers, or documents'
-  },
-  {
-    action: 'Send Message',
-    cost: 1,
-    icon: MessageSquare,
-    description: 'Send messages to potential investors or collaborators'
-  },
-  {
-    action: 'Premium Analytics',
-    cost: 10,
-    icon: BarChart3,
-    description: 'Access detailed analytics and insights'
-  },
-  {
-    action: 'Email Support',
-    cost: 20,
-    icon: Star,
-    description: 'Get email customer support'
-  }
-];
+// Derived from the backend's single source of truth (CREDIT_COSTS in
+// subscription-plans.ts) so the "How Credits Work" guide can never drift from
+// what users are actually charged. Presentation-only metadata (icon + label)
+// is mapped per action; cost/description come from config.
+const CREDIT_ACTION_META: Record<string, { label: string; icon: typeof Coins }> = {
+  basic_upload: { label: 'New Pitch Upload', icon: Upload },
+  word_doc: { label: 'Document (script, budget, treatment)', icon: FileText },
+  picture_doc: { label: 'Picture Document (lookbook, mood board)', icon: Image },
+  extra_image: { label: 'Extra Image', icon: Image },
+  video_link: { label: 'Video Link', icon: Film },
+  promoted_pitch: { label: 'Promoted Pitch', icon: TrendingUp },
+  view_pitch: { label: 'View a Pitch', icon: Eye },
+  send_message: { label: 'Send Message', icon: MessageSquare },
+  nda_request: { label: 'NDA Access Request', icon: Lock },
+};
+
+const CREDIT_USAGE = CREDIT_COSTS.map((c) => {
+  const meta = CREDIT_ACTION_META[c.action];
+  return {
+    action: meta?.label ?? c.action,
+    cost: c.credits,
+    icon: meta?.icon ?? Coins,
+    description: c.description,
+  };
+});
 
 export default function CreditPurchase({ credits, onRefresh }: CreditPurchaseProps) {
   const [loading, setLoading] = useState(false);
@@ -216,7 +233,7 @@ export default function CreditPurchase({ credits, onRefresh }: CreditPurchasePro
                 <div className="space-y-3 mb-6">
                   <div className="text-center">
                     <div className="text-2xl font-bold text-purple-600">
-                      ${pkg.price}
+                      {pkg.symbol}{pkg.price}
                     </div>
                     <div className="text-sm text-gray-500">{pkg.value}</div>
                   </div>

--- a/frontend/src/pages/Following.tsx
+++ b/frontend/src/pages/Following.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { ArrowLeft, TrendingUp, Users, Film, Calendar, MapPin, Eye, Heart, AlertCircle, Search, Bookmark } from 'lucide-react';
+import { ArrowLeft, TrendingUp, Users, Film, Calendar, MapPin, Eye, Heart, AlertCircle, Search, Bookmark, FileText } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import { API_URL } from '../config';
 import { useBetterAuthStore } from '../store/betterAuthStore';
@@ -27,7 +27,7 @@ interface Creator {
 
 interface ActivityUpdate {
   id: number;
-  type: 'pitch_created' | 'pitch_updated' | 'new_follower';
+  type: 'pitch_created' | 'pitch_updated' | 'new_follower' | 'message_attachment';
   creator: {
     id: number;
     username: string;
@@ -44,6 +44,13 @@ interface ActivityUpdate {
     requireNda?: boolean;
     ndaSigned?: boolean;
     ndaPending?: boolean;
+  };
+  // Present for message_attachment events (a creator shared a file with you).
+  attachment?: {
+    fileName: string;
+    count: number;
+    conversationId?: number;
+    pitchId?: number;
   };
   createdAt: string;
 }
@@ -76,6 +83,31 @@ const mapPitchesToActivities = (pitches: any[]): ActivityUpdate[] =>
 // Map a unified activity_feed item (from /api/activity/feed) into an activity item.
 const mapFeedItem = (item: any): ActivityUpdate | null => {
   if (!item || !item.actor) return null;
+
+  // Messaged attachment — a creator shared a file with you (recipient-only event).
+  if (item.action === 'message_attachment') {
+    const md = item.metadata || {};
+    const count = Number(md.attachmentCount) || 1;
+    return {
+      id: item.id,
+      type: 'message_attachment',
+      creator: {
+        id: item.actor.id,
+        username: item.actor.name || item.actor.username || 'Someone',
+        profileImage: item.actor.profileImage,
+        userType: item.actor.userType || 'creator',
+      },
+      action: count > 1 ? `shared ${count} files with you` : 'shared a document with you',
+      attachment: {
+        fileName: md.fileName || 'a file',
+        count,
+        conversationId: md.conversationId,
+        pitchId: md.pitchId,
+      },
+      createdAt: item.createdAt || '',
+    };
+  }
+
   const isUpdate = item.action === 'pitch_updated';
   return {
     id: item.id,
@@ -381,6 +413,27 @@ const Following: React.FC = () => {
                               </span>
                             )
                           )}
+                        </div>
+                      </div>
+                    )}
+
+                    {update.attachment && (
+                      <div
+                        className="cursor-pointer group flex items-center gap-3 p-3 bg-gray-50 rounded-lg border border-gray-100 hover:border-blue-200"
+                        onClick={() => navigate(
+                          update.attachment!.conversationId
+                            ? `/messages?conversation=${update.attachment!.conversationId}`
+                            : '/messages'
+                        )}
+                      >
+                        <div className="w-9 h-9 bg-blue-100 rounded-lg flex items-center justify-center flex-shrink-0">
+                          <FileText className="w-5 h-5 text-blue-600" />
+                        </div>
+                        <div className="min-w-0">
+                          <p className="font-medium text-gray-900 group-hover:text-blue-600 truncate">
+                            {update.attachment.fileName}
+                          </p>
+                          <p className="text-xs text-gray-500">View in Messages →</p>
                         </div>
                       </div>
                     )}

--- a/frontend/src/pages/Following.tsx
+++ b/frontend/src/pages/Following.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { ArrowLeft, TrendingUp, Users, Film, Calendar, MapPin, Eye, Heart, AlertCircle, Search } from 'lucide-react';
+import { ArrowLeft, TrendingUp, Users, Film, Calendar, MapPin, Eye, Heart, AlertCircle, Search, Bookmark } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import { API_URL } from '../config';
 import { useBetterAuthStore } from '../store/betterAuthStore';
 import { SocialService } from '@features/browse/services/social.service';
+import { SavedPitchesService, type SavedPitch } from '@features/pitches/services/saved-pitches.service';
 import { getPortalPath } from '@/utils/navigation';
 
 interface Creator {
@@ -47,13 +48,67 @@ interface ActivityUpdate {
   createdAt: string;
 }
 
+// Map a followed-creator pitch row (from /api/pitches/following) into an activity item.
+// Used as the fallback when the unified activity_feed is empty (e.g. pre-migration).
+const mapPitchesToActivities = (pitches: any[]): ActivityUpdate[] =>
+  pitches.map((p: any) => ({
+    id: p.id,
+    type: 'pitch_created' as const,
+    creator: {
+      id: p.user_id || p.userId,
+      username: p.creator_name || p.creator_email?.split('@')[0] || 'Creator',
+      profileImage: p.creator_profile_image || p.profile_image,
+      userType: 'creator',
+    },
+    action: 'published a pitch',
+    pitch: {
+      id: p.id,
+      title: p.title,
+      genre: p.genre || '',
+      logline: p.logline || p.short_synopsis || '',
+      requireNda: Boolean(p.requireNda ?? p.require_nda),
+      ndaSigned: Boolean(p.ndaSigned ?? p.nda_signed),
+      ndaPending: Boolean(p.ndaPending ?? p.nda_pending),
+    },
+    createdAt: p.created_at || p.createdAt || '',
+  }));
+
+// Map a unified activity_feed item (from /api/activity/feed) into an activity item.
+const mapFeedItem = (item: any): ActivityUpdate | null => {
+  if (!item || !item.actor) return null;
+  const isUpdate = item.action === 'pitch_updated';
+  return {
+    id: item.id,
+    type: isUpdate ? 'pitch_updated' : 'pitch_created',
+    creator: {
+      id: item.actor.id,
+      username: item.actor.name || item.actor.username || 'Creator',
+      profileImage: item.actor.profileImage,
+      userType: item.actor.userType || 'creator',
+    },
+    action: isUpdate ? 'updated a pitch' : 'published a pitch',
+    pitch: item.pitch
+      ? {
+          id: item.pitch.id,
+          title: item.pitch.title,
+          genre: item.pitch.genre || '',
+          logline: item.pitch.logline || '',
+          requireNda: Boolean(item.pitch.requireNda),
+        }
+      : undefined,
+    createdAt: item.createdAt || '',
+  };
+};
+
 const Following: React.FC = () => {
   const [searchParams] = useSearchParams();
-  const initialTab = (['activity', 'followers', 'following'] as const).includes(searchParams.get('tab') as any)
-    ? (searchParams.get('tab') as 'activity' | 'followers' | 'following')
+  type TabKey = 'activity' | 'followers' | 'following' | 'saved';
+  const initialTab = (['activity', 'followers', 'following', 'saved'] as const).includes(searchParams.get('tab') as any)
+    ? (searchParams.get('tab') as TabKey)
     : 'followers';
-  const [activeTab, setActiveTab] = useState<'activity' | 'followers' | 'following'>(initialTab);
+  const [activeTab, setActiveTab] = useState<TabKey>(initialTab);
   const [data, setData] = useState<(Creator[] | ActivityUpdate[])>([]);
+  const [savedPitches, setSavedPitches] = useState<SavedPitch[]>([]);
   const [summary, setSummary] = useState({
     newPitches: 0,
     activeCreators: 0,
@@ -76,65 +131,75 @@ const Following: React.FC = () => {
     setLoading(true);
     setError(null);
     setData([]);
+    setSavedPitches([]);
 
     try {
-      // Note: Better Auth uses cookies, not localStorage tokens
-      // The route protection in App.tsx handles unauthenticated users
-
-      let endpoint: string;
-      
-      // Use different endpoints based on the active tab
-      if (activeTab === 'activity') {
-        endpoint = '/api/pitches/following';
-      } else if (activeTab === 'followers') {
-        endpoint = '/api/follows/followers';
-      } else if (activeTab === 'following') {
-        endpoint = '/api/follows/following';
-      } else {
-        endpoint = '/api/follows/following'; // default
+      // Saved tab — reuse the saved-pitches service (its own data shape).
+      if (activeTab === 'saved') {
+        const res = await SavedPitchesService.getSavedPitches({ limit: 50 });
+        setSavedPitches(res.savedPitches || []);
+        return;
       }
-      
-    const separator = endpoint.includes('?') ? '&' : '?';
-    const url = timeframe && timeframe !== 'all' ? `${API_URL}${endpoint}${separator}timeframe=${timeframe}` : `${API_URL}${endpoint}`;
-    const response = await fetch(url, {
-      method: 'GET',
-      credentials: 'include' // Send cookies for Better Auth session
-    });
+
+      // Activity tab — prefer the unified activity_feed; fall back to
+      // followed-creator pitches when the feed is empty (e.g. pre-migration,
+      // or no events emitted yet).
+      if (activeTab === 'activity') {
+        let activities: ActivityUpdate[] = [];
+        let summaryFromApi: typeof summary | null = null;
+        try {
+          const feedRes = await fetch(`${API_URL}/api/activity/feed?limit=30`, {
+            method: 'GET',
+            credentials: 'include',
+          });
+          if (feedRes.ok) {
+            const fr = await feedRes.json();
+            if (fr?.summary) summaryFromApi = fr.summary;
+            const items = fr?.data?.items || fr?.items || [];
+            activities = items.map(mapFeedItem).filter(Boolean) as ActivityUpdate[];
+          }
+        } catch {
+          // ignore — fall through to the pitches-following fallback
+        }
+        if (activities.length === 0) {
+          const tf = timeframe && timeframe !== 'all' ? `?timeframe=${timeframe}` : '';
+          const fb = await fetch(`${API_URL}/api/pitches/following${tf}`, {
+            method: 'GET',
+            credentials: 'include',
+          });
+          if (!fb.ok) {
+            throw new Error('Failed to fetch following data');
+          }
+          const result = await fb.json();
+          if (result.success) {
+            if (result.summary) summaryFromApi = result.summary;
+            const pitches = result.data?.pitches || result.pitches || result.data || [];
+            activities = mapPitchesToActivities(pitches);
+          }
+        }
+        setData(activities);
+        if (summaryFromApi) setSummary(summaryFromApi);
+        return;
+      }
+
+      // Followers / Following lists.
+      const endpoint = activeTab === 'followers' ? '/api/follows/followers' : '/api/follows/following';
+      const separator = endpoint.includes('?') ? '&' : '?';
+      const url = timeframe && timeframe !== 'all' ? `${API_URL}${endpoint}${separator}timeframe=${timeframe}` : `${API_URL}${endpoint}`;
+      const response = await fetch(url, {
+        method: 'GET',
+        credentials: 'include' // Send cookies for session
+      });
 
       if (!response.ok) {
         throw new Error('Failed to fetch following data');
       }
 
       const result = await response.json();
-      
+
       if (result.success) {
         // Handle different response formats based on the tab
-        if (activeTab === 'activity') {
-          // Transform pitches from followed creators into activity items
-          const pitches = result.data?.pitches || result.pitches || result.data || [];
-          const activities = pitches.map((p: any) => ({
-            id: p.id,
-            type: 'pitch_created' as const,
-            creator: {
-              id: p.user_id || p.userId,
-              username: p.creator_name || p.creator_email?.split('@')[0] || 'Creator',
-              profileImage: p.creator_profile_image || p.profile_image,
-              userType: 'creator',
-            },
-            action: 'published a pitch',
-            pitch: {
-              id: p.id,
-              title: p.title,
-              genre: p.genre || '',
-              logline: p.logline || p.short_synopsis || '',
-              requireNda: Boolean(p.requireNda ?? p.require_nda),
-              ndaSigned: Boolean(p.ndaSigned ?? p.nda_signed),
-              ndaPending: Boolean(p.ndaPending ?? p.nda_pending),
-            },
-            createdAt: p.created_at || p.createdAt || '',
-          }));
-          setData(activities);
-        } else if (activeTab === 'followers') {
+        if (activeTab === 'followers') {
           const raw = result.data?.followers || result.data?.users || result.followers || result.data || [];
           setData(raw.map((f: any) => ({
             ...f,
@@ -565,6 +630,69 @@ const Following: React.FC = () => {
     );
   };
 
+  const renderSavedTab = () => {
+    return (
+      <div className="space-y-4">
+        {savedPitches.length === 0 ? (
+          <div className="bg-white p-8 rounded-lg shadow-sm border text-center">
+            <Bookmark className="w-12 h-12 text-gray-400 mx-auto mb-3" />
+            <p className="text-gray-500 mb-4">You haven't saved any pitches yet</p>
+            <button
+              onClick={() => navigate('/marketplace')}
+              className="bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700"
+            >
+              Browse Marketplace
+            </button>
+          </div>
+        ) : (
+          savedPitches.filter(sp => sp && (sp.pitch || sp.pitchId)).map((sp) => {
+            const p: any = sp.pitch || {};
+            const pitchId = sp.pitchId || p.id;
+            return (
+              <div
+                key={sp.id || pitchId}
+                className="bg-white p-6 rounded-lg shadow-sm border hover:shadow-md transition-shadow cursor-pointer"
+                onClick={() => navigate(`/pitch/${pitchId}`)}
+              >
+                <div className="flex items-start space-x-4">
+                  <div className="flex-shrink-0">
+                    <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center">
+                      <Film className="w-6 h-6 text-blue-600" />
+                    </div>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <h4 className="font-semibold text-gray-900 hover:text-blue-600">
+                        {p.title || 'Untitled pitch'}
+                      </h4>
+                      <Bookmark className="w-4 h-4 text-blue-600 fill-current" />
+                    </div>
+                    {(p.logline || p.shortSynopsis) && (
+                      <p className="text-gray-600 text-sm mb-2 line-clamp-2">
+                        {p.logline || p.shortSynopsis}
+                      </p>
+                    )}
+                    <div className="flex items-center flex-wrap gap-2 text-sm text-gray-500">
+                      {p.genre && (
+                        <span className="px-2 py-1 bg-gray-100 rounded-full">{p.genre}</span>
+                      )}
+                      {sp.savedAt && (
+                        <span className="flex items-center gap-1">
+                          <Calendar className="w-3 h-3" />
+                          Saved {formatDate(sp.savedAt)}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    );
+  };
+
 
   if (loading) {
     return (
@@ -666,6 +794,19 @@ const Following: React.FC = () => {
                 Following
               </div>
             </button>
+            <button
+              onClick={() => setActiveTab('saved')}
+              className={`flex-1 py-4 px-6 text-center font-medium transition ${
+                activeTab === 'saved'
+                  ? 'bg-blue-50 text-blue-600 border-b-2 border-blue-600'
+                  : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50'
+              }`}
+            >
+              <div className="flex items-center justify-center gap-2">
+                <Bookmark className="w-4 h-4" />
+                Saved
+              </div>
+            </button>
           </div>
         </div>
 
@@ -673,6 +814,7 @@ const Following: React.FC = () => {
         {activeTab === 'activity' && renderActivityTab()}
         {activeTab === 'followers' && renderFollowersTab()}
         {activeTab === 'following' && renderFollowingTab()}
+        {activeTab === 'saved' && renderSavedTab()}
       </div>
     </div>
   );

--- a/frontend/src/pages/Homepage.tsx
+++ b/frontend/src/pages/Homepage.tsx
@@ -10,7 +10,7 @@ import FormatDisplay from '../components/FormatDisplay';
 import GenrePlaceholder from '@shared/components/GenrePlaceholder';
 import HeatBadge, { getHeatScore, getPitcheyScore } from '../components/HeatBadge';
 import PitcheyRating from '../components/PitcheyRating';
-import { getPortalPath } from '@/utils/navigation';
+import { getPortalPath, getDashboardRoute } from '@/utils/navigation';
 import { getPortalTheme } from '@shared/hooks/usePortalTheme';
 
 
@@ -29,6 +29,26 @@ export default function Homepage() {
   // likedPitches state removed — replaced by Pitchey Score
 
   // Like handler removed — replaced by Pitchey Score rating system
+
+  // "Create Your First Pitch" CTA: signed-in creators/production go straight to
+  // the create flow; investors/watchers (can't create) land on their dashboard;
+  // signed-out visitors go to portal select to sign in/up.
+  const handleCreatePitch = () => {
+    if (!isAuthenticated) {
+      navigate('/portals');
+      return;
+    }
+    switch (userType) {
+      case 'creator':
+        navigate('/creator/pitch/new');
+        break;
+      case 'production':
+        navigate('/production/pitch/new');
+        break;
+      default:
+        navigate(getDashboardRoute(userType));
+    }
+  };
 
   useEffect(() => {
     // Add delay to prevent rate limiting on initial page load
@@ -556,7 +576,7 @@ export default function Homepage() {
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <button
-              onClick={() => navigate('/portals')}
+              onClick={handleCreatePitch}
               className="text-button px-8 py-4 bg-purple-600 text-white rounded-xl hover:bg-purple-700 transition"
             >
               Create Your First Pitch

--- a/frontend/src/pages/__tests__/Following.test.tsx
+++ b/frontend/src/pages/__tests__/Following.test.tsx
@@ -308,6 +308,30 @@ describe('Following', () => {
     })
   })
 
+  it('renders a messaged-attachment event in the feed', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        success: true,
+        data: {
+          items: [{
+            id: 77,
+            action: 'message_attachment',
+            createdAt: '2025-03-01T00:00:00Z',
+            actor: { id: 9, name: 'Sam Writer', username: 'sam', userType: 'creator', profileImage: null },
+            metadata: { conversationId: 4, attachmentCount: 1, fileName: 'pitch-deck.pdf' },
+          }],
+        },
+      }),
+    })
+
+    renderComponent(['/following?tab=activity'])
+    await waitFor(() => {
+      expect(screen.getByText('pitch-deck.pdf')).toBeInTheDocument()
+      expect(screen.getByText('shared a document with you')).toBeInTheDocument()
+    })
+  })
+
   it('renders the Saved tab', async () => {
     renderComponent()
     await waitFor(() => {

--- a/frontend/src/pages/__tests__/Following.test.tsx
+++ b/frontend/src/pages/__tests__/Following.test.tsx
@@ -35,6 +35,12 @@ vi.mock('../../config', () => ({
   },
 }))
 
+// ─── saved-pitches service (Saved tab) ──────────────────────────────
+vi.mock('@features/pitches/services/saved-pitches.service', () => ({
+  SavedPitchesService: { getSavedPitches: vi.fn() },
+}))
+import { SavedPitchesService } from '@features/pitches/services/saved-pitches.service'
+
 // ─── Dynamic import ─────────────────────────────────────────────────
 let Following: React.ComponentType
 beforeAll(async () => {
@@ -64,6 +70,7 @@ describe('Following', () => {
       activities: [],
       summary: { newPitches: 0, activeCreators: 0, engagementRate: 0 }
     }))
+    ;(SavedPitchesService.getSavedPitches as any).mockResolvedValue({ savedPitches: [], total: 0 })
   })
 
   afterEach(() => {
@@ -257,6 +264,75 @@ describe('Following', () => {
         return element?.tagName === 'SPAN' && content.includes('active creators')
       })
       expect(span).toBeInTheDocument()
+    })
+  })
+
+  // ─── Phase 2: unified activity feed + Saved tab ───────────────────
+
+  it('renders activity items from the unified activity_feed', async () => {
+    // First fetch (/api/activity/feed) returns events → no fallback needed.
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        success: true,
+        data: {
+          items: [{
+            id: 99,
+            action: 'pitch_published',
+            createdAt: '2025-02-01T00:00:00Z',
+            actor: { id: 7, name: 'Jane Director', username: 'jane', userType: 'creator', profileImage: null },
+            pitch: { id: 42, title: 'Neon Skies', genre: 'Sci-Fi', logline: 'The grid awakens', requireNda: false },
+          }],
+        },
+      }),
+    })
+
+    renderComponent(['/following?tab=activity'])
+    await waitFor(() => {
+      expect(screen.getByText('Neon Skies')).toBeInTheDocument()
+      expect(screen.getByText('Jane Director')).toBeInTheDocument()
+    })
+  })
+
+  it('falls back to followed-creator pitches when the feed is empty', async () => {
+    // Feed empty (no items) → component fetches /api/pitches/following.
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true, data: { items: [] } }) })
+      .mockResolvedValueOnce(makeSuccessResponse({
+        pitches: [{ id: 5, title: 'Fallback Film', genre: 'Action', logline: 'A hero rises', user_id: 10, creator_name: 'creator1' }],
+      }))
+
+    renderComponent(['/following?tab=activity'])
+    await waitFor(() => {
+      expect(screen.getByText('Fallback Film')).toBeInTheDocument()
+    })
+  })
+
+  it('renders the Saved tab', async () => {
+    renderComponent()
+    await waitFor(() => {
+      expect(screen.getByText('Saved')).toBeInTheDocument()
+    })
+  })
+
+  it('renders saved pitches in the Saved tab', async () => {
+    ;(SavedPitchesService.getSavedPitches as any).mockResolvedValue({
+      savedPitches: [{ id: 1, pitchId: 42, savedAt: '2025-01-01T00:00:00Z', pitch: { id: 42, title: 'Saved Film', genre: 'Drama', logline: 'A quiet story' } }],
+      total: 1,
+    })
+
+    renderComponent(['/following?tab=saved'])
+    await waitFor(() => {
+      expect(screen.getByText('Saved Film')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty saved state when nothing is saved', async () => {
+    ;(SavedPitchesService.getSavedPitches as any).mockResolvedValue({ savedPitches: [], total: 0 })
+
+    renderComponent(['/following?tab=saved'])
+    await waitFor(() => {
+      expect(screen.getByText("You haven't saved any pitches yet")).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/pages/__tests__/PitchDetail.test.tsx
+++ b/frontend/src/pages/__tests__/PitchDetail.test.tsx
@@ -50,6 +50,13 @@ vi.mock('@features/ndas/components/NDA/EnhancedNDARequest', () => ({
     ) : null,
 }))
 
+vi.mock('@features/ndas/services/nda.service', () => ({
+  ndaService: {
+    // Default: eligible to request, no existing request → not pending.
+    canRequestNDA: vi.fn().mockResolvedValue({ canRequest: true }),
+  },
+}))
+
 vi.mock('../../components/FormatDisplay', () => ({
   default: ({ format }: any) => <span>{format || 'Feature Film'}</span>,
 }))
@@ -188,7 +195,9 @@ describe('PitchDetail', () => {
   describe('Authenticated User', () => {
     beforeEach(() => {
       mockAuthStore.isAuthenticated = true
-      mockAuthStore.user = { id: 3, email: 'user@test.com', name: 'User' }
+      // Investor — only investor/production may request NDA access, so the
+      // request affordances under test are role-gated to this type.
+      mockAuthStore.user = { id: 3, email: 'user@test.com', name: 'User', userType: 'investor' }
       mockPitchService.getByIdAuthenticated.mockResolvedValue(createMockPitch())
     })
 
@@ -364,7 +373,8 @@ describe('PitchDetail', () => {
   describe('NDA State', () => {
     beforeEach(() => {
       mockAuthStore.isAuthenticated = true
-      mockAuthStore.user = { id: 3, email: 'user@test.com' }
+      // Investor — NDA-request affordances are gated to investor/production.
+      mockAuthStore.user = { id: 3, email: 'user@test.com', userType: 'investor' }
     })
 
     it('shows NDA Signed badge when NDA is signed', async () => {
@@ -412,6 +422,25 @@ describe('PitchDetail', () => {
       await waitFor(() => {
         expect(screen.getByTestId('nda-modal')).toBeInTheDocument()
       })
+    })
+
+    it('shows pending state instead of request button when a request is in progress', async () => {
+      const { ndaService } = await import('@features/ndas/services/nda.service')
+      ;(ndaService.canRequestNDA as any).mockResolvedValueOnce({
+        canRequest: false,
+        existingNDA: { status: 'pending' },
+      })
+      mockPitchService.getByIdAuthenticated.mockResolvedValue(
+        createMockPitch({ hasSignedNDA: false })
+      )
+
+      renderPitchDetail()
+
+      await waitFor(() => {
+        expect(screen.getByText('NDA Request Pending')).toBeInTheDocument()
+      })
+      // The request CTA should no longer be offered while a request is pending.
+      expect(screen.queryByText('Request Enhanced Access')).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/src/services/feedback.service.ts
+++ b/frontend/src/services/feedback.service.ts
@@ -76,6 +76,17 @@ export interface ConsumptionStatus {
   threshold: number;
 }
 
+/** "Progress from feedback" — has the pitch changed since the viewer's feedback. */
+export interface FeedbackProgress {
+  hasFeedback: boolean;
+  feedbackAt: string | null;
+  editedSinceFeedback: boolean;
+  editCount: number;
+  scoreAtFeedback: number | null;
+  scoreNow: number | null;
+  scoreDelta: number | null;
+}
+
 export class FeedbackService {
   // Note: apiClient.get returns { success, data } where `data` is ALREADY the
   // server's `.data` field unwrapped (see api-client.ts makeRequest). Consumers
@@ -104,6 +115,15 @@ export class FeedbackService {
     try {
       const res = await apiClient.get<FeedbackEntry | null>(`/api/pitches/${pitchId}/feedback/mine`);
       return res.data ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  static async getFeedbackProgress(pitchId: number): Promise<FeedbackProgress | null> {
+    try {
+      const res = await apiClient.get<{ progress: FeedbackProgress }>(`/api/pitches/${pitchId}/feedback-progress`);
+      return res.data?.progress ?? null;
     } catch {
       return null;
     }

--- a/frontend/src/shared/components/layout/EnhancedProductionNav.tsx
+++ b/frontend/src/shared/components/layout/EnhancedProductionNav.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import {
-  Home, Activity, Film, FolderOpen, Upload,
+  Home, Activity, Film, Upload,
   Bookmark, Users, GitBranch,
   MessageSquare, Settings, UserPlus, Shield, FileText
 } from 'lucide-react';
@@ -36,9 +36,11 @@ export const productionNavigationSections: NavigationSection[] = [
     ],
   },
   {
-    title: 'Submissions',
+    // "Submissions" review pipeline retired 2026-06-01 (activity-feed pivot, Phase 3) —
+    // pages/routes parked, not deleted. Activity now lives in the Activity + Following
+    // feeds. Acquisition loop ("Invite Creators") stays.
+    title: 'Creators',
     items: [
-      { label: 'Submissions', path: PRODUCTION_ROUTES.submissions, icon: FolderOpen },
       { label: 'Invite Creators', path: PRODUCTION_ROUTES.invites, icon: UserPlus },
     ],
   },

--- a/src/db/activity-feed.ts
+++ b/src/db/activity-feed.ts
@@ -14,13 +14,16 @@ import * as Sentry from '@sentry/cloudflare';
 
 type DbEnv = { DATABASE_URL: string };
 
-export type ActivityAction = 'pitch_published' | 'pitch_updated' | 'user_followed';
+export type ActivityAction = 'pitch_published' | 'pitch_updated' | 'user_followed' | 'message_attachment';
 
 export interface RecordActivityInput {
   actorId: number;
   action: ActivityAction | string;
-  objectType: 'pitch' | 'user' | string;
+  objectType: 'pitch' | 'user' | 'message' | string;
   objectId?: number | null;
+  /** When set, the event is PRIVATE — visible only to this recipient, never
+   *  fanned out to the actor's followers. Used for messaged attachments. */
+  recipientId?: number | null;
   metadata?: Record<string, unknown>;
 }
 
@@ -29,12 +32,13 @@ export async function recordActivity(env: DbEnv, input: RecordActivityInput): Pr
     if (!input.actorId || Number.isNaN(input.actorId)) return;
     const sql = postgres(env.DATABASE_URL);
     await sql`
-      INSERT INTO activity_feed (actor_id, action, object_type, object_id, metadata)
+      INSERT INTO activity_feed (actor_id, action, object_type, object_id, recipient_id, metadata)
       VALUES (
         ${input.actorId},
         ${input.action},
         ${input.objectType},
         ${input.objectId ?? null},
+        ${input.recipientId ?? null},
         ${JSON.stringify(input.metadata ?? {})}::jsonb
       )
     `;
@@ -110,10 +114,18 @@ export async function getActivityFeed(
       LEFT JOIN pitches p ON af.object_type = 'pitch' AND p.id = af.object_id
       WHERE af.actor_id <> ${viewerId}
         AND (
-          af.actor_id IN (SELECT following_id FROM follows WHERE follower_id = ${viewerId})
+          -- PRIVATE events: visible only to their recipient (e.g. messaged attachments).
+          af.recipient_id = ${viewerId}
           OR (
-            af.object_type = 'pitch'
-            AND af.object_id IN (SELECT pitch_id FROM saved_pitches WHERE user_id = ${viewerId})
+            -- BROADCAST events: fanned out to followers + saved-pitch watchers.
+            af.recipient_id IS NULL
+            AND (
+              af.actor_id IN (SELECT following_id FROM follows WHERE follower_id = ${viewerId})
+              OR (
+                af.object_type = 'pitch'
+                AND af.object_id IN (SELECT pitch_id FROM saved_pitches WHERE user_id = ${viewerId})
+              )
+            )
           )
         )
         -- Don't surface published pitches that have since been unpublished/archived.

--- a/src/db/activity-feed.ts
+++ b/src/db/activity-feed.ts
@@ -1,0 +1,168 @@
+/**
+ * activity-feed — the actor/action/object event source behind the Following feed.
+ *
+ * Model: one row per actor action (see migration 094). Fan-out to followers and
+ * saved-pitch watchers happens at READ time in getActivityFeed(), not on write.
+ *
+ * recordActivity() is fire-and-forget by contract: it NEVER throws to the caller.
+ * A missing table (before migration 094 is applied) or any DB error is logged +
+ * reported to Sentry, but the originating request (publish, follow) still succeeds.
+ * Call it without awaiting, or with ctx.waitUntil().
+ */
+import postgres from 'postgres';
+import * as Sentry from '@sentry/cloudflare';
+
+type DbEnv = { DATABASE_URL: string };
+
+export type ActivityAction = 'pitch_published' | 'pitch_updated' | 'user_followed';
+
+export interface RecordActivityInput {
+  actorId: number;
+  action: ActivityAction | string;
+  objectType: 'pitch' | 'user' | string;
+  objectId?: number | null;
+  metadata?: Record<string, unknown>;
+}
+
+export async function recordActivity(env: DbEnv, input: RecordActivityInput): Promise<void> {
+  try {
+    if (!input.actorId || Number.isNaN(input.actorId)) return;
+    const sql = postgres(env.DATABASE_URL);
+    await sql`
+      INSERT INTO activity_feed (actor_id, action, object_type, object_id, metadata)
+      VALUES (
+        ${input.actorId},
+        ${input.action},
+        ${input.objectType},
+        ${input.objectId ?? null},
+        ${JSON.stringify(input.metadata ?? {})}::jsonb
+      )
+    `;
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    // Don't surface — the feed is best-effort. Missing table pre-migration lands here.
+    console.error('recordActivity failed:', e.message);
+    try {
+      Sentry.withScope((scope) => {
+        scope.setTag('activity.action', String(input.action));
+        scope.setTag('activity.context', 'recordActivity');
+        Sentry.captureException(e);
+      });
+    } catch { /* Sentry hub not initialized */ }
+  }
+}
+
+export interface ActivityFeedActor {
+  id: number;
+  name: string;
+  username: string | null;
+  userType: string | null;
+  profileImage: string | null;
+}
+
+export interface ActivityFeedPitch {
+  id: number;
+  title: string;
+  genre: string | null;
+  logline: string | null;
+  requireNda: boolean;
+}
+
+export interface ActivityFeedItem {
+  id: number;
+  actorId: number;
+  action: string;
+  objectType: string;
+  objectId: number | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  actor: ActivityFeedActor | null;
+  pitch: ActivityFeedPitch | null;
+}
+
+/**
+ * Events relevant to `viewerId`: actions by creators they follow, plus actions on
+ * pitches they've saved. Enriched with actor + pitch detail. Excludes the viewer's
+ * own actions. Returns [] on any error (caller need not guard).
+ */
+export async function getActivityFeed(
+  env: DbEnv,
+  viewerId: number,
+  opts: { limit?: number; offset?: number } = {}
+): Promise<ActivityFeedItem[]> {
+  const limit = Math.min(Math.max(opts.limit ?? 30, 1), 100);
+  const offset = Math.max(opts.offset ?? 0, 0);
+  try {
+    const sql = postgres(env.DATABASE_URL);
+    const rows = await sql`
+      SELECT
+        af.id, af.actor_id, af.action, af.object_type, af.object_id, af.metadata, af.created_at,
+        u.name        AS actor_name,
+        u.username    AS actor_username,
+        u.user_type   AS actor_user_type,
+        COALESCE(u.profile_image, u.avatar_url) AS actor_profile_image,
+        p.title       AS pitch_title,
+        p.genre       AS pitch_genre,
+        p.logline     AS pitch_logline,
+        COALESCE(p.require_nda, false) AS pitch_require_nda
+      FROM activity_feed af
+      LEFT JOIN users u   ON u.id = af.actor_id
+      LEFT JOIN pitches p ON af.object_type = 'pitch' AND p.id = af.object_id
+      WHERE af.actor_id <> ${viewerId}
+        AND (
+          af.actor_id IN (SELECT following_id FROM follows WHERE follower_id = ${viewerId})
+          OR (
+            af.object_type = 'pitch'
+            AND af.object_id IN (SELECT pitch_id FROM saved_pitches WHERE user_id = ${viewerId})
+          )
+        )
+        -- Don't surface published pitches that have since been unpublished/archived.
+        AND (af.object_type <> 'pitch' OR p.id IS NOT NULL)
+      ORDER BY af.created_at DESC
+      LIMIT ${limit} OFFSET ${offset}
+    `;
+
+    return rows.map((r: Record<string, unknown>): ActivityFeedItem => {
+      const actorId = Number(r.actor_id);
+      const objectId = r.object_id == null ? null : Number(r.object_id);
+      const metadata = (r.metadata as Record<string, unknown>) ?? {};
+      return {
+        id: Number(r.id),
+        actorId,
+        action: String(r.action),
+        objectType: String(r.object_type),
+        objectId,
+        metadata,
+        createdAt: r.created_at instanceof Date ? r.created_at.toISOString() : String(r.created_at),
+        actor: r.actor_name != null || r.actor_username != null
+          ? {
+              id: actorId,
+              name: (r.actor_name as string) ?? '',
+              username: (r.actor_username as string) ?? null,
+              userType: (r.actor_user_type as string) ?? null,
+              profileImage: (r.actor_profile_image as string) ?? null,
+            }
+          : null,
+        pitch: r.object_type === 'pitch' && r.pitch_title != null
+          ? {
+              id: objectId ?? 0,
+              title: (r.pitch_title as string) ?? '',
+              genre: (r.pitch_genre as string) ?? null,
+              logline: (r.pitch_logline as string) ?? null,
+              requireNda: Boolean(r.pitch_require_nda),
+            }
+          : null,
+      };
+    });
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error('getActivityFeed failed:', e.message);
+    try {
+      Sentry.withScope((scope) => {
+        scope.setTag('activity.context', 'getActivityFeed');
+        Sentry.captureException(e);
+      });
+    } catch { /* Sentry hub not initialized */ }
+    return [];
+  }
+}

--- a/src/db/migrations/094_activity_feed.sql
+++ b/src/db/migrations/094_activity_feed.sql
@@ -1,0 +1,32 @@
+-- Activity feed: actor/action/object event store powering the Following feed.
+-- One row per actor action; fan-out to followers + saved-pitch watchers happens
+-- at READ time in getActivityFeed() (no per-recipient rows). This keeps writes
+-- O(1) and lets the same event surface to anyone who later follows the actor.
+--
+-- Phase 2 of the "Following/Saved activity feed" pivot. Emitters:
+--   pitch_published — POST /api/pitches/:id/publish
+--   user_followed   — POST /api/follows/action (follow)
+-- Readers:
+--   GET /api/activity/feed (src/db/activity-feed.ts:getActivityFeed)
+
+CREATE TABLE IF NOT EXISTS activity_feed (
+  id          BIGSERIAL PRIMARY KEY,
+  actor_id    INTEGER NOT NULL,
+  action      TEXT    NOT NULL,                       -- pitch_published | pitch_updated | user_followed
+  object_type TEXT    NOT NULL,                       -- pitch | user
+  object_id   INTEGER,
+  metadata    JSONB   NOT NULL DEFAULT '{}'::jsonb,   -- denormalized title/name for cheap render
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Feed read path filters by actor (followed creators) then sorts by recency.
+CREATE INDEX IF NOT EXISTS idx_activity_feed_actor_created
+  ON activity_feed (actor_id, created_at DESC);
+
+-- Global recency sort / pagination.
+CREATE INDEX IF NOT EXISTS idx_activity_feed_created
+  ON activity_feed (created_at DESC);
+
+-- Saved-pitch branch of the feed (object_type='pitch' AND object_id IN saved).
+CREATE INDEX IF NOT EXISTS idx_activity_feed_object
+  ON activity_feed (object_type, object_id);

--- a/src/db/migrations/095_activity_feed_recipient.sql
+++ b/src/db/migrations/095_activity_feed_recipient.sql
@@ -1,0 +1,14 @@
+-- Recipient-scoped activity events (Phase 4A — messaged attachments).
+--
+-- Default activity_feed rows are BROADCAST: recipient_id IS NULL, fanned out at
+-- read time to the actor's followers + saved-pitch watchers. A row with a
+-- recipient_id is PRIVATE: visible ONLY to that recipient (getActivityFeed gates
+-- it). Used for "X shared a document with you" — messaged attachments serve
+-- publicly today and must NOT widen exposure beyond the conversation participant.
+
+ALTER TABLE activity_feed ADD COLUMN IF NOT EXISTS recipient_id INTEGER;
+
+-- Direct-to-me lookup (the private branch of the feed query).
+CREATE INDEX IF NOT EXISTS idx_activity_feed_recipient
+  ON activity_feed (recipient_id, created_at DESC)
+  WHERE recipient_id IS NOT NULL;

--- a/src/db/migrations/096_pitch_versions.sql
+++ b/src/db/migrations/096_pitch_versions.sql
@@ -1,0 +1,26 @@
+-- Pitch content snapshots — powers "progress from feedback" (Phase 4B / WS-5).
+--
+-- A row is written on each pitch UPDATE (src/worker-integrated.ts updatePitch),
+-- capturing the content + score at that moment. With this history we can show a
+-- reviewer that a pitch was edited AFTER their feedback, and how its score moved
+-- since then (baseline = snapshot at/just-before the feedback timestamp).
+--
+-- Pitches still update in-place; this is an append-only audit alongside, not a
+-- replacement. No backfill — deltas accrue from the first edit after deploy.
+
+CREATE TABLE IF NOT EXISTS pitch_versions (
+  id               BIGSERIAL PRIMARY KEY,
+  pitch_id         INTEGER NOT NULL,
+  title            TEXT,
+  logline          TEXT,
+  short_synopsis   TEXT,
+  long_synopsis    TEXT,
+  rating_average   NUMERIC,
+  rating_count     INTEGER,
+  pitchey_score_avg NUMERIC,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- "latest snapshot at/before T" and "edits since T" both scan by (pitch, time).
+CREATE INDEX IF NOT EXISTS idx_pitch_versions_pitch_created
+  ON pitch_versions (pitch_id, created_at DESC);

--- a/src/db/pitch-progress.ts
+++ b/src/db/pitch-progress.ts
@@ -1,0 +1,124 @@
+/**
+ * pitch-progress — "progress from feedback" (Phase 4B / WS-5).
+ *
+ * For a reviewer who left feedback on a pitch, computes whether the creator has
+ * edited the pitch SINCE that feedback, and how the pitch's score has moved.
+ * Backed by pitch_versions snapshots (migration 096) + pitch_feedback.
+ *
+ * Returns a safe "no progress" shape on any error (never throws). Deltas only
+ * exist once a baseline snapshot was captured at/before the feedback — older
+ * feedback (pre-snapshots) reports editedSinceFeedback without a score delta.
+ */
+import postgres from 'postgres';
+import * as Sentry from '@sentry/cloudflare';
+
+type DbEnv = { DATABASE_URL: string };
+
+export interface FeedbackProgress {
+  hasFeedback: boolean;
+  feedbackAt: string | null;
+  editedSinceFeedback: boolean;
+  editCount: number;
+  scoreAtFeedback: number | null;
+  scoreNow: number | null;
+  scoreDelta: number | null;
+}
+
+const EMPTY: FeedbackProgress = {
+  hasFeedback: false,
+  feedbackAt: null,
+  editedSinceFeedback: false,
+  editCount: 0,
+  scoreAtFeedback: null,
+  scoreNow: null,
+  scoreDelta: null,
+};
+
+const num = (v: unknown): number | null => {
+  if (v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+};
+
+export async function getFeedbackProgress(
+  env: DbEnv,
+  pitchId: number,
+  viewerId: number
+): Promise<FeedbackProgress> {
+  if (!pitchId || !viewerId) return EMPTY;
+  try {
+    const sql = postgres(env.DATABASE_URL);
+
+    const [fb] = await sql`
+      SELECT created_at
+      FROM pitch_feedback
+      WHERE pitch_id = ${pitchId} AND reviewer_id = ${viewerId}
+      ORDER BY created_at ASC
+      LIMIT 1
+    `;
+    if (!fb) return EMPTY;
+    const feedbackAt: string = fb.created_at instanceof Date ? fb.created_at.toISOString() : String(fb.created_at);
+
+    // Edits since the feedback (snapshots written after the feedback timestamp).
+    const [edits] = await sql`
+      SELECT COUNT(*)::int AS n
+      FROM pitch_versions
+      WHERE pitch_id = ${pitchId} AND created_at > ${fb.created_at}
+    `;
+    const editCount = Number(edits?.n ?? 0);
+
+    // Baseline: the score snapshot at/just-before the feedback.
+    const [baseline] = await sql`
+      SELECT pitchey_score_avg, rating_average
+      FROM pitch_versions
+      WHERE pitch_id = ${pitchId} AND created_at <= ${fb.created_at}
+      ORDER BY created_at DESC
+      LIMIT 1
+    `;
+
+    // Current score (prefer the industry Pitchey score, fall back to combined).
+    const [now] = await sql`
+      SELECT pitchey_score_avg, rating_average, updated_at
+      FROM pitches
+      WHERE id = ${pitchId}
+      LIMIT 1
+    `;
+
+    const pickScore = (row: any): number | null =>
+      row ? (num(row.pitchey_score_avg) ?? num(row.rating_average)) : null;
+
+    const scoreAtFeedback = pickScore(baseline);
+    const scoreNow = pickScore(now);
+    const scoreDelta =
+      scoreAtFeedback != null && scoreNow != null
+        ? Math.round((scoreNow - scoreAtFeedback) * 10) / 10
+        : null;
+
+    // editedSinceFeedback: snapshots are authoritative, but fall back to the
+    // pitch's own updated_at for feedback left before snapshots existed.
+    let editedSinceFeedback = editCount > 0;
+    if (!editedSinceFeedback && now?.updated_at) {
+      editedSinceFeedback = new Date(now.updated_at).getTime() > new Date(feedbackAt).getTime();
+    }
+
+    return {
+      hasFeedback: true,
+      feedbackAt,
+      editedSinceFeedback,
+      editCount,
+      scoreAtFeedback,
+      scoreNow,
+      scoreDelta,
+    };
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error('getFeedbackProgress failed:', e.message);
+    try {
+      Sentry.withScope((scope) => {
+        scope.setTag('activity.context', 'getFeedbackProgress');
+        Sentry.captureException(e);
+      });
+    } catch { /* Sentry hub not initialized */ }
+    return EMPTY;
+  }
+}

--- a/src/handlers/messaging-simple.ts
+++ b/src/handlers/messaging-simple.ts
@@ -151,10 +151,73 @@ export class SimpleMessagingHandler {
         ).catch(() => {});
       }
 
+      // Surface messaged attachments in the recipient's activity feed (Phase 4A).
+      // PRIVATE event — recipient-scoped only, never fanned out to followers, since
+      // message attachments are not NDA-gated. Non-blocking.
+      if (hasAttachments && convId && message[0]) {
+        await this.recordMessageAttachmentActivity(
+          userId, convId, Number(message[0].id), attachments, recipient_id
+        ).catch(() => {});
+      }
+
       return { success: true, data: { message: message[0] } };
     } catch (error) {
       console.error('Send message error:', error);
       return { success: false, error: 'Failed to send message' };
+    }
+  }
+
+  // Write a PRIVATE (recipient-scoped) activity_feed row per conversation recipient
+  // when a message carries attachments. Visibility is limited to each recipient —
+  // these never fan out to the actor's followers. Best-effort; never throws.
+  private async recordMessageAttachmentActivity(
+    senderId: number,
+    convId: number,
+    messageId: number,
+    attachments: any[],
+    directRecipientId?: number
+  ): Promise<void> {
+    try {
+      // Resolve recipients: the other active participants in the conversation.
+      let recipientIds: number[] = [];
+      if (directRecipientId) {
+        recipientIds = [Number(directRecipientId)];
+      } else {
+        const rows = await this.db.query(
+          `SELECT user_id FROM conversation_participants
+           WHERE conversation_id = $1 AND user_id <> $2`,
+          [convId, senderId]
+        );
+        recipientIds = rows.map((r: any) => Number(r.user_id)).filter((n: number) => n && n !== senderId);
+      }
+      if (recipientIds.length === 0) return;
+
+      // Pitch context for the feed card link (conversations may be tied to a pitch).
+      let pitchId: number | null = null;
+      try {
+        const [conv] = await this.db.query(`SELECT pitch_id FROM conversations WHERE id = $1`, [convId]);
+        pitchId = conv?.pitch_id ?? null;
+      } catch { /* pitch_id optional */ }
+
+      const list = Array.isArray(attachments) ? attachments : [];
+      const first = list[0] || {};
+      const metadata = {
+        conversationId: convId,
+        pitchId,
+        attachmentCount: list.length,
+        fileName: first.originalName || first.name || first.fileName || 'a file',
+      };
+
+      for (const recipientId of recipientIds) {
+        await this.db.query(
+          `INSERT INTO activity_feed (actor_id, action, object_type, object_id, recipient_id, metadata)
+           VALUES ($1, 'message_attachment', 'message', $2, $3, $4::jsonb)`,
+          [senderId, messageId, recipientId, JSON.stringify(metadata)]
+        );
+      }
+    } catch (err) {
+      // Best-effort — a missing recipient_id column (pre-migration 095) lands here.
+      console.error('recordMessageAttachmentActivity failed:', err instanceof Error ? err.message : String(err));
     }
   }
 

--- a/src/handlers/messaging-simple.ts
+++ b/src/handlers/messaging-simple.ts
@@ -155,9 +155,11 @@ export class SimpleMessagingHandler {
       // PRIVATE event — recipient-scoped only, never fanned out to followers, since
       // message attachments are not NDA-gated. Non-blocking.
       if (hasAttachments && convId && message[0]) {
+        // recordMessageAttachmentActivity wraps its whole body in try/catch and
+        // logs on failure, returning void — no outer swallow needed here.
         await this.recordMessageAttachmentActivity(
           userId, convId, Number(message[0].id), attachments, recipient_id
-        ).catch(() => {});
+        );
       }
 
       return { success: true, data: { message: message[0] } };

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -99,6 +99,9 @@ import {
   pitchArchiveHandler
 } from './handlers/pitch-interactions';
 
+// Activity feed (Following/Saved pivot, Phase 2) — actor/action event source.
+import { recordActivity, getActivityFeed } from './db/activity-feed';
+
 // Import rating + comment handlers
 import {
   submitAnonymousRating,
@@ -2596,6 +2599,16 @@ class RouteRegistry {
                   data: { pitchId: pitch.id, title: pitch.title, creatorId: userId, creatorName }
                 });
               }
+
+              // Persist to the activity feed (one actor row; fanned out at read time).
+              // recordActivity never throws — safe to await inline.
+              await recordActivity(this.env, {
+                actorId: Number(userId),
+                action: 'pitch_published',
+                objectType: 'pitch',
+                objectId: Number(pitch.id),
+                metadata: { title: pitch.title, creatorName },
+              });
             }
           }
         } catch (e) {
@@ -2740,6 +2753,10 @@ class RouteRegistry {
     this.register('GET', '/api/follows', (req) => followsHandler(req, this.env));
     this.register('GET', '/api/follows/followers', (req) => followersHandler(req, this.env));
     this.register('GET', '/api/follows/following', (req) => followingHandler(req, this.env));
+
+    // Unified activity feed (Following/Saved pivot, Phase 2) — events from
+    // followed creators + saved pitches. Returns [] gracefully pre-migration.
+    this.register('GET', '/api/activity/feed', this.getActivityFeedRoute.bind(this));
 
     // Enhanced follows endpoints
     this.register('POST', '/api/follows/action', (req) => followActionHandler(req, this.env));
@@ -13086,6 +13103,23 @@ pitchey_analytics_datapoints_per_minute 1250
   }
 
   // Missing endpoint implementations
+  // Unified Following/Saved activity feed — events emitted by followed creators
+  // (pitch_published, …) plus events on saved pitches. Backed by the activity_feed
+  // table (migration 094). getActivityFeed() returns [] on any error, so this is
+  // safe to call before the migration is applied (feed just shows empty).
+  private async getActivityFeedRoute(request: Request): Promise<Response> {
+    const authResult = await this.requireAuth(request);
+    if (!authResult.authorized) return authResult.response!;
+
+    const builder = new ApiResponseBuilder(request);
+    const url = new URL(request.url);
+    const limit = parseInt(url.searchParams.get('limit') || '30');
+    const offset = parseInt(url.searchParams.get('offset') || '0');
+
+    const items = await getActivityFeed(this.env, Number(authResult.user.id), { limit, offset });
+    return builder.success({ items });
+  }
+
   private async getPitchesFollowing(request: Request): Promise<Response> {
     const authResult = await this.requireAuth(request);
     if (!authResult.authorized) return authResult.response!;

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -101,6 +101,8 @@ import {
 
 // Activity feed (Following/Saved pivot, Phase 2) — actor/action event source.
 import { recordActivity, getActivityFeed } from './db/activity-feed';
+// Progress-from-feedback (Phase 4B / WS-5).
+import { getFeedbackProgress } from './db/pitch-progress';
 
 // Import rating + comment handlers
 import {
@@ -2242,6 +2244,8 @@ class RouteRegistry {
     this.register('GET', '/api/pitches/:id/comments', (req) => getPitchComments(req, this.env));
     this.register('POST', '/api/pitches/:id/comments', (req) => submitPitchComment(req, this.env));
     this.register('GET', '/api/pitches/:id/engagement', (req) => getPitchEngagementHandler(req, this.env));
+    // Progress-from-feedback (Phase 4B / WS-5) — did the pitch improve since my feedback?
+    this.register('GET', '/api/pitches/:id/feedback-progress', this.getFeedbackProgressRoute.bind(this));
     this.register('GET', '/api/pitches/:id/heat', async (req) => {
       const { pitchHeatBreakdownHandler } = await import('./handlers/heat-score');
       return pitchHeatBreakdownHandler(req, this.env);
@@ -6267,6 +6271,41 @@ pitchey_analytics_datapoints_per_minute 1250
 
       // Invalidate browse cache (updated pitch data should reflect in listings)
       try { await this.invalidateBrowseCache(); } catch (_) { /* non-blocking */ }
+
+      // Snapshot the post-edit content + score for "progress from feedback"
+      // (Phase 4B / WS-5). Append-only; non-blocking — never fail the update.
+      if (updated) {
+        try {
+          const u = updated as {
+            id: number;
+            title?: string | null;
+            logline?: string | null;
+            short_synopsis?: string | null;
+            long_synopsis?: string | null;
+            rating_average?: number | null;
+            rating_count?: number | null;
+            pitchey_score_avg?: number | null;
+          };
+          await this.db.query(
+            `INSERT INTO pitch_versions
+               (pitch_id, title, logline, short_synopsis, long_synopsis,
+                rating_average, rating_count, pitchey_score_avg)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+            [
+              u.id,
+              u.title ?? null,
+              u.logline ?? null,
+              u.short_synopsis ?? null,
+              u.long_synopsis ?? null,
+              u.rating_average ?? null,
+              u.rating_count ?? null,
+              u.pitchey_score_avg ?? null,
+            ]
+          );
+        } catch (snapErr) {
+          console.error('pitch_versions snapshot failed:', snapErr instanceof Error ? snapErr.message : String(snapErr));
+        }
+      }
 
       return builder.success({ pitch: updated });
     } catch (error) {
@@ -13118,6 +13157,24 @@ pitchey_analytics_datapoints_per_minute 1250
 
     const items = await getActivityFeed(this.env, Number(authResult.user.id), { limit, offset });
     return builder.success({ items });
+  }
+
+  // GET /api/pitches/:id/feedback-progress — for the authenticated reviewer, has
+  // the pitch been edited since their feedback and how has its score moved.
+  // Returns hasFeedback:false (not an error) when the viewer hasn't reviewed it.
+  private async getFeedbackProgressRoute(request: Request): Promise<Response> {
+    const authResult = await this.requireAuth(request);
+    if (!authResult.authorized) return authResult.response!;
+
+    const builder = new ApiResponseBuilder(request);
+    const params = (request as any).params;
+    const pitchId = parseInt(params.id);
+    if (!pitchId || Number.isNaN(pitchId)) {
+      return builder.error(ErrorCode.VALIDATION_ERROR, 'Invalid pitch id');
+    }
+
+    const progress = await getFeedbackProgress(this.env, pitchId, Number(authResult.user.id));
+    return builder.success({ progress });
   }
 
   private async getPitchesFollowing(request: Request): Promise<Response> {


### PR DESCRIPTION
## Why

Reconciles a **split-brain prod deploy** discovered during a Step-0 audit:

- **Worker** (`pitchey-api-prod`) was running the **activity-feed pivot** (these 5 commits), manually `wrangler deploy`'d last night — `/api/activity/feed` is live (401, registered).
- **Frontend** (`pitchey-5o8.pages.dev`) was still on **main** (CI-deployed PR #157) — no pivot UI; `Debug-*.js` chunk present, Phase-4 strings absent.
- The pivot commits were **local-only** (origin branch ref sat at the merge base; not in main, not in CI).

Because main auto-deploys the worker on every push (#146), the **next push to main would have CI-overwritten the pivot worker** with main's code (which lacks `/api/activity/feed`), instantly breaking Karl's feed in prod — while the only copy of the pivot lived on one machine.

## What this does

Merges the 4-phase Following/Saved activity-feed pivot into main so CI redeploys **frontend + worker from one consistent main**, eliminating the split-brain and the auto-deploy landmine.

## Commits
- `6f079b10` fix(homepage,credits): auth-aware create-pitch CTA + truthful credit costs
- `0092120a` test(pitch-detail): cover follow-without-NDA pending state (Phase 1 WS-3)
- `ee811869` feat(activity-feed): unified Following+Saved feed backbone (Phase 2)
- `2aa67011` feat(production-nav): retire Submissions review pipeline from nav (Phase 3)
- `cfe077e1` feat(activity-feed): messaged attachments + progress-from-feedback (Phase 4)

## Merge safety
- `git merge-tree` against current main: **clean, zero conflicts**.
- Post-merge worker is a superset: main's diagnostics (`/api/version`, `/debug`, Sentry tagging) **+** pivot's activity feed.
- Merging triggers CI deploy of both surfaces — coordinate against concurrent sessions before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
