### PR TITLE
feat(feedback): Priority 5 — reviewer choice decides name visibility

### DIFF
--- a/src/handlers/pitch-feedback.ts
+++ b/src/handlers/pitch-feedback.ts
@@ -362,58 +362,16 @@ export async function getPitchFeedbackPublic(request: Request, env: Env): Promis
   const sql = getDb(env);
   if (!sql) return jsonResponse({ success: true, data: { ratings: null, feedback: [] } }, origin);
 
-  // Optional viewer identity. Endpoint is public — anonymous callers still get
-  // the feedback list, but reviewer identities are gated behind NDA/ownership.
-  const viewerId = await getUserId(request, env);
-
   try {
-    // Verify pitch exists and grab owner for NDA/ownership gate
+    // Verify pitch exists and is published
     const [pitch] = await sql`SELECT id, user_id FROM pitches WHERE id = ${pitchId} AND status = 'published'`;
     if (!pitch) return errorResponse('Pitch not found or not published', origin, 404);
 
-    // Determine whether to reveal reviewer identity. Only pitch owner or users
-    // with an active NDA / granted access see names; everyone else (including
-    // authenticated non-NDA viewers) sees "Anonymous Reviewer" regardless of
-    // the reviewer's own is_anonymous choice. The reviewer's opt-in anonymity
-    // still applies — this just tightens the default floor.
-    const isOwner = !!viewerId && String(pitch.user_id) === String(viewerId);
-    let hasNDAAccess = false;
-    if (!isOwner && viewerId) {
-      // Same permissive NDA probe as getPitch — columns drifted across history.
-      try {
-        const rows = await sql`
-          SELECT 1 FROM ndas
-          WHERE pitch_id = ${pitchId} AND signer_id = ${Number(viewerId)}
-            AND (status = 'approved' OR status = 'signed')
-          LIMIT 1
-        `;
-        hasNDAAccess = rows.length > 0;
-      } catch { /* column may not exist */ }
-      if (!hasNDAAccess) {
-        try {
-          const rows = await sql`
-            SELECT 1 FROM ndas
-            WHERE pitch_id = ${pitchId} AND requester_id = ${Number(viewerId)}
-              AND (status = 'approved' OR status = 'signed')
-            LIMIT 1
-          `;
-          hasNDAAccess = rows.length > 0;
-        } catch { /* ignore */ }
-      }
-      if (!hasNDAAccess) {
-        try {
-          const rows = await sql`
-            SELECT 1 FROM pitch_access
-            WHERE pitch_id = ${pitchId} AND user_id = ${Number(viewerId)}
-              AND (revoked_at IS NULL)
-              AND (expires_at IS NULL OR expires_at > NOW())
-            LIMIT 1
-          `;
-          hasNDAAccess = rows.length > 0;
-        } catch { /* pitch_access may not exist */ }
-      }
-    }
-    const canSeeReviewerNames = isOwner || hasNDAAccess;
+    // Reviewer identity follows the reviewer's OWN choice (P5 decision):
+    // non-anonymous feedback shows the reviewer's name to every viewer;
+    // anonymous feedback stays hidden. The previous owner/NDA viewer gate was
+    // dropped — a reviewer who opts to be named is named for all. Likes remain
+    // named separately and are unaffected.
 
     // Rating aggregation — dual scores + 10-bucket distribution
     const [ratings] = await sql`
@@ -483,38 +441,21 @@ export async function getPitchFeedbackPublic(request: Request, env: Env): Promis
           }, {} as Record<string, { count: number; avgRating: number; weightedAvg: number }>)
         : undefined;
 
-    // Individual feedback with anonymization.
-    //
-    // Two layers of gating stack here:
-    // 1. `pf.is_anonymous` — the reviewer opted to stay anonymous at submission time.
-    // 2. `canSeeReviewerNames` — the viewer is neither the pitch owner nor NDA-signed,
-    //    so names are hidden regardless of what the reviewer chose. This is the fix
-    //    for "non-NDA viewers see who gave feedback" — previously names leaked to
-    //    any unauthenticated caller who hit this public endpoint.
-    const feedback = canSeeReviewerNames
-      ? await sql`
-          SELECT
-            pf.id, pf.reviewer_type, pf.rating, pf.strengths, pf.weaknesses,
-            pf.suggestions, pf.overall_feedback, pf.is_interested, pf.is_anonymous, pf.created_at,
-            CASE WHEN pf.is_anonymous THEN NULL ELSE u.id END as reviewer_id,
-            CASE WHEN pf.is_anonymous THEN 'Anonymous' ELSE COALESCE(u.name, u.username, 'User') END as reviewer_name,
-            CASE WHEN pf.is_anonymous THEN NULL ELSE u.company_name END as reviewer_company
-          FROM pitch_feedback pf
-          LEFT JOIN users u ON u.id = pf.reviewer_id
-          WHERE pf.pitch_id = ${pitchId}
-          ORDER BY pf.created_at DESC
-        `
-      : await sql`
-          SELECT
-            pf.id, pf.reviewer_type, pf.rating, pf.strengths, pf.weaknesses,
-            pf.suggestions, pf.overall_feedback, pf.is_interested, pf.is_anonymous, pf.created_at,
-            NULL as reviewer_id,
-            'Anonymous Reviewer' as reviewer_name,
-            NULL as reviewer_company
-          FROM pitch_feedback pf
-          WHERE pf.pitch_id = ${pitchId}
-          ORDER BY pf.created_at DESC
-        `;
+    // Individual feedback. Identity is gated by the reviewer's own choice only:
+    // `pf.is_anonymous` → 'Anonymous' with no id/company; otherwise the name is
+    // shown to every viewer (P5 — reviewer choice decides, no owner/NDA gate).
+    const feedback = await sql`
+      SELECT
+        pf.id, pf.reviewer_type, pf.rating, pf.strengths, pf.weaknesses,
+        pf.suggestions, pf.overall_feedback, pf.is_interested, pf.is_anonymous, pf.created_at,
+        CASE WHEN pf.is_anonymous THEN NULL ELSE u.id END as reviewer_id,
+        CASE WHEN pf.is_anonymous THEN 'Anonymous' ELSE COALESCE(u.name, u.username, 'User') END as reviewer_name,
+        CASE WHEN pf.is_anonymous THEN NULL ELSE u.company_name END as reviewer_company
+      FROM pitch_feedback pf
+      LEFT JOIN users u ON u.id = pf.reviewer_id
+      WHERE pf.pitch_id = ${pitchId}
+      ORDER BY pf.created_at DESC
+    `;
 
     return jsonResponse({
       success: true,


### PR DESCRIPTION
## Priority 5 — feedback author display (reviewer choice decides)

Resolves the conflicting requirements per the locked decision: **the reviewer's own choice decides**, dropping the owner/NDA viewer gate.

- Before: named feedback was hidden unless the viewer was the pitch owner or NDA-signed (`canSeeReviewerNames = isOwner || hasNDAAccess`), regardless of what the reviewer chose.
- After: identity follows `pf.is_anonymous` only — non-anonymous feedback shows the reviewer's name (+id/company) to **every** viewer; anonymous stays "Anonymous". Likes remain named separately, unaffected.
- Removed the unused `viewerId`/`isOwner`/`hasNDAAccess` NDA-probe block; collapsed the two-branch query to one. Frontend already renders `is_anonymous ? 'Anonymous' : reviewer_name` — no client change.

**Privacy implication (owner-approved):** a reviewer who opts to be named is visible to all viewers, not just owner/NDA-signed.

Validation: worker `tsc` (0) + `build:worker` + catch-swallow gate (0). Backend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
