### PR TITLE
feat(verification): P7 OpenCorporates intl verification + P5 email mask + P7 billing scoping doc

### DIFF
--- a/docs/p7-locale-billing-scoping-2026-06-02.md
+++ b/docs/p7-locale-billing-scoping-2026-06-02.md
@@ -1,0 +1,55 @@
+# P7 — Locale / Currency Billing — Scoping (2026-06-02)
+
+Status: **scoping only, no code.** Money + Stripe-live config. Decisions required before any implementation.
+
+## Current state
+- **Single currency: EUR.** `frontend/src/config/subscription-plans.ts` defines `SUBSCRIPTION_TIERS` (Creator/Production/Exec) and `CREDIT_PACKAGES`, all priced in EUR.
+- **Single-mode live price IDs.** 16 live price IDs were swapped 1:1 by euro amount (commit `5606f10d`). Flipping currency/mode today means editing that file + redeploy — there is no env-aware or currency-aware price map.
+- **Credits balance** now reports `currency: 'EUR'` (P4). The public `/pricing` page and `CreditPurchase` read EUR from config and were built to switch to a locale source later.
+- **Known open item** (from `project_stripe_live`): "Stripe Adaptive Pricing EUR→GBP" — i.e. GBP was never wired.
+- **Geo signal available for free:** Cloudflare Workers expose `request.cf.country` (ISO-3166) and `request.cf` locale hints — no IP-geo vendor needed.
+
+## What "vary by location/currency" actually requires
+Three independent layers, each with a decision:
+
+### 1. Price source (the money model) — DECISION NEEDED
+| Option | How | Pros | Cons |
+|---|---|---|---|
+| **A. Stripe multi-currency Prices** (`currency_options` on one Price, or one Price per currency) | Define each tier's amount per currency in Stripe; Checkout picks by `currency`/customer locale | Real localized amounts you control (€19.99 vs £17.99 vs $21.99); clean Stripe-native | Must set every amount per currency per tier (16 prices × N currencies); config map grows |
+| **B. Stripe Adaptive Pricing** | Enable in Stripe Dashboard; Stripe auto-converts presentment currency at checkout from your single (EUR) price | Near-zero code; instant multi-currency | Amounts are FX-converted (ugly £18.37), not rounded marketing prices; less control; availability/fees caveats |
+| **C. Presentment-only display** | Keep charging EUR; show approximate local price as a hint on the pricing page | Trivial; no Stripe change | Doesn't actually charge local currency — fails the requirement |
+
+**Recommendation: A** for the subscription ladder (marketing prices matter), optionally **B** as a stopgap for long-tail currencies. C alone does not satisfy the ask.
+
+### 2. Currency/locale selection — DECISION NEEDED
+- **Auto from `request.cf.country`** (Worker injects a `currency` into the pricing/checkout responses), with
+- **an explicit currency selector** on the pricing page (override), persisted per user.
+- Recommendation: auto-detect default + manual override; never silently lock a user to a geo-guessed currency.
+
+### 3. Config shape (de-drift)
+- Replace the flat `price.monthly/annual` with a per-currency map, e.g. `price: { EUR: {monthly, annual, priceId}, GBP: {...}, USD: {...} }`, and a `getTierPrice(tierId, currency)` helper.
+- The `/pricing` page and `CreditPurchase` already centralize reads — point them at the helper so display + checkout can't diverge.
+
+## Dependencies / prerequisites
+- **Stripe Dashboard work** (out of code): create per-currency prices (Option A) or enable Adaptive Pricing (Option B). New live price IDs to capture.
+- **Currencies to support** — DECISION NEEDED (proposed launch set: EUR, GBP, USD; expand later).
+- **Tax/VAT**: charging GBP/USD raises VAT/sales-tax questions (Stripe Tax?) — flag for finance, out of P7 code scope but a launch dependency.
+- **Reversibility**: keep a single source of truth (config map) and an env flag to fall back to EUR-only, so a bad rollout reverts cleanly (the current single-mode setup has no such switch).
+
+## Risks
+- Money logic touching live Stripe — must be staged + smoke-tested in test mode first (mirror the Stripe-live go-live discipline).
+- Price/currency mismatch (charging EUR while displaying GBP) is the exact class of bug P4 just fixed — the config-map single-source mitigates it.
+- Adaptive Pricing FX amounts can confuse users vs. the marketing ladder.
+
+## Proposed phased plan (when approved)
+1. Decide currency set + price model (A/B). Create Stripe prices; capture IDs.
+2. Refactor `subscription-plans.ts` to a per-currency map + `getTierPrice` helper (display only first — no checkout change). Ship, verify pricing page shows correct per-currency amounts behind a currency selector.
+3. Wire checkout to pass the selected currency's price ID; smoke-test in Stripe test mode end-to-end (the go-live script pattern).
+4. Auto-detect default currency from `request.cf.country`; persist override.
+5. Tax/VAT review before enabling non-EUR charging in production.
+
+## Open decisions to confirm
+1. Price model: **A (per-currency prices)** vs B (Adaptive) vs hybrid.
+2. Launch currency set (proposed EUR/GBP/USD).
+3. Who creates the Stripe prices (owner) — code can't until IDs exist.
+4. Tax handling owner + whether Stripe Tax is in scope.

--- a/src/handlers/company-verification.ts
+++ b/src/handlers/company-verification.ts
@@ -114,6 +114,9 @@ export async function submitVerificationHandler(
   const autoChecks = await runAutoChecks(
     submission,
     env.COMPANIES_HOUSE_API_KEY as string | undefined,
+    undefined,
+    undefined,
+    (env as unknown as { OPENCORPORATES_API_KEY?: string }).OPENCORPORATES_API_KEY,
   );
 
   const autoApproved = shouldAutoApprove(autoChecks, hasCompanyNumber);

--- a/src/handlers/pitch-feedback.ts
+++ b/src/handlers/pitch-feedback.ts
@@ -449,7 +449,15 @@ export async function getPitchFeedbackPublic(request: Request, env: Env): Promis
         pf.id, pf.reviewer_type, pf.rating, pf.strengths, pf.weaknesses,
         pf.suggestions, pf.overall_feedback, pf.is_interested, pf.is_anonymous, pf.created_at,
         CASE WHEN pf.is_anonymous THEN NULL ELSE u.id END as reviewer_id,
-        CASE WHEN pf.is_anonymous THEN 'Anonymous' ELSE COALESCE(u.name, u.username, 'User') END as reviewer_name,
+        -- Names are public to all viewers now (P5). If a user's display name is
+        -- actually an email (no real name set), show only the local part so we
+        -- don't leak their full email address to anonymous callers.
+        CASE
+          WHEN pf.is_anonymous THEN 'Anonymous'
+          WHEN COALESCE(u.name, u.username, 'User') LIKE '%@%.%'
+            THEN split_part(COALESCE(u.name, u.username, 'User'), '@', 1)
+          ELSE COALESCE(u.name, u.username, 'User')
+        END as reviewer_name,
         CASE WHEN pf.is_anonymous THEN NULL ELSE u.company_name END as reviewer_company
       FROM pitch_feedback pf
       LEFT JOIN users u ON u.id = pf.reviewer_id

--- a/src/services/company-verification.service.ts
+++ b/src/services/company-verification.service.ts
@@ -23,6 +23,9 @@ export interface AutoCheckResults {
   companies_house_exists?: CheckResult;
   companies_house_active?: CheckResult;
   companies_house_name_match?: CheckResult;
+  opencorporates_exists?: CheckResult;
+  opencorporates_active?: CheckResult;
+  opencorporates_name_match?: CheckResult;
   website_resolves?: CheckResult;
   website_responds?: CheckResult;
   website_mentions_company?: CheckResult;
@@ -123,6 +126,64 @@ export async function checkCompaniesHouse(
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     console.error(`[CompaniesHouse] Fetch error: ${e.message}`);
+    return { exists: 'skip', active: 'skip', nameMatch: 'skip' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// OpenCorporates Lookup (non-UK/non-USA — ~140 jurisdictions)
+// ---------------------------------------------------------------------------
+
+export async function checkOpenCorporates(
+  companyNumber: string,
+  companyName: string,
+  apiKey: string | undefined,
+): Promise<{ exists: CheckResult; active: CheckResult; nameMatch: CheckResult }> {
+  // No key → skip (every check 'skip' → no auto-approve → manual review fallback).
+  if (!apiKey) {
+    return { exists: 'skip', active: 'skip', nameMatch: 'skip' };
+  }
+
+  try {
+    // Search by the supplied company number across all jurisdictions; the
+    // submission doesn't capture a jurisdiction code, so we match on number + name.
+    const url = `https://api.opencorporates.com/v0.4/companies/search?q=${encodeURIComponent(companyNumber.trim())}&api_token=${encodeURIComponent(apiKey)}`;
+    const resp = await fetch(url, { headers: { 'User-Agent': 'Pitchey/1.0' } });
+
+    if (!resp.ok) {
+      console.error(`[OpenCorporates] API error: ${resp.status}`);
+      return { exists: 'skip', active: 'skip', nameMatch: 'skip' };
+    }
+
+    const data = await resp.json() as {
+      results?: { companies?: Array<{ company?: { name?: string; company_number?: string; current_status?: string; inactive?: boolean } }> };
+    };
+    const companies = data.results?.companies ?? [];
+    if (companies.length === 0) {
+      return { exists: 'fail', active: 'fail', nameMatch: 'fail' };
+    }
+
+    const normalize = (s: string) => s.toLowerCase().replace(/[^a-z0-9\s]/g, '').trim();
+    const submittedName = normalize(companyName);
+    // Prefer an exact company-number match; otherwise the top result.
+    const match = companies.find(c => (c.company?.company_number || '').trim() === companyNumber.trim()) ?? companies[0];
+    const co = match.company || {};
+
+    const exists: CheckResult = 'pass';
+    const active: CheckResult =
+      co.inactive === true || /dissolved|inactive|closed|liquidat/i.test(co.current_status || '')
+        ? 'fail'
+        : 'pass';
+    const apiName = normalize(co.name || '');
+    const nameMatch: CheckResult =
+      apiName === submittedName || apiName.includes(submittedName) || submittedName.includes(apiName)
+        ? 'pass'
+        : 'warn';
+
+    return { exists, active, nameMatch };
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error(`[OpenCorporates] Fetch error: ${e.message}`);
     return { exists: 'skip', active: 'skip', nameMatch: 'skip' };
   }
 }
@@ -264,6 +325,7 @@ export async function runAutoChecks(
   companiesHouseApiKey: string | undefined,
   insuranceMimeType?: string,
   insuranceFileSize?: number,
+  openCorporatesApiKey?: string,
 ): Promise<AutoCheckResults> {
   const results: AutoCheckResults = {
     checked_at: new Date().toISOString(),
@@ -284,6 +346,20 @@ export async function runAutoChecks(
     results.companies_house_exists = ch.exists;
     results.companies_house_active = ch.active;
     results.companies_house_name_match = ch.nameMatch;
+  }
+
+  // Non-UK/non-USA companies: OpenCorporates lookup across ~140 jurisdictions.
+  // Without an API key the checks come back 'skip' → no auto-approve → the
+  // submission drops to manual admin review (the existing fallback).
+  if (submission.region === 'other' && submission.hasCompanyNumber && submission.companyNumber) {
+    const oc = await checkOpenCorporates(
+      submission.companyNumber,
+      submission.companyName,
+      openCorporatesApiKey,
+    );
+    results.opencorporates_exists = oc.exists;
+    results.opencorporates_active = oc.active;
+    results.opencorporates_name_match = oc.nameMatch;
   }
 
   // Website check (all regions)


### PR DESCRIPTION
## Priority 7 (part) + P5 follow-up

**P7 verification — OpenCorporates for non-UK/non-USA companies.** The `other` region previously had no live registry lookup (manual/insurance only). Now runs a live OpenCorporates search (~140 jurisdictions) — exists/active/name-match, mirroring the UK Companies House path. Gated on `OPENCORPORATES_API_KEY` (secret); absent → checks 'skip' → existing manual admin review (the fallback). No new wrangler binding needed until a key is set.

**P5 follow-up — mask email-shaped reviewer names.** Dropping the viewer gate could expose a reviewer's email when their display name is an email; `reviewer_name` now shows the local part only (split_part on '@') for email-shaped names.

**P7 billing — scoping doc, no code.** `docs/p7-locale-billing-scoping-2026-06-02.md` lays out price-model options (multi-currency Prices vs Adaptive Pricing), currency detection, a per-currency config map to prevent drift, dependencies (Stripe prices, currency set, VAT), and a phased plan. Open decisions listed for the owner.

Validation: worker `tsc` (0) + `build:worker` + catch-swallow gate (0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
