### PR TITLE
fix(persistence): Priority 1 — profile/username + pitch-doc upload/retrieval

### DIFF
--- a/frontend/src/pages/PitchEdit.tsx
+++ b/frontend/src/pages/PitchEdit.tsx
@@ -221,7 +221,21 @@ export default function PitchEdit() {
         image: null,
         pdf: null,
         video: null,
-        documents: [],
+        // Load the pitch's existing documents so they're visible (and not lost)
+        // on the edit/manage screen. They're marked completed with a url and no
+        // File, so the save loop's `d.file && !d.url` filter skips re-uploading
+        // them. (Previously hardcoded to [] → uploaded docs vanished from edit.)
+        documents: (Array.isArray((pitch as any).documents) ? (pitch as any).documents : []).map(
+          (d: any, i: number): DocumentFile => ({
+            id: String(d.id ?? d.fileKey ?? d.file_key ?? `existing-${i}`),
+            type: (d.documentType ?? d.document_type ?? d.type ?? 'supporting_materials') as DocumentFile['type'],
+            title: d.fileName ?? d.file_name ?? d.originalFileName ?? d.original_file_name ?? d.title ?? 'Document',
+            url: d.fileUrl ?? d.file_url ?? d.url,
+            uploadStatus: 'completed',
+            uploadProgress: 100,
+            file: undefined as unknown as File,
+          })
+        ),
         ndaConfig: {
           requireNDA: pitch.requireNDA || false,
           ndaType: pitch.requireNDA ? 'platform' : 'none',

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -362,6 +362,24 @@ export default function Profile() {
               <div>
                 <h3 className="text-lg font-semibold text-gray-900 mb-4">Personal Information</h3>
                 <div className="space-y-4">
+                  {/* Username is editable only here; the read view is the @handle
+                      shown in the header above, so we don't repeat it in read mode. */}
+                  {isEditing && (
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Username</label>
+                      <input
+                        type="text"
+                        value={editedProfile.username ?? ''}
+                        onChange={(e) => handleInputChange('username', e.target.value)}
+                        className={`w-full px-3 py-2 border border-gray-300 rounded-lg ${theme.inputFocus}`}
+                        placeholder="your-username"
+                      />
+                      <p className="mt-1 text-xs text-gray-500">
+                        Letters, numbers, dots, hyphens and underscores. Min 3 characters. Must be unique.
+                      </p>
+                    </div>
+                  )}
+
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">First Name</label>
                     {isEditing ? (

--- a/frontend/src/pages/__tests__/PitchEdit.test.tsx
+++ b/frontend/src/pages/__tests__/PitchEdit.test.tsx
@@ -23,6 +23,8 @@ vi.mock('react-router-dom', async () => {
 vi.mock('@features/pitches/services/pitch.service', () => ({
   pitchService: {
     getById: mockGetById,
+    // PitchEdit fetches via getByIdAuthenticated (owner endpoint — works for drafts).
+    getByIdAuthenticated: mockGetById,
     update: mockUpdate,
   },
 }))
@@ -85,6 +87,9 @@ const mockPitch = {
   requireNDA: false,
   characters: [],
   titleImage: 'https://example.com/image.jpg',
+  documents: [
+    { id: 7, file_name: 'script.pdf', file_url: 'https://cdn.example.com/script.pdf', document_type: 'script', file_size: 2048 },
+  ],
 }
 
 describe('PitchEdit', () => {
@@ -118,6 +123,20 @@ describe('PitchEdit', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Edit Pitch')).toBeInTheDocument()
+    })
+  })
+
+  it('loads the pitch\'s existing documents into the upload section', async () => {
+    // Regression: PitchEdit hardcoded documents: [] so uploaded docs vanished
+    // from the edit/manage screen. They must now be loaded from pitch.documents.
+    render(
+      <MemoryRouter>
+        <PitchEdit />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('document-upload')).toHaveTextContent('1 files')
     })
   })
 

--- a/src/db/safe-query.ts
+++ b/src/db/safe-query.ts
@@ -165,3 +165,38 @@ export async function observedSwallowReturning<T, F>(
     return fallback;
   }
 }
+
+/**
+ * mutateOrThrow — write-side guard. A write that affects zero rows is almost
+ * never success: the WHERE matched nothing (wrong id, row vanished, ownership
+ * mismatch) or a RETURNING came back empty. The historical bug shape here is a
+ * handler doing `const [row] = await sql\`...RETURNING...\`` then returning
+ * `{ success: true }` even when `row` is undefined — the UI shows a save that
+ * never landed (the class of "writes that don't persist on read-back" bugs).
+ *
+ * Pass the result of a write that uses RETURNING (or otherwise returns the
+ * affected rows). Asserts a non-empty result, reports to Sentry, and THROWS so
+ * the caller's catch surfaces a real error instead of fake success. Returns the
+ * first row on success.
+ *
+ *   const user = mutateOrThrow(
+ *     await sql.query(updateQuery, values),
+ *     'user-profile.update',
+ *   );
+ */
+export function mutateOrThrow<T>(rows: T[] | unknown, context: string): T {
+  const arr = Array.isArray(rows) ? rows : [];
+  if (arr.length === 0) {
+    const error = new Error(`Write affected 0 rows: ${context}`);
+    try {
+      Sentry.withScope((scope) => {
+        scope.setTag('mutate_or_throw.context', context);
+        Sentry.captureException(error);
+      });
+    } catch {
+      // Sentry hub not initialized (test env, standalone scripts) — swallow.
+    }
+    throw error;
+  }
+  return arr[0] as T;
+}

--- a/src/handlers/profile.ts
+++ b/src/handlers/profile.ts
@@ -12,40 +12,39 @@ export async function profileHandler(request: Request, env: Env): Promise<Respon
   const origin = request.headers.get('Origin');
   const corsHeaders = getCorsHeaders(origin);
 
+  // Per-user authenticated data: never let a browser or shared cache hold it.
+  // This endpoint previously shipped `Cache-Control: public, max-age=300`,
+  // which made profile edits look like they didn't persist — a reload within
+  // 5 minutes served the stale pre-edit body from cache (and risked one user's
+  // PII being served to another via a shared cache).
+  const noStore = 'private, no-store';
+
   // Get user ID from authentication
   const userId = await getUserId(request, env) || '1';
-  
-  // Return demo user if DB fails
-  const demoUser = {
-    id: userId,
-    email: 'alex.creator@demo.com',
-    username: 'alexcreator',
-    name: 'Alex Creator',
-    userType: 'creator',
-    firstName: 'Alex',
-    lastName: 'Creator',
-    companyName: 'Creative Studios',
-    profileImage: null,
-    subscriptionTier: 'pro',
-    createdAt: new Date().toISOString(),
-    bio: 'Demo user profile',
-    verified: false
-  };
-  
+
+  // Env-level fallback: no DB binding (misconfiguration), not a per-user error.
   if (!sql) {
-    return new Response(JSON.stringify({
-      success: true,
-      data: demoUser
-    }), {
+    const demoUser = {
+      id: userId,
+      email: 'alex.creator@demo.com',
+      username: 'alexcreator',
+      name: 'Alex Creator',
+      userType: 'creator',
+      firstName: 'Alex',
+      lastName: 'Creator',
+      companyName: 'Creative Studios',
+      profileImage: null,
+      subscriptionTier: 'pro',
+      createdAt: new Date().toISOString(),
+      bio: 'Demo user profile',
+      verified: false
+    };
+    return new Response(JSON.stringify({ success: true, data: demoUser }), {
       status: 200,
-      headers: { 
-        'Content-Type': 'application/json',
-        'Cache-Control': 'public, max-age=300', // Cache for 5 minutes
-        ...corsHeaders
-      }
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': noStore, ...corsHeaders }
     });
   }
-  
+
   try {
     const result = await sql`
       SELECT
@@ -64,46 +63,39 @@ export async function profileHandler(request: Request, env: Env): Promise<Respon
       WHERE id = ${userId}
       LIMIT 1
     `;
-    
+
     if (result && result[0]) {
       return new Response(JSON.stringify({
         success: true,
         data: result[0]
       }), {
         status: 200,
-        headers: { 
-          'Content-Type': 'application/json',
-          'Cache-Control': 'public, max-age=300',
-          ...corsHeaders
-        }
+        headers: { 'Content-Type': 'application/json', 'Cache-Control': noStore, ...corsHeaders }
       });
     }
-    
-    // Return demo user if not found
+
+    // Genuinely not found — surface it instead of masking with demo data
+    // (returning a hardcoded user here made wrong/stale data look like the
+    // logged-in user's own profile). The frontend falls back to the auth-store
+    // user on a non-2xx, which is the real session user.
     return new Response(JSON.stringify({
-      success: true,
-      data: demoUser
+      success: false,
+      error: { message: 'Profile not found' }
     }), {
-      status: 200,
-      headers: { 
-        'Content-Type': 'application/json',
-        'Cache-Control': 'public, max-age=300',
-        ...corsHeaders
-      }
+      status: 404,
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': noStore, ...corsHeaders }
     });
-    
+
   } catch (error) {
     console.error('Profile query error:', error);
+    // Surface DB errors rather than returning a 200 demo user that masks the
+    // failure (this masking hid the persistence-class bugs for weeks).
     return new Response(JSON.stringify({
-      success: true,
-      data: demoUser
+      success: false,
+      error: { message: 'Failed to load profile' }
     }), {
-      status: 200,
-      headers: { 
-        'Content-Type': 'application/json',
-        'Cache-Control': 'public, max-age=300',
-        ...corsHeaders
-      }
+      status: 500,
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': noStore, ...corsHeaders }
     });
   }
 }

--- a/src/routes/user-profile.ts
+++ b/src/routes/user-profile.ts
@@ -6,6 +6,7 @@
 import { createAuthAdapter } from '../auth/auth-adapter';
 import { neon } from '@neondatabase/serverless';
 import { getCorsHeaders } from '../utils/response';
+import { mutateOrThrow } from '../db/safe-query';
 import * as bcrypt from 'bcryptjs';
 
 export interface UserProfileUpdate {
@@ -238,7 +239,13 @@ export class UserProfileRoutes {
           updated_at as "updatedAt"
       `;
 
-      const [updatedUser] = (await this.sql.query(updateQuery, values)) as any[];
+      // Guard the 0-rows blind spot: if the UPDATE matched nothing (row gone,
+      // wrong id), this throws → 500 instead of returning a phantom
+      // `success: true, user: undefined` that looks like a save that didn't stick.
+      const updatedUser = mutateOrThrow(
+        await this.sql.query(updateQuery, values),
+        'user-profile.update',
+      );
 
       return new Response(JSON.stringify({
         success: true,

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -16,7 +16,7 @@ import * as Sentry from '@sentry/cloudflare';
 import { createAxiomLogger } from './middleware/axiom-logging';
 // Per-request trace context for SQLCommenter + Axiom query correlation
 import { traceStorage } from './db/trace-context';
-import { safeQuery, observedSwallowReturning } from './db/safe-query';
+import { safeQuery, observedSwallowReturning, mutateOrThrow } from './db/safe-query';
 
 import { createDatabase } from './db/raw-sql-connection';
 import { UserProfileRoutes } from './routes/user-profile';
@@ -6374,14 +6374,6 @@ pitchey_analytics_datapoints_per_minute 1250
     const headers = { 'Content-Type': 'application/json', ...corsHeaders };
 
     try {
-      // Enforce credit cost: basic_upload = 10 credits
-      const creditResult = await this.deductCreditsInternal(
-        authResult.user.id, 10, 'File upload', 'basic_upload'
-      );
-      if (!creditResult.success) {
-        return new Response(JSON.stringify({ message: creditResult.error }), { status: 402, headers });
-      }
-
       const formData = await request.formData();
       const file = formData.get('file') as File;
       const folder = (formData.get('folder') as string) || 'uploads';
@@ -6404,6 +6396,25 @@ pitchey_analytics_datapoints_per_minute 1250
         return new Response(JSON.stringify({ message: 'File too large. Maximum size is 50MB.' }), { status: 400, headers });
       }
 
+      // Pitch documents are FREE — uploading the script/deck/budget is core to
+      // creating a pitch, not a paid extra. Only standalone/generic uploads
+      // (no pitch linkage) cost credits. This also kills the "upload twice"
+      // symptom: previously every doc cost 10 credits and the first one could
+      // 402 right after pitch creation had already spent the balance.
+      const isPitchDocument = pitchId !== null && !isNaN(pitchId);
+      let creditsUsed = 0;
+      let creditsRemaining: number | undefined;
+      if (!isPitchDocument) {
+        const creditResult = await this.deductCreditsInternal(
+          authResult.user.id, 10, 'File upload', 'basic_upload'
+        );
+        if (!creditResult.success) {
+          return new Response(JSON.stringify({ message: creditResult.error }), { status: 402, headers });
+        }
+        creditsUsed = 10;
+        creditsRemaining = creditResult.newBalance;
+      }
+
       const handler = new (await import('./handlers/media-access')).MediaAccessHandler(this.db, this.env);
 
       const timestamp = Date.now();
@@ -6415,47 +6426,48 @@ pitchey_analytics_datapoints_per_minute 1250
         return new Response(JSON.stringify({ message: uploadResult.error || 'Upload failed' }), { status: 500, headers });
       }
 
-      // Link the file to its pitch when a pitchId was supplied AND the caller
-      // owns the pitch. Owner check prevents attaching files to someone else's
-      // pitch. Best-effort: a linkage failure must not fail an upload the user
-      // already paid credits for, so we log and continue.
-      if (pitchId && !isNaN(pitchId)) {
-        try {
-          const ownerRows = await this.db.query(
-            `SELECT 1 FROM pitches WHERE id = $1 AND user_id = $2`,
-            [pitchId, authResult.user.id]
-          );
-          if (ownerRows.length > 0) {
-            await this.db.query(`
-              INSERT INTO pitch_documents (
-                pitch_id, file_name, original_file_name, file_url, file_key,
-                file_type, mime_type, file_size, document_type, is_public,
-                requires_nda, uploaded_by, uploaded_at, last_modified, download_count, metadata
-              ) VALUES (
-                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
-              )
-            `, [
-              pitchId,
-              file.name,
-              file.name,
-              uploadResult.url ?? null,
-              storagePath,
-              documentType,
-              file.type,
-              file.size,
-              documentType,
-              isPublic,
-              requiresNda,
-              authResult.user.id,
-              new Date(),
-              new Date(),
-              0,
-              JSON.stringify({ uploadedAt: new Date().toISOString(), originalName: file.name }),
-            ]);
-          }
-        } catch (linkErr) {
-          console.error('pitch_documents linkage failed (upload succeeded):', linkErr);
+      // Link the file to its pitch. SURFACE failures instead of swallowing them:
+      // a file in R2 with no pitch_documents row is invisible forever (the
+      // "uploaded but not retrievable" + "upload twice" symptoms). Pitch-doc
+      // uploads are free, so failing the request is safe — the user retries
+      // without losing credits.
+      if (isPitchDocument) {
+        const ownerRows = await this.db.query(
+          `SELECT 1 FROM pitches WHERE id = $1 AND user_id = $2`,
+          [pitchId, authResult.user.id]
+        );
+        if (ownerRows.length === 0) {
+          return new Response(JSON.stringify({ message: 'You do not own this pitch' }), { status: 403, headers });
         }
+        const inserted = await this.db.query(`
+          INSERT INTO pitch_documents (
+            pitch_id, file_name, original_file_name, file_url, file_key,
+            file_type, mime_type, file_size, document_type, is_public,
+            requires_nda, uploaded_by, uploaded_at, last_modified, download_count, metadata
+          ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
+          ) RETURNING id
+        `, [
+          pitchId,
+          file.name,
+          file.name,
+          uploadResult.url ?? null,
+          storagePath,
+          documentType,
+          file.type,
+          file.size,
+          documentType,
+          isPublic,
+          requiresNda,
+          authResult.user.id,
+          new Date(),
+          new Date(),
+          0,
+          JSON.stringify({ uploadedAt: new Date().toISOString(), originalName: file.name }),
+        ]);
+        // Throws (→ outer catch → 500) if the INSERT recorded nothing, so the
+        // client sees a real failure rather than a phantom success.
+        mutateOrThrow(inserted, 'handle-upload.pitch_documents-insert');
       }
 
       return new Response(JSON.stringify({
@@ -6463,8 +6475,8 @@ pitchey_analytics_datapoints_per_minute 1250
         filename: file.name,
         size: file.size,
         type: file.type,
-        creditsUsed: 10,
-        creditsRemaining: creditResult.newBalance
+        creditsUsed,
+        creditsRemaining
       }), { status: 200, headers });
     } catch (error) {
       console.error('Upload error:', error);


### PR DESCRIPTION
## Priority 1 — data-persistence root-cause fixes (Karl backlog)

Three "write succeeds in UI but data isn't there on read-back" symptoms — traced to **separate** causes (not one shared bug), fixed at the cause:

| Symptom | Root cause | Fix |
|---|---|---|
| Profile/username saves don't persist | `GET /api/user/profile` shipped `Cache-Control: public, max-age=300` → reload served stale cached body (write committed fine); handler also masked errors with a demo user | `private, no-store`; not-found→404 / error→500; `mutateOrThrow` guard on the update |
| Username uneditable | Live portal Profile page had username display-only | Validated username input (edit mode) |
| "Upload twice" | 10 credits/doc → first doc 402s after create spent credits (swallowed); `pitch_documents` INSERT swallowed (200 on failure → R2 orphan) | **Pitch docs now free**; non-owner→403; INSERT guarded with `mutateOrThrow` |
| Docs not retrievable in Manage Pitch | `PitchEdit.tsx` hardcoded `documents: []` (not a table mismatch) | Maps `pitch.documents` into the form; +regression test |

Plus a reusable `mutateOrThrow` write-guard in `src/db/safe-query.ts`.

**Money note:** pitch-document uploads are now free (uploads carrying a `pitchId`); standalone `/api/upload` calls still charge 10 credits. Approved by owner.

**Validation:** worker `tsc` + `build:worker` + catch-swallow gate (0); frontend `tsc` (0) + `build`; Profile + PitchEdit unit tests 39 green (fixed 18 stale-mock failures + added a regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
