### PR TITLE
fix(billing): remove untrue 'First month free' plan feature bullet

### DIFF
--- a/frontend/src/config/subscription-plans.ts
+++ b/frontend/src/config/subscription-plans.ts
@@ -97,7 +97,6 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       '10 Creator Credits per month',
       'Basic Analytics',
       'Profile views, pitch views, search appearances',
-      'First month free (12 month contract)'
     ],
     userType: 'creator'
   },
@@ -111,7 +110,6 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       '30 Creator Credits per month',
       'Enhanced Analytics',
       'Who viewed, time spent, location/device',
-      'First month free (12 month contract)'
     ],
     userType: 'creator'
   },
@@ -124,7 +122,6 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
     features: [
       'Unlimited Creator Credits per month',
       'Enhanced & Customizable Analytics',
-      'First month free (12 month contract)'
     ],
     userType: 'creator'
   },
@@ -140,7 +137,6 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       '20 Credits per month',
       'Basic Analytics',
       'Profile views, pitch views, search appearances',
-      'First month free (12 month contract)'
     ],
     userType: 'production'
   },
@@ -154,7 +150,6 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       '40 Creator Credits per month',
       'Enhanced Analytics',
       'Who viewed, time spent, location/device',
-      'First month free (12 month contract)'
     ],
     userType: 'production'
   },
@@ -168,7 +163,6 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       'Unlimited Creator Credits per month',
       'Enhanced & Customizable Analytics',
       'Choose what to track, export, or monitor in real time',
-      'First month free (12 month contract)'
     ],
     userType: 'production'
   },
@@ -184,7 +178,6 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       '30 Credits per month',
       'Basic Analytics',
       'Profile views, pitch views, search appearances',
-      'First month free (12 month contract)'
     ],
     userType: 'exec'
   },
@@ -198,7 +191,6 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       'Unlimited Credits per month',
       'Enhanced & Customizable Analytics',
       'Choose what to track, export, or monitor in real time',
-      'First month free (12 month contract)'
     ],
     userType: 'exec'
   }

--- a/src/config/subscription-plans.ts
+++ b/src/config/subscription-plans.ts
@@ -119,7 +119,6 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       '10 Creator Credits per month',
       'Basic Analytics',
       'Profile views, pitch views, search appearances',
-      'First month free (12 month contract)'
     ],
     userType: 'creator'
   },
@@ -134,7 +133,6 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       '30 Creator Credits per month',
       'Enhanced Analytics',
       'Who viewed, time spent, location/device',
-      'First month free (12 month contract)'
     ],
     userType: 'creator'
   },
@@ -148,7 +146,6 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
     features: [
       'Unlimited Creator Credits per month',
       'Enhanced & Customizable Analytics',
-      'First month free (12 month contract)'
     ],
     userType: 'creator'
   },
@@ -165,7 +162,6 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       '20 Credits per month',
       'Basic Analytics',
       'Profile views, pitch views, search appearances',
-      'First month free (12 month contract)',
       'Company verification required'
     ],
     userType: 'production'
@@ -181,7 +177,6 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       '40 Credits per month',
       'Enhanced Analytics',
       'Who viewed, time spent, location/device',
-      'First month free (12 month contract)',
       'Company verification required'
     ],
     userType: 'production'
@@ -197,7 +192,6 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       'Unlimited Credits per month',
       'Enhanced & Customizable Analytics',
       'Choose what to track, export, or monitor in real time',
-      'First month free (12 month contract)',
       'Company verification required'
     ],
     userType: 'production'
@@ -215,7 +209,6 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       '30 Credits per month',
       'Basic Analytics',
       'Profile views, pitch views, search appearances',
-      'First month free (12 month contract)'
     ],
     userType: 'exec'
   },
@@ -230,7 +223,6 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
       'Unlimited Credits per month',
       'Enhanced & Customizable Analytics',
       'Choose what to track, export, or monitor in real time',
-      'First month free (12 month contract)'
     ],
     userType: 'exec'
   }


### PR DESCRIPTION
Removes the 'First month free (12 month contract)' bullet from every paid tier (backend + frontend config). Checkout has no trial and no contract is enforced, so the claim was untrue at the point of sale — this was the 'first time free' that appeared on every visit. Display-only copy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)