### PR TITLE
fix(credits): Priority 4 — EUR currency consistency + readable per-credit cost

### DIFF
--- a/frontend/src/features/billing/components/CreditPurchase.tsx
+++ b/frontend/src/features/billing/components/CreditPurchase.tsx
@@ -52,7 +52,9 @@ const UI_CREDIT_PACKAGES = CREDIT_PACKAGES.map((pkg, index) => {
     credits: pkg.credits,
     price: pkg.price,
     symbol,
-    value: `${symbol}${(pkg.price / pkg.credits).toFixed(3)} per credit`,
+    // Per-credit cost over the EFFECTIVE credits (incl. bonus), to 2 decimals —
+    // 3 decimals read as "a fraction of a pence" and were incomprehensible.
+    value: `${symbol}${(pkg.price / (pkg.credits + (pkg.bonus ?? 0))).toFixed(2)} per credit`,
     icon: icons[index] || Coins,
     description: pkg.description || descriptions[index] || 'Credit package',
     popular: index === 1, // Make second package popular

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -9765,7 +9765,10 @@ pitchey_analytics_datapoints_per_minute 1250
     return builder.success({
       balance: { credits, totalPurchased, totalUsed },
       credits,
-      currency: 'USD'
+      // Credits are priced in EUR (matching the live Stripe price IDs and the
+      // package config); reporting USD here produced the mixed $/€ display.
+      // Locale-aware currency is deferred to the P7 billing-localisation work.
+      currency: 'EUR'
     });
   }
 


### PR DESCRIPTION
## Priority 4 — credits page coherence (currency + per-credit)

- **Mixed $/€ fixed**: `getCreditsBalance` reported `currency: 'USD'` while every package/price is EUR. Now returns `'EUR'` (display-only — amounts unchanged). Locale-aware currency deferred to P7.
- **Per-credit cost readable**: was `.toFixed(3)` ("€0.499/credit") divided by base credits ignoring bonus → now 2 decimals over effective credits incl. bonus (e.g. €0.75/credit for 30+10).

**Deferred:** the repeating "first time free" offer — not locatable in the codebase (no promo banner / credits-component hit). Awaiting a pointer to where it surfaces before adding a one-time consumption flag.

Validation: worker `tsc` + gate (0); frontend `tsc` (0) + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
