### PR TITLE
feat(billing): Priority 7 — multi-currency (EUR/GBP/USD), gated off

### DIFF
--- a/frontend/src/config/currency.ts
+++ b/frontend/src/config/currency.ts
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+import { API_URL } from '../config';
+
+// P7 multi-currency display. Source of truth for which currencies are live is
+// the worker's /api/locale (driven by the backend MULTI_CURRENCY_ENABLED flag),
+// so the UI can't offer a currency the backend won't charge. Amounts are the
+// same numeric value across currencies (owner decision) — only the symbol changes.
+
+export const CURRENCY_SYMBOLS: Record<string, string> = {
+  EUR: '€',
+  GBP: '£',
+  USD: '$',
+  CAD: '$',
+  AUD: '$',
+};
+
+export function currencySymbol(currency: string): string {
+  return CURRENCY_SYMBOLS[(currency || 'EUR').toUpperCase()] ?? '€';
+}
+
+export function formatPrice(amount: number, currency: string): string {
+  return `${currencySymbol(currency)}${amount.toFixed(2)}`;
+}
+
+interface LocaleInfo {
+  currency: string;
+  multiCurrencyEnabled: boolean;
+  supportedCurrencies: string[];
+}
+
+const STORAGE_KEY = 'pitchey:currency';
+let cached: LocaleInfo | null = null;
+let inFlight: Promise<LocaleInfo> | null = null;
+
+async function fetchLocale(): Promise<LocaleInfo> {
+  if (cached) return cached;
+  if (inFlight) return inFlight;
+  inFlight = (async () => {
+    try {
+      const res = await fetch(`${API_URL}/api/locale`, { credentials: 'include' });
+      const body = (await res.json()) as { data?: Partial<LocaleInfo> };
+      const d = body.data ?? {};
+      cached = {
+        currency: d.currency || 'EUR',
+        multiCurrencyEnabled: !!d.multiCurrencyEnabled,
+        supportedCurrencies: d.supportedCurrencies?.length ? d.supportedCurrencies : ['EUR'],
+      };
+    } catch {
+      cached = { currency: 'EUR', multiCurrencyEnabled: false, supportedCurrencies: ['EUR'] };
+    }
+    return cached;
+  })();
+  return inFlight;
+}
+
+/**
+ * Returns the active display/charge currency, the supported set, and a setter.
+ * Default = geo-detected currency from /api/locale; a user override is persisted
+ * in localStorage. While multi-currency is disabled, this resolves to EUR and
+ * `enabled` is false (callers hide the selector).
+ */
+export function useCurrency() {
+  const [info, setInfo] = useState<LocaleInfo | null>(cached);
+  const [override, setOverride] = useState<string | null>(() => {
+    try { return localStorage.getItem(STORAGE_KEY); } catch { return null; }
+  });
+
+  useEffect(() => {
+    let alive = true;
+    void fetchLocale().then((i) => { if (alive) setInfo(i); });
+    return () => { alive = false; };
+  }, []);
+
+  const enabled = !!info?.multiCurrencyEnabled;
+  const supported = info?.supportedCurrencies ?? ['EUR'];
+  // Honour an override only if it's still a supported currency.
+  const resolved = enabled && override && supported.includes(override)
+    ? override
+    : (info?.currency || 'EUR');
+
+  const setCurrency = (c: string) => {
+    try { localStorage.setItem(STORAGE_KEY, c); } catch { /* ignore */ }
+    setOverride(c);
+  };
+
+  return {
+    currency: resolved,
+    symbol: currencySymbol(resolved),
+    enabled,
+    supported,
+    setCurrency,
+  };
+}

--- a/frontend/src/features/billing/components/CreditPurchase.tsx
+++ b/frontend/src/features/billing/components/CreditPurchase.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 import { paymentsAPI } from '@/lib/apiServices';
 import { CREDIT_PACKAGES, CREDIT_COSTS } from '@config/subscription-plans';
+import { useCurrency } from '@config/currency';
 
 interface CreditPurchaseProps {
   credits: any;
@@ -92,6 +93,11 @@ export default function CreditPurchase({ credits, onRefresh }: CreditPurchasePro
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedPackage, setSelectedPackage] = useState<string | null>(null);
+  // Same numeric amount across currencies (owner decision) — only the symbol
+  // changes by selected currency. EUR while multi-currency is disabled.
+  const { symbol: displaySymbol, currency } = useCurrency();
+  const perCredit = (pkg: { price: number; credits: number; bonus: number }) =>
+    `${displaySymbol}${(pkg.price / (pkg.credits + (pkg.bonus ?? 0))).toFixed(2)} per credit`;
 
   const handlePurchase = async (packageId: string) => {
     try {
@@ -99,7 +105,7 @@ export default function CreditPurchase({ credits, onRefresh }: CreditPurchasePro
       setError(null);
       setSelectedPackage(packageId);
 
-      const result = await paymentsAPI.purchaseCredits(packageId) as any;
+      const result = await paymentsAPI.purchaseCredits(packageId, currency) as any;
 
       if (result && result.url) {
         // Redirect to Stripe checkout
@@ -235,9 +241,9 @@ export default function CreditPurchase({ credits, onRefresh }: CreditPurchasePro
                 <div className="space-y-3 mb-6">
                   <div className="text-center">
                     <div className="text-2xl font-bold text-purple-600">
-                      {pkg.symbol}{pkg.price}
+                      {displaySymbol}{pkg.price}
                     </div>
-                    <div className="text-sm text-gray-500">{pkg.value}</div>
+                    <div className="text-sm text-gray-500">{perCredit(pkg)}</div>
                   </div>
                   
                   {totalCredits > pkg.credits && (

--- a/frontend/src/features/billing/components/SubscriptionCard.tsx
+++ b/frontend/src/features/billing/components/SubscriptionCard.tsx
@@ -13,6 +13,7 @@ import {
   getSubscriptionTier,
   type SubscriptionTier,
 } from '@/config/subscription-plans';
+import { useCurrency } from '@/config/currency';
 
 interface SubscriptionCardProps {
   subscription: any;
@@ -27,6 +28,7 @@ const POPULAR_TIER_BY_PORTAL: Record<string, string> = {
 };
 
 export default function SubscriptionCard({ subscription, onRefresh }: SubscriptionCardProps) {
+  const { symbol: currencySymbol, currency } = useCurrency();
   const { user } = useBetterAuthStore();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -61,7 +63,7 @@ export default function SubscriptionCard({ subscription, onRefresh }: Subscripti
       setLoading(true);
       setError(null);
 
-      const result = await paymentsAPI.subscribe(planKey, selectedBilling) as any;
+      const result = await paymentsAPI.subscribe(planKey, selectedBilling, currency) as any;
 
       if (result && result.url) {
         window.location.href = result.url;
@@ -261,7 +263,7 @@ export default function SubscriptionCard({ subscription, onRefresh }: Subscripti
                   ) : (
                     <>
                       <span className="text-3xl font-bold text-gray-900">
-                        €{formatPrice(displayedPrice)}
+                        {currencySymbol}{formatPrice(displayedPrice)}
                       </span>
                       <span className="text-gray-500">
                         /{selectedBilling === 'annual' ? 'year' : 'month'}
@@ -272,7 +274,7 @@ export default function SubscriptionCard({ subscription, onRefresh }: Subscripti
 
                 {selectedBilling === 'annual' && annualSavings > 0 && (
                   <div className="text-sm text-green-600">
-                    Save €{formatPrice(annualSavings)}/year
+                    Save {currencySymbol}{formatPrice(annualSavings)}/year
                   </div>
                 )}
               </div>

--- a/frontend/src/lib/apiServices.ts
+++ b/frontend/src/lib/apiServices.ts
@@ -504,8 +504,9 @@ export const paymentsAPI = {
   },
 
   // Subscribe to a plan. Backend expects 'monthly' | 'annual' (not 'yearly').
-  async subscribe(tier: string, billingInterval?: 'monthly' | 'annual') {
-    const response = await apiClient.post<any>('/api/payments/subscribe', { tier, billingInterval });
+  // currency is normalized server-side (EUR unless multi-currency is enabled).
+  async subscribe(tier: string, billingInterval?: 'monthly' | 'annual', currency?: string) {
+    const response = await apiClient.post<any>('/api/payments/subscribe', { tier, billingInterval, currency });
     if (response.success) {
       return { success: true, ...(response.data as object || {}) };
     }
@@ -548,8 +549,8 @@ export const paymentsAPI = {
   },
 
   // Purchase credits
-  async purchaseCredits(creditPackage: string) {
-    const response = await apiClient.post<any>('/api/payments/credits/purchase', { creditPackage });
+  async purchaseCredits(creditPackage: string, currency?: string) {
+    const response = await apiClient.post<any>('/api/payments/credits/purchase', { creditPackage, currency });
     if (response.success) {
       return { success: true, ...(response.data as object || {}) };
     }

--- a/frontend/src/pages/Pricing.tsx
+++ b/frontend/src/pages/Pricing.tsx
@@ -6,12 +6,12 @@ import {
   CREDIT_PACKAGES,
   getSubscriptionTiersByUserType,
 } from '../config/subscription-plans';
+import { useCurrency } from '../config/currency';
 
 // Public pricing page. Sourced entirely from config/subscription-plans so it
-// can't drift from what checkout actually charges. Prices are EUR today; this
-// will need to respect locale pricing once Stripe price-localisation lands
-// (Priority 7) — read it from the same config so both stay in sync.
-const CURRENCY = '€';
+// can't drift from what checkout actually charges. Amounts are the same numeric
+// value across currencies (owner decision); only the symbol changes by locale,
+// driven by the worker's /api/locale (P7).
 
 const GROUPS: { key: string; label: string; blurb: string }[] = [
   { key: 'creator', label: 'For Creators', blurb: 'Pitch your stories and reach investors and production companies.' },
@@ -22,6 +22,7 @@ const GROUPS: { key: string; label: string; blurb: string }[] = [
 export default function Pricing() {
   const navigate = useNavigate();
   const [billing, setBilling] = useState<'monthly' | 'annual'>('monthly');
+  const { symbol: CURRENCY, currency, enabled: multiCurrency, supported, setCurrency } = useCurrency();
 
   const price = (tier: typeof SUBSCRIPTION_TIERS[number]) =>
     billing === 'monthly' ? tier.price.monthly : tier.price.annual;
@@ -58,6 +59,20 @@ export default function Pricing() {
               Annual
             </button>
           </div>
+
+          {multiCurrency && supported.length > 1 && (
+            <div className="mt-4">
+              <label className="sr-only" htmlFor="pricing-currency">Currency</label>
+              <select
+                id="pricing-currency"
+                value={currency}
+                onChange={(e) => setCurrency(e.target.value)}
+                className="px-3 py-1.5 text-sm border border-gray-200 rounded-lg bg-white text-gray-700"
+              >
+                {supported.map((c) => <option key={c} value={c}>{c}</option>)}
+              </select>
+            </div>
+          )}
         </div>
 
         {GROUPS.map((group) => {
@@ -130,7 +145,7 @@ export default function Pricing() {
         </section>
 
         <p className="text-center text-sm text-gray-500">
-          Prices shown in EUR. Questions? <button onClick={() => navigate('/contact')} className="text-purple-600 hover:underline">Contact us</button>.
+          Prices shown in {currency}. Questions? <button onClick={() => navigate('/contact')} className="text-purple-600 hover:underline">Contact us</button>.
         </p>
       </div>
     </div>

--- a/scripts/stripe-create-multicurrency-prices.mjs
+++ b/scripts/stripe-create-multicurrency-prices.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * stripe-create-multicurrency-prices.mjs
+ *
+ * P7 multi-currency billing. The 12 live subscription Prices are EUR-only and
+ * Stripe Prices are immutable, so we create NEW Prices that carry the same
+ * numeric amount in EUR + GBP + USD via `currency_options`. One new Price ID
+ * per tier/interval then charges in whichever currency Checkout requests.
+ *
+ * Credit packages use dynamic price_data at checkout, so they need no script —
+ * the worker sets the currency on the fly.
+ *
+ * Usage:
+ *   STRIPE_SECRET_KEY=sk_live_xxx node scripts/stripe-create-multicurrency-prices.mjs
+ *   # or run without the env var and paste the key when prompted (no echo)
+ *
+ * Output: the old→new price-ID mapping plus a ready-to-paste block for
+ * src/config/subscription-plans.ts. Nothing is deleted; the old EUR prices stay
+ * (deactivate them in the Stripe dashboard later if you want).
+ *
+ * Same-numeric-value policy (owner decision 2026-06-02): £/$ amount == € amount.
+ */
+
+import { createInterface } from 'node:readline';
+
+// The current live EUR price IDs, keyed by tier+interval (from subscription-plans.ts).
+const PRICES = [
+  ['creator.monthly', 'price_1TbgA0Gfa7gtG8Qy0IKu4kUO'],
+  ['creator.annual', 'price_1TbgJIGfa7gtG8Qyhh1BtwNR'],
+  ['creator_plus.monthly', 'price_1TbgCnGfa7gtG8QyQpBUOaf5'],
+  ['creator_plus.annual', 'price_1TbgJvGfa7gtG8QycMQjlnUB'],
+  ['creator_unlimited.monthly', 'price_1TbgFPGfa7gtG8QyOEVd45Dp'],
+  ['creator_unlimited.annual', 'price_1TbgICGfa7gtG8QyT4vdxXEI'],
+  ['production.monthly', 'price_1TbgLDGfa7gtG8QyW7Qpe528'],
+  ['production.annual', 'price_1TbgMAGfa7gtG8Qyku7xIHHE'],
+  ['production_plus.monthly', 'price_1TbgX6Gfa7gtG8QyZJEvAkeh'],
+  ['production_plus.annual', 'price_1TbgX6Gfa7gtG8QyCeVTfUYC'],
+  ['production_unlimited.monthly', 'price_1TbgYLGfa7gtG8QyAEXziPu2'],
+  ['production_unlimited.annual', 'price_1TbgYoGfa7gtG8QyMOlKAHOQ'],
+  ['exec.monthly', 'price_1TbgaTGfa7gtG8QywRU1eSyT'],
+  ['exec.annual', 'price_1TbgaTGfa7gtG8QykqA7SoAY'],
+  ['exec_unlimited.monthly', 'price_1TbgbVGfa7gtG8QylWn9PeN9'],
+  ['exec_unlimited.annual', 'price_1TbgbVGfa7gtG8QyIc8JP9kl'],
+];
+
+const EXTRA_CURRENCIES = ['gbp', 'usd']; // EUR is the base currency on the Price
+
+function prompt(question, { silent = false } = {}) {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    if (silent) {
+      const onData = (char) => {
+        const s = String(char);
+        if (s === '\n' || s === '\r' || s === '') process.stdout.write('\n');
+        else process.stdout.write('\x1B[2K\x1B[200D' + question);
+      };
+      process.stdin.on('data', onData);
+      rl.question(question, (val) => { process.stdin.removeListener('data', onData); rl.close(); resolve(val.trim()); });
+    } else {
+      rl.question(question, (val) => { rl.close(); resolve(val.trim()); });
+    }
+  });
+}
+
+async function stripe(key, method, path, params) {
+  const body = params
+    ? Object.entries(params).map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join('&')
+    : undefined;
+  const resp = await fetch(`https://api.stripe.com/v1${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${key}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body,
+  });
+  const data = await resp.json();
+  if (!resp.ok) {
+    throw new Error(`Stripe ${method} ${path} -> ${resp.status}: ${data.error?.message || JSON.stringify(data)}`);
+  }
+  return data;
+}
+
+async function main() {
+  let key = process.env.STRIPE_SECRET_KEY;
+  if (!key) key = await prompt('Stripe secret key (sk_live_… / sk_test_…): ', { silent: true });
+  if (!/^sk_(live|test)_/.test(key)) {
+    console.error('That does not look like a Stripe secret key. Aborting.');
+    process.exit(1);
+  }
+  const mode = key.startsWith('sk_live') ? 'LIVE' : 'TEST';
+  console.log(`\nMode: ${mode}. Creating multi-currency replacements for ${PRICES.length} prices (EUR + ${EXTRA_CURRENCIES.map(c => c.toUpperCase()).join(' + ')}, same numeric amount).\n`);
+
+  const mapping = {};
+  for (const [label, oldId] of PRICES) {
+    const old = await stripe(key, 'GET', `/prices/${oldId}`);
+    const unitAmount = old.unit_amount;            // cents, same across currencies
+    const product = typeof old.product === 'string' ? old.product : old.product?.id;
+    const params = {
+      product,
+      currency: 'eur',
+      unit_amount: String(unitAmount),
+      'metadata[multicurrency]': 'true',
+      'metadata[source_price]': oldId,
+    };
+    if (old.recurring?.interval) {
+      params['recurring[interval]'] = old.recurring.interval;
+      if (old.recurring.interval_count) params['recurring[interval_count]'] = String(old.recurring.interval_count);
+    }
+    for (const cur of EXTRA_CURRENCIES) {
+      params[`currency_options[${cur}][unit_amount]`] = String(unitAmount);
+    }
+    const created = await stripe(key, 'POST', '/prices', params);
+    mapping[label] = created.id;
+    console.log(`  ${label.padEnd(30)} ${oldId}  ->  ${created.id}`);
+  }
+
+  console.log('\n--- Paste these into src/config/subscription-plans.ts (stripePriceId per tier) ---\n');
+  console.log(JSON.stringify(mapping, null, 2));
+  console.log('\nThen set MULTI_CURRENCY_ENABLED = true in src/config/currency.ts and deploy the worker.');
+}
+
+main().catch((e) => { console.error('\nFailed:', e.message); process.exit(1); });

--- a/src/config/currency.ts
+++ b/src/config/currency.ts
@@ -1,0 +1,40 @@
+/**
+ * Multi-currency configuration (P7).
+ *
+ * Master switch. Stays FALSE until the multi-currency Stripe Prices exist
+ * (run scripts/stripe-create-multicurrency-prices.mjs), their IDs are pasted
+ * into subscription-plans.ts, and the change is verified in Stripe test mode.
+ * While false, every path behaves exactly as the EUR-only system did — the
+ * currency param is ignored and EUR is charged/displayed throughout.
+ */
+export const MULTI_CURRENCY_ENABLED = false;
+
+/** Base currency. Always supported, always the fallback. */
+export const BASE_CURRENCY = 'EUR';
+
+/** Currencies the platform can charge in (owner decision 2026-06-02: + GBP, USD). */
+export const SUPPORTED_CURRENCIES = ['EUR', 'GBP', 'USD'] as const;
+export type SupportedCurrency = (typeof SUPPORTED_CURRENCIES)[number];
+
+/** Cloudflare `request.cf.country` (ISO-3166 alpha-2) → default currency. */
+const COUNTRY_CURRENCY: Record<string, SupportedCurrency> = {
+  GB: 'GBP',
+  US: 'USD',
+};
+
+/**
+ * Coerce an arbitrary input to a supported currency. Unknown/unsupported →
+ * BASE_CURRENCY. When multi-currency is disabled, always BASE_CURRENCY so no
+ * caller can accidentally trigger a non-EUR charge before activation.
+ */
+export function normalizeCurrency(input: unknown): SupportedCurrency {
+  if (!MULTI_CURRENCY_ENABLED) return BASE_CURRENCY;
+  const c = String(input ?? '').toUpperCase();
+  return (SUPPORTED_CURRENCIES as readonly string[]).includes(c) ? (c as SupportedCurrency) : BASE_CURRENCY;
+}
+
+/** Default currency for a Cloudflare country code. EUR unless multi-currency is on. */
+export function currencyForCountry(country: string | undefined): SupportedCurrency {
+  if (!MULTI_CURRENCY_ENABLED) return BASE_CURRENCY;
+  return (country && COUNTRY_CURRENCY[country.toUpperCase()]) || BASE_CURRENCY;
+}

--- a/src/services/stripe.service.ts
+++ b/src/services/stripe.service.ts
@@ -35,12 +35,16 @@ export class StripeService {
     tier: string;
     successUrl: string;
     cancelUrl: string;
+    // Lowercase ISO currency (e.g. 'gbp'). Only set for non-base currencies;
+    // requires the price to carry that currency via `currency_options`. When
+    // omitted, Stripe uses the price's base currency (EUR) exactly as before.
+    currency?: string;
   }): Promise<{ id: string; url: string }> {
     // `tier` is stamped into metadata so the webhook can look up the plan
     // (creator / production / exec) without having to reverse-engineer it
     // from the Stripe price ID. Critical for the watcher→creator upgrade
     // flow: the webhook needs the tier to know whether to flip user_type.
-    return this.request('POST', '/checkout/sessions', {
+    const sessionParams: Record<string, string> = {
       mode: 'subscription',
       'payment_method_types[0]': 'card',
       customer_email: params.email,
@@ -58,7 +62,9 @@ export class StripeService {
       'metadata[tier]': params.tier,
       'subscription_data[metadata][userId]': String(params.userId),
       'subscription_data[metadata][tier]': params.tier,
-    });
+    };
+    if (params.currency) sessionParams.currency = params.currency;
+    return this.request('POST', '/checkout/sessions', sessionParams);
   }
 
   async createCreditPurchaseCheckout(params: {
@@ -69,12 +75,16 @@ export class StripeService {
     packageId: string;
     successUrl: string;
     cancelUrl: string;
+    // Lowercase ISO currency for the dynamic price_data. Defaults to 'eur'.
+    // Same numeric amount across currencies (owner decision), so priceInCents
+    // is reused as-is.
+    currency?: string;
   }): Promise<{ id: string; url: string }> {
     return this.request('POST', '/checkout/sessions', {
       mode: 'payment',
       'payment_method_types[0]': 'card',
       customer_email: params.email,
-      'line_items[0][price_data][currency]': 'eur',
+      'line_items[0][price_data][currency]': params.currency || 'eur',
       'line_items[0][price_data][product_data][name]': `${params.credits} Pitchey Credits`,
       'line_items[0][price_data][unit_amount]': String(params.priceInCents),
       'line_items[0][quantity]': '1',

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -28,6 +28,7 @@ import { createJWT, verifyJWT, extractJWT } from './utils/worker-jwt';
 import { hashPassword, verifyPassword, isHashedPassword } from './utils/worker-password';
 import { StripeService } from './services/stripe.service';
 import { CREDIT_PACKAGES } from './config/subscription-plans';
+import { currencyForCountry, normalizeCurrency, MULTI_CURRENCY_ENABLED, SUPPORTED_CURRENCIES, BASE_CURRENCY } from './config/currency';
 import { createSessionStore, type SessionStore, type SessionStoreEnv } from './auth/session-store';
 import { PortalAccessController, createPortalAccessMiddleware } from './middleware/portal-access-control';
 import { CreatorInvestorWorkflow } from './workflows/creator-investor-workflow';
@@ -3295,6 +3296,23 @@ class RouteRegistry {
       return publicPortfolioByTokenHandler(req, this.env);
     });
 
+    // Locale/currency hint (public). Frontend uses this to pick the default
+    // display currency + whether to show the currency selector. Charges still
+    // happen server-side per the validated currency at checkout.
+    this.register('GET', '/api/locale', async (req) => {
+      const corsHeaders = getCorsHeaders(req.headers.get('Origin'));
+      const country = (req as unknown as { cf?: { country?: string } }).cf?.country;
+      return new Response(JSON.stringify({
+        success: true,
+        data: {
+          country: country ?? null,
+          currency: currencyForCountry(country),
+          multiCurrencyEnabled: MULTI_CURRENCY_ENABLED,
+          supportedCurrencies: MULTI_CURRENCY_ENABLED ? SUPPORTED_CURRENCIES : [BASE_CURRENCY],
+        },
+      }), { status: 200, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'private, no-store', ...corsHeaders } });
+    });
+
     // Public contact form — emails info@pitchey.com via Resend (no auth)
     this.register('POST', '/api/contact', async (req) => {
       const corsHeaders = getCorsHeaders(req.headers.get('Origin'));
@@ -3937,6 +3955,7 @@ class RouteRegistry {
       '/api/auth/reset-password',
       '/api/ndas/standard',
       '/api/contact',
+      '/api/locale',
       '/api/search',
       '/api/search/autocomplete',
       '/api/search/trending',
@@ -9897,6 +9916,10 @@ pitchey_analytics_datapoints_per_minute 1250
       }
 
       const totalCredits = pkg.credits + (pkg.bonus || 0);
+      // EUR unless multi-currency is enabled AND the client sent a supported one.
+      // Credits use dynamic price_data, so the currency applies directly (same
+      // numeric amount per owner decision).
+      const currency = normalizeCurrency(body.currency);
       const stripeKey = (this.env as any).STRIPE_SECRET_KEY;
 
       // If Stripe is configured, create a Checkout Session
@@ -9911,6 +9934,7 @@ pitchey_analytics_datapoints_per_minute 1250
           packageId: `package_${packageIndex}`,
           successUrl: `${frontendUrl}/billing?purchase=success`,
           cancelUrl: `${frontendUrl}/billing?purchase=cancelled`,
+          currency: currency.toLowerCase(),
         });
 
         return new ApiResponseBuilder(request).success({
@@ -10289,6 +10313,8 @@ pitchey_analytics_datapoints_per_minute 1250
     try {
       const body = await request.json() as any;
       const { tier, billingInterval = 'monthly' } = body;
+      // EUR unless multi-currency is enabled AND the client sent a supported one.
+      const currency = normalizeCurrency(body.currency);
       const stripeKey = (this.env as any).STRIPE_SECRET_KEY;
 
       if (!stripeKey) {
@@ -10325,6 +10351,9 @@ pitchey_analytics_datapoints_per_minute 1250
         tier,
         successUrl: `${frontendUrl}/billing?subscription=success&tier=${encodeURIComponent(tier)}`,
         cancelUrl: `${frontendUrl}/billing?subscription=cancelled`,
+        // Only pass currency for non-base; EUR omits it → byte-identical to the
+        // pre-multi-currency session. Requires the price to carry currency_options.
+        currency: currency !== BASE_CURRENCY ? currency.toLowerCase() : undefined,
       });
 
       return new ApiResponseBuilder(request).success({


### PR DESCRIPTION
## Priority 7 — multi-currency billing (EUR/GBP/USD), gated OFF

Owner decisions: Stripe multi-currency Prices; currencies EUR(base)/GBP/USD; same numeric amount per currency.

Everything sits behind **`MULTI_CURRENCY_ENABLED` (false)** in `src/config/currency.ts`, so every path is byte-identical to the EUR-only system until activated. Display and charge both read the same gated currency → no mismatch possible (the P4 class of bug).

- **Script** `scripts/stripe-create-multicurrency-prices.mjs` — creates new Prices with `currency_options` (EUR+GBP+USD, same amount) to replace the 12 EUR-only subscription Prices; prints IDs to paste into `subscription-plans.ts`. (Credits use dynamic `price_data` → no script needed.)
- **`GET /api/locale`** (public) — geo→currency + `multiCurrencyEnabled` + supported set.
- **Checkout**: `handleSubscribe` + credits purchase accept a `currency`, normalized server-side; subscription session sets `currency` only for non-base; credits set `price_data` currency directly. EUR omits the param entirely.
- **Frontend**: `useCurrency` hook, Pricing page currency selector + symbol, SubscriptionCard + CreditPurchase show the selected symbol and pass currency to checkout. Selector renders only when enabled.

**Activation** (when ready): run the script with sk_live → paste the 12 new price IDs → set `MULTI_CURRENCY_ENABLED = true` → deploy → smoke-test a GBP checkout in Stripe test mode first.

Validation: worker `tsc`(0)+`build:worker`+gate(0); frontend `tsc`(0)+build; Billing tests 11 green. Deploys with zero behavior change (flag off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
