### PR TITLE
fix(pitch-detail): gate Enhanced Information/NDA on real protected content

### DIFF
--- a/frontend/src/pages/PitchDetail.tsx
+++ b/frontend/src/pages/PitchDetail.tsx
@@ -616,8 +616,12 @@ export default function PitchDetail() {
               </div>
             </div>
 
-            {/* Enhanced Information - NDA Protected */}
-            {!hasSignedNDA && !isOwner ? (
+            {/* Enhanced Information — only render when the pitch actually has
+                NDA-gated content (require_nda set or protected content present).
+                Previously this advertised protected content + an NDA on every
+                pitch, dead-ending signers at "Enhanced Information Unavailable". */}
+            {(pitch.requireNDA || (pitch as any).require_nda || (pitch as any).hasProtectedContent || pitch?.protectedContent) && (
+              !hasSignedNDA && !isOwner ? (
               <div className="bg-gradient-to-br from-blue-50 to-purple-50 rounded-xl shadow-sm p-6 border-2 border-blue-200">
                 <div className="flex items-start space-x-3">
                   <Lock className="w-6 h-6 text-blue-600 mt-1" />
@@ -873,7 +877,7 @@ export default function PitchDetail() {
                   </div>
                 </div>
               ) : null
-            )}
+            ))}
 
             {/* Media. Cover image is a public asset (shown on marketplace +
                 public pitch pages); document downloads (script/deck/trailer/

--- a/frontend/src/pages/__tests__/PitchDetail.test.tsx
+++ b/frontend/src/pages/__tests__/PitchDetail.test.tsx
@@ -407,8 +407,10 @@ describe('PitchDetail', () => {
 
     it('opens NDA modal when Request Access clicked', async () => {
       const u = userEvent.setup()
+      // Pitch must actually require an NDA for the Enhanced Information /
+      // Request Access teaser to render (it's now gated on real NDA/content).
       mockPitchService.getByIdAuthenticated.mockResolvedValue(
-        createMockPitch({ hasSignedNDA: false })
+        createMockPitch({ hasSignedNDA: false, requireNDA: true })
       )
 
       renderPitchDetail()

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -6040,6 +6040,22 @@ pitchey_analytics_datapoints_per_minute 1250
         return hit ? (hit.file_url as string) : undefined;
       };
 
+      // Does this pitch actually have NDA-gated content to reveal? The frontend
+      // uses this (with requireNDA) to decide whether to show the "Enhanced
+      // Information"/Request-NDA section at all — it previously advertised
+      // protected content on every pitch even when there was none, dead-ending
+      // NDA-signers at "Enhanced Information Unavailable".
+      const _isNonEmpty = (v: unknown): boolean => {
+        if (v == null) return false;
+        const s = typeof v === 'string' ? v.trim() : JSON.stringify(v);
+        return s !== '' && s !== '{}' && s !== '[]' && s !== 'null' && s !== '""';
+      };
+      const hasProtectedContent = [
+        pitch.private_attachments, pitch.budget_breakdown, pitch.production_timeline,
+        pitch.attached_talent, pitch.financial_projections, pitch.distribution_plan,
+        pitch.marketing_strategy, pitch.contact_details, pitch.revenue_model,
+      ].some(_isNonEmpty) || documents.some((d: any) => d.requires_nda === true);
+
       // Combine the data with proper creator object
       // Use pitches.view_count directly (accurate, maintained by view tracking)
       //
@@ -6068,6 +6084,7 @@ pitchey_analytics_datapoints_per_minute 1250
         isOwner,
         hasSignedNDA: hasNDAAccess,
         hasNDA: hasNDAAccess,
+        hasProtectedContent,
         view_count: parseInt(String(pitch.view_count || '0')),
         investment_count: investmentCount,
         creator: {


### PR DESCRIPTION
The Enhanced Information / Request NDA teaser showed on every pitch even when there was no protected content and no NDA requirement (e.g. At Ever Las: require_nda=false, no attachments) — inviting an NDA request that dead-ended at 'Enhanced Information Unavailable'.

- Backend: getPitch returns `hasProtectedContent` (private_attachments / protected fields / NDA-gated doc).
- Frontend: PitchDetail gates the whole section on `requireNDA || hasProtectedContent || protectedContent`.
- Test updated to model an NDA-required pitch.

Validation: worker tsc+gate+build, frontend tsc+build, PitchDetail 31 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)