### PR TITLE
feat(public): Priority 6 — pricing page, footer cleanup, working contact form

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -161,6 +161,7 @@ const PublicSlate = lazyRetry(() => import('./pages/PublicSlate'));
 const HowItWorks = lazyRetry(() => import('./pages/HowItWorks'));
 const About = lazyRetry(() => import('./pages/About'));
 const Contact = lazyRetry(() => import('./pages/Contact'));
+const Pricing = lazyRetry(() => import('./pages/Pricing'));
 const Terms = lazyRetry(() => import('./pages/Terms'));
 const Privacy = lazyRetry(() => import('./pages/Privacy'));
 const StandardNDA = lazyRetry(() => import('./pages/StandardNDA'));
@@ -437,6 +438,7 @@ function App() {
           <Route path="/how-it-works" element={<HowItWorks />} />
           <Route path="/about" element={<About />} />
           <Route path="/contact" element={<Contact />} />
+          <Route path="/pricing" element={<Pricing />} />
           <Route path="/terms" element={<Terms />} />
           <Route path="/privacy" element={<Privacy />} />
           <Route path="/legal/standard-nda" element={<StandardNDA />} />

--- a/frontend/src/pages/Contact.tsx
+++ b/frontend/src/pages/Contact.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Send } from 'lucide-react';
+import { API_URL } from '../config';
 
 export default function Contact() {
   const navigate = useNavigate();
@@ -11,8 +12,11 @@ export default function Contact() {
     message: ''
   });
   const [submitted, setSubmitted] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
 
   const feedbackTypes = [
+    { value: 'general-enquiry', label: 'General Enquiry' },
     { value: 'web-issue', label: 'Web Issue' },
     { value: 'pitch-complaint', label: 'Complaint about a Pitch' },
     { value: 'investor-complaint', label: 'Complaint about an Investor' },
@@ -22,13 +26,29 @@ export default function Contact() {
     { value: 'other', label: 'Other' }
   ];
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // Here you would typically send the form data to your backend
-    setSubmitted(true);
-    setTimeout(() => {
-      navigate('/');
-    }, 3000);
+    setError('');
+    setSubmitting(true);
+    try {
+      const res = await fetch(`${API_URL}/api/contact`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData),
+      });
+      const data = (await res.json().catch(() => ({}))) as { success?: boolean; error?: string };
+      if (!res.ok || !data.success) {
+        throw new Error(data.error || 'Failed to send message. Please try again.');
+      }
+      setSubmitted(true);
+      setTimeout(() => {
+        navigate('/');
+      }, 3000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to send message. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
@@ -144,12 +164,17 @@ export default function Contact() {
               />
             </div>
 
+            {error && (
+              <p className="text-sm text-red-600" role="alert">{error}</p>
+            )}
+
             <button
               type="submit"
-              className="w-full bg-purple-600 text-white font-semibold py-3 px-6 rounded-lg hover:bg-purple-700 transition flex items-center justify-center gap-2"
+              disabled={submitting}
+              className="w-full bg-purple-600 text-white font-semibold py-3 px-6 rounded-lg hover:bg-purple-700 transition flex items-center justify-center gap-2 disabled:opacity-60"
             >
               <Send className="w-4 h-4" />
-              Send Message
+              {submitting ? 'Sending…' : 'Send Message'}
             </button>
           </form>
         </div>

--- a/frontend/src/pages/Homepage.tsx
+++ b/frontend/src/pages/Homepage.tsx
@@ -642,21 +642,20 @@ export default function Homepage() {
                 <img src="/pitchey-logotype.png" alt="Pitchey" className="h-7 w-auto" />
               </div>
               <p className="text-metadata">
-                Connecting stories with opportunities since 2025.
+                Connecting stories since 2026.
               </p>
             </div>
             <div>
               <h3 className="text-card-title mb-4">For Creators</h3>
               <ul className="space-y-2">
                 <li><button onClick={() => navigate('/portals')} className="text-metadata hover:text-purple-600 transition">Submit Pitch</button></li>
-                <li><button onClick={() => navigate('/billing')} className="text-metadata hover:text-purple-600 transition">Pricing</button></li>
+                <li><button onClick={() => navigate('/pricing')} className="text-metadata hover:text-purple-600 transition">Pricing</button></li>
               </ul>
             </div>
             <div>
               <h3 className="text-card-title mb-4">Browse</h3>
               <ul className="space-y-2">
                 <li><button onClick={() => navigate('/marketplace')} className="text-metadata hover:text-purple-600 transition">Browse Pitches</button></li>
-                <li><button className="text-metadata hover:text-purple-600 transition">Format</button></li>
               </ul>
             </div>
             <div>

--- a/frontend/src/pages/Pricing.tsx
+++ b/frontend/src/pages/Pricing.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, Check, Sparkles } from 'lucide-react';
+import {
+  SUBSCRIPTION_TIERS,
+  CREDIT_PACKAGES,
+  getSubscriptionTiersByUserType,
+} from '../config/subscription-plans';
+
+// Public pricing page. Sourced entirely from config/subscription-plans so it
+// can't drift from what checkout actually charges. Prices are EUR today; this
+// will need to respect locale pricing once Stripe price-localisation lands
+// (Priority 7) — read it from the same config so both stay in sync.
+const CURRENCY = '€';
+
+const GROUPS: { key: string; label: string; blurb: string }[] = [
+  { key: 'creator', label: 'For Creators', blurb: 'Pitch your stories and reach investors and production companies.' },
+  { key: 'production', label: 'For Production Companies', blurb: 'Source projects, manage NDAs, and run your development pipeline.' },
+  { key: 'exec', label: 'For Executives & Studios', blurb: 'Discover and evaluate pitches at scale.' },
+];
+
+export default function Pricing() {
+  const navigate = useNavigate();
+  const [billing, setBilling] = useState<'monthly' | 'annual'>('monthly');
+
+  const price = (tier: typeof SUBSCRIPTION_TIERS[number]) =>
+    billing === 'monthly' ? tier.price.monthly : tier.price.annual;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <button
+          onClick={() => navigate('/')}
+          className="flex items-center gap-2 text-gray-600 hover:text-gray-900 mb-8 transition"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Home
+        </button>
+
+        <div className="text-center mb-10">
+          <h1 className="text-4xl font-bold text-gray-900 mb-3">Simple, transparent pricing</h1>
+          <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+            Choose the plan that fits how you work. Watchers browse for free — no plan needed.
+          </p>
+
+          {/* Billing cycle toggle */}
+          <div className="inline-flex items-center gap-1 mt-6 p-1 bg-gray-100 rounded-xl">
+            <button
+              onClick={() => setBilling('monthly')}
+              className={`px-4 py-1.5 text-sm font-medium rounded-lg transition ${billing === 'monthly' ? 'bg-white shadow-sm text-gray-900' : 'text-gray-500'}`}
+            >
+              Monthly
+            </button>
+            <button
+              onClick={() => setBilling('annual')}
+              className={`px-4 py-1.5 text-sm font-medium rounded-lg transition ${billing === 'annual' ? 'bg-white shadow-sm text-gray-900' : 'text-gray-500'}`}
+            >
+              Annual
+            </button>
+          </div>
+        </div>
+
+        {GROUPS.map((group) => {
+          const tiers = getSubscriptionTiersByUserType(group.key);
+          if (!tiers.length) return null;
+          return (
+            <section key={group.key} className="mb-14">
+              <div className="mb-6">
+                <h2 className="text-2xl font-bold text-gray-900">{group.label}</h2>
+                <p className="text-gray-600">{group.blurb}</p>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                {tiers.map((tier, i) => {
+                  const featured = i === 1; // middle tier highlighted
+                  return (
+                    <div
+                      key={tier.id}
+                      className={`relative bg-white rounded-2xl border p-6 flex flex-col ${featured ? 'border-purple-300 shadow-lg ring-1 ring-purple-200' : 'border-gray-200 shadow-sm'}`}
+                    >
+                      {featured && (
+                        <span className="absolute -top-3 left-1/2 -translate-x-1/2 inline-flex items-center gap-1 px-3 py-0.5 rounded-full bg-purple-600 text-white text-xs font-medium">
+                          <Sparkles className="w-3 h-3" /> Most popular
+                        </span>
+                      )}
+                      <h3 className="text-lg font-semibold text-gray-900">{tier.name}</h3>
+                      <div className="mt-3 flex items-baseline gap-1">
+                        <span className="text-3xl font-bold text-gray-900">{CURRENCY}{price(tier).toFixed(2)}</span>
+                        <span className="text-sm text-gray-500">/{billing === 'monthly' ? 'mo' : 'yr'}</span>
+                      </div>
+                      <p className="mt-1 text-sm text-gray-500">
+                        {tier.credits === -1 ? 'Unlimited credits' : `${tier.credits} credits / month`}
+                      </p>
+                      <ul className="mt-5 space-y-2 flex-1">
+                        {tier.features.map((f) => (
+                          <li key={f} className="flex items-start gap-2 text-sm text-gray-700">
+                            <Check className="w-4 h-4 text-green-600 mt-0.5 shrink-0" />
+                            <span>{f}</span>
+                          </li>
+                        ))}
+                      </ul>
+                      <button
+                        onClick={() => navigate('/portals')}
+                        className={`mt-6 w-full py-2.5 rounded-lg font-medium transition ${featured ? 'bg-purple-600 text-white hover:bg-purple-700' : 'bg-gray-100 text-gray-900 hover:bg-gray-200'}`}
+                      >
+                        Get Started
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          );
+        })}
+
+        {/* Pay-as-you-go credits */}
+        <section className="mb-8">
+          <div className="mb-6">
+            <h2 className="text-2xl font-bold text-gray-900">Pay-as-you-go credits</h2>
+            <p className="text-gray-600">Prefer not to subscribe? Top up credits any time.</p>
+          </div>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {CREDIT_PACKAGES.map((pkg) => (
+              <div key={pkg.credits} className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 text-center">
+                <p className="text-2xl font-bold text-gray-900">{pkg.credits + (pkg.bonus ?? 0)}</p>
+                <p className="text-sm text-gray-500">credits{pkg.bonus ? ` (incl. ${pkg.bonus} free)` : ''}</p>
+                <p className="mt-3 text-lg font-semibold text-purple-600">{CURRENCY}{pkg.price.toFixed(2)}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <p className="text-center text-sm text-gray-500">
+          Prices shown in EUR. Questions? <button onClick={() => navigate('/contact')} className="text-purple-600 hover:underline">Contact us</button>.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/__tests__/Contact.test.tsx
+++ b/frontend/src/pages/__tests__/Contact.test.tsx
@@ -26,6 +26,11 @@ beforeAll(async () => {
 describe('Contact', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Contact submission now POSTs to /api/contact; mock a successful send.
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    }) as unknown as typeof fetch
   })
 
   const renderComponent = () =>

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -3295,6 +3295,49 @@ class RouteRegistry {
       return publicPortfolioByTokenHandler(req, this.env);
     });
 
+    // Public contact form — emails info@pitchey.com via Resend (no auth)
+    this.register('POST', '/api/contact', async (req) => {
+      const corsHeaders = getCorsHeaders(req.headers.get('Origin'));
+      const headers = { 'Content-Type': 'application/json', ...corsHeaders };
+      try {
+        const body = (await req.json().catch(() => ({}))) as { type?: string; email?: string; subject?: string; message?: string };
+        const email = (body.email || '').trim();
+        const message = (body.message || '').trim();
+        const subject = (body.subject || '').trim();
+        if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email) || message.length < 5) {
+          return new Response(JSON.stringify({ success: false, error: 'A valid email and a message (5+ chars) are required.' }), { status: 400, headers });
+        }
+        if (!this.emailService) {
+          return new Response(JSON.stringify({ success: false, error: 'Email service unavailable' }), { status: 503, headers });
+        }
+        // Strip angle brackets to avoid HTML injection into the notification email.
+        const safe = (s: string) => s.replace(/[<>]/g, '').slice(0, 5000);
+        const typeLabel = safe(body.type || 'General Enquiry') || 'General Enquiry';
+        const html = `
+          <h2>New contact form submission</h2>
+          <p><strong>Type:</strong> ${typeLabel}</p>
+          <p><strong>From:</strong> ${safe(email)}</p>
+          <p><strong>Subject:</strong> ${safe(subject) || '(none)'}</p>
+          <p><strong>Message:</strong></p>
+          <p>${safe(message).replace(/\n/g, '<br>')}</p>
+        `;
+        const sent = await this.emailService.send({
+          to: 'info@pitchey.com',
+          subject: `[Contact] ${typeLabel}${subject ? ' — ' + safe(subject) : ''}`,
+          html,
+          replyTo: email,
+        }, { templateType: 'contact_form' });
+        if (!sent.success) {
+          return new Response(JSON.stringify({ success: false, error: 'Failed to send message' }), { status: 502, headers });
+        }
+        return new Response(JSON.stringify({ success: true }), { status: 200, headers });
+      } catch (e) {
+        const err = e instanceof Error ? e : new Error(String(e));
+        console.error('Contact form error:', err.message);
+        return new Response(JSON.stringify({ success: false, error: 'Failed to send message' }), { status: 500, headers });
+      }
+    });
+
     // Slates — curated pitch collections
     this.register('POST', '/api/slates', async (req) => {
       const { createSlateHandler } = await import('./handlers/slates');
@@ -3893,6 +3936,7 @@ class RouteRegistry {
       '/api/auth/request-reset',
       '/api/auth/reset-password',
       '/api/ndas/standard',
+      '/api/contact',
       '/api/search',
       '/api/search/autocomplete',
       '/api/search/trending',


### PR DESCRIPTION
## Priority 6 — public / pre-auth pages (footer cluster)

- **Public Pricing page** (`/pricing`) — sourced entirely from `config/subscription-plans` (tiers grouped by audience + credit packages + monthly/annual toggle) so it can't drift from checkout. EUR today; structured to respect locale pricing once P7 lands.
- **Footer** (Homepage): "Pricing" now → `/pricing` (was `/billing`, which 401s signed-out); removed the dead "Format" link; tagline → "Connecting stories since 2026."
- **Contact**: form now actually sends — new public **`POST /api/contact`** emails submissions to **info@pitchey.com** via Resend (reply-to = submitter), validated + injection-safe. Frontend wired with submitting/error states; added a "General Enquiry" type.
- **Terms & Privacy**: already ship **real** legal copy (numbered sections, GDPR rights, investment disclaimer) — no placeholder work needed; confirmed during the audit.

Validation: worker `tsc` + `build:worker` + catch-swallow gate (0); frontend `tsc` (0) + `build`; Contact tests 15 green (added a fetch mock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
