### PR TITLE
ci+fix: run vitest in CI (non-blocking) + critical audit fixes (settings 500, NDA 404, currency €)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -74,6 +74,15 @@ jobs:
       - name: 🔧 Type checking
         run: npm run type-check
 
+      # Unit tests now RUN in CI (previously they never executed here, so mocks
+      # silently drifted from the real API). Non-blocking for now: ~79 of 3523
+      # are pre-existing stale-mock failures. Burn-down plan: drive failures to 0,
+      # then remove continue-on-error so this gates. New/contract tests should be
+      # kept green from the start.
+      - name: 🧪 Run unit tests
+        run: npm run test:run
+        continue-on-error: true
+
       - name: 🏗️ Build frontend
         run: npm run build
         env:

--- a/frontend/src/features/browse/components/EmailAlerts.tsx
+++ b/frontend/src/features/browse/components/EmailAlerts.tsx
@@ -61,7 +61,7 @@ export default function EmailAlerts({
 
   const checkEmailPreferences = async () => {
     try {
-      const response = await fetch(`${API_URL}/api/user/notification-preferences`, {
+      const response = await fetch(`${API_URL}/api/notifications/preferences`, {
         method: 'GET',
         credentials: 'include'
       });

--- a/frontend/src/features/notifications/services/notifications.service.ts
+++ b/frontend/src/features/notifications/services/notifications.service.ts
@@ -152,7 +152,8 @@ export class NotificationsService {
    */
   static async updatePreferences(preferences: Partial<NotificationPreferences>): Promise<boolean> {
     try {
-      const response = await apiClient.put('/api/notifications/preferences', preferences);
+      // Registered verb is POST, not PUT (PUT 404'd).
+      const response = await apiClient.post('/api/notifications/preferences', preferences);
       return response.success;
     } catch (error) {
       console.error('Failed to update notification preferences:', error);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -522,7 +522,9 @@ export const pitchAPI = {
   },
 
   async requestNDA(pitchId: number, message?: string, requestType?: string) {
-    const response = await api.post(`/api/pitches/${pitchId}/request-nda`, { message, requestType });
+    // Live endpoint is POST /api/ndas/request with { pitchId, reason }. The old
+    // /api/pitches/:id/request-nda path was never registered (404'd silently).
+    const response = await api.post('/api/ndas/request', { pitchId, reason: message, requestType });
     return response.data;
   },
 };
@@ -530,9 +532,8 @@ export const pitchAPI = {
 // NDA API
 export const ndaAPI = {
   async requestNDA(pitchId: number, customTerms?: string) {
-    const response = await api.post<NDA>(`/api/pitches/${pitchId}/nda/request`, {
-      customTerms
-    });
+    // Live endpoint is POST /api/ndas/request (was /api/pitches/:id/nda/request → 404).
+    const response = await api.post<NDA>('/api/ndas/request', { pitchId, reason: customTerms });
     return response.data;
   },
 

--- a/frontend/src/portals/investor/pages/InvestorStats.tsx
+++ b/frontend/src/portals/investor/pages/InvestorStats.tsx
@@ -74,7 +74,7 @@ export default function InvestorStats() {
         followOnRate: data.followOnRate ?? 0
       });
 
-      const fmtM = (n: number) => n >= 1000000 ? `$${(n / 1000000).toFixed(2)}M` : n >= 1000 ? `$${(n / 1000).toFixed(0)}K` : `$${n}`;
+      const fmtM = (n: number) => n >= 1000000 ? `€${(n / 1000000).toFixed(2)}M` : n >= 1000 ? `€${(n / 1000).toFixed(0)}K` : `€${n}`;
 
       setStats([
         {
@@ -240,7 +240,7 @@ export default function InvestorStats() {
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
-      currency: 'USD',
+      currency: 'EUR',
       minimumFractionDigits: 0,
       maximumFractionDigits: 0
     }).format(amount);

--- a/frontend/src/services/__tests__/user.service.test.ts
+++ b/frontend/src/services/__tests__/user.service.test.ts
@@ -266,16 +266,16 @@ describe('UserService', () => {
 
       const result = await UserService.getNotificationPreferences()
 
-      expect(mockApiClient.get).toHaveBeenCalledWith('/api/user/notification-preferences')
+      expect(mockApiClient.get).toHaveBeenCalledWith('/api/notifications/preferences')
       expect(result.emailEnabled).toBe(true)
     })
   })
 
   describe('updateNotificationPreferences', () => {
     it('updates notification preferences', async () => {
-      mockApiClient.put.mockResolvedValue({ success: true })
+      mockApiClient.post.mockResolvedValue({ success: true })
       await expect(UserService.updateNotificationPreferences({ emailEnabled: false })).resolves.toBeUndefined()
-      expect(mockApiClient.put).toHaveBeenCalledWith('/api/user/notification-preferences', { emailEnabled: false })
+      expect(mockApiClient.post).toHaveBeenCalledWith('/api/notifications/preferences', { emailEnabled: false })
     })
   })
 

--- a/frontend/src/services/user.service.ts
+++ b/frontend/src/services/user.service.ts
@@ -353,10 +353,11 @@ export class UserService {
     }
   }
 
-  // Get notifications preferences
+  // Get notifications preferences. Registered route is /api/notifications/preferences
+  // (the /api/user/notification-preferences path was never registered → 404).
   static async getNotificationPreferences(): Promise<any> {
     const response = await apiClient.get<{ success: boolean; preferences: any }>(
-      '/api/user/notification-preferences'
+      '/api/notifications/preferences'
     );
 
     if (!response.success) {
@@ -366,10 +367,11 @@ export class UserService {
     return response.data?.preferences;
   }
 
-  // Update notification preferences
+  // Update notification preferences. Registered verb is POST (not PUT) on
+  // /api/notifications/preferences.
   static async updateNotificationPreferences(preferences: any): Promise<void> {
-    const response = await apiClient.put<{ success: boolean }>(
-      '/api/user/notification-preferences',
+    const response = await apiClient.post<{ success: boolean }>(
+      '/api/notifications/preferences',
       preferences
     );
 

--- a/frontend/src/shared/utils/formatters.ts
+++ b/frontend/src/shared/utils/formatters.ts
@@ -11,7 +11,7 @@ export const formatCurrency = (value: unknown, options?: {
   
   return new Intl.NumberFormat('en-US', {
     style: 'currency',
-    currency: 'USD',
+    currency: 'EUR', // platform base currency (was USD — wrong symbol on every figure)
     minimumFractionDigits: options?.minimumFractionDigits ?? 0,
     maximumFractionDigits: options?.maximumFractionDigits ?? 0,
   }).format(safeValue);
@@ -25,7 +25,7 @@ export const formatBudgetCompact = (value: unknown): string => {
   if (n === 0) return '';
   return new Intl.NumberFormat('en-US', {
     style: 'currency',
-    currency: 'USD',
+    currency: 'EUR', // platform base currency (was USD — wrong symbol on every figure)
     notation: 'compact',
     compactDisplay: 'short',
     minimumFractionDigits: 0,

--- a/src/handlers/investor-sidebar.ts
+++ b/src/handlers/investor-sidebar.ts
@@ -803,7 +803,7 @@ export async function investorWalletHandler(request: Request, env: Env): Promise
   const userId = await getUserId(request, env);
   if (!userId) return authError(origin);
 
-  const emptyData = { balance: 0, currency: 'USD', transactions: [] as any[] };
+  const emptyData = { balance: 0, currency: 'EUR', transactions: [] as any[] };
 
   const sql = getDb(env);
   if (!sql) return jsonResponse(emptyData, origin);
@@ -837,7 +837,7 @@ export async function investorWalletHandler(request: Request, env: Env): Promise
       // transactions table may not exist
     }
 
-    return jsonResponse({ balance, currency: 'USD', transactions }, origin);
+    return jsonResponse({ balance, currency: 'EUR', transactions }, origin);
   } catch (error) {
     console.error('[investorWalletHandler] Query error:', error);
     return jsonResponse(emptyData, origin);

--- a/src/handlers/settings.ts
+++ b/src/handlers/settings.ts
@@ -3,7 +3,11 @@
  */
 
 import type { Env } from '../db/connection';
-import { createDatabase } from '../db/raw-sql-connection';
+// NOTE: the query helpers below (upsertUserSettings, logAccountAction, …) call
+// their arg as a tagged template (`sql`…``). neon() returns exactly that.
+// createDatabase() returned a RawSQLDatabase *class instance* (not callable) →
+// every settings write/2FA handler 500'd. Use neon() directly.
+import { neon } from '@neondatabase/serverless';
 import { verifyAuth } from '../utils/auth';
 import {
   getUserSettings,
@@ -31,7 +35,7 @@ export async function getUserSettingsHandler(request: Request, env: Env): Promis
       });
     }
 
-    const db = createDatabase(env.DATABASE_URL);
+    const db = neon(env.DATABASE_URL);
     const settings = await getUserSettings(db as any, authResult.user.id.toString());
 
     // If no settings exist yet, create default settings
@@ -159,7 +163,7 @@ export async function updateUserSettingsHandler(request: Request, env: Env): Pro
       });
     }
 
-    const db = createDatabase(env.DATABASE_URL);
+    const db = neon(env.DATABASE_URL);
     const updatedSettings = await upsertUserSettings(db as any, authResult.user.id.toString(), settingsUpdate);
 
     // Log the action
@@ -222,7 +226,7 @@ export async function getUserSessionsHandler(request: Request, env: Env): Promis
       });
     }
 
-    const db = createDatabase(env.DATABASE_URL);
+    const db = neon(env.DATABASE_URL);
     const sessions = await getUserSessions(db as any, authResult.user.id.toString());
 
     return new Response(JSON.stringify({ sessions }), {
@@ -252,7 +256,7 @@ export async function getAccountActivityHandler(request: Request, env: Env): Pro
       });
     }
 
-    const db = createDatabase(env.DATABASE_URL);
+    const db = neon(env.DATABASE_URL);
     const activities = await getAccountActions(db as any, authResult.user.id.toString());
 
     return new Response(JSON.stringify({ activities }), {
@@ -292,7 +296,7 @@ export async function enableTwoFactorHandler(request: Request, env: Env): Promis
       });
     }
 
-    const db = createDatabase(env.DATABASE_URL);
+    const db = neon(env.DATABASE_URL);
     const success = await enableTwoFactor(db as any, authResult.user.id.toString(), secret as string);
 
     if (success) {
@@ -337,7 +341,7 @@ export async function disableTwoFactorHandler(request: Request, env: Env): Promi
       });
     }
 
-    const db = createDatabase(env.DATABASE_URL);
+    const db = neon(env.DATABASE_URL);
     const success = await disableTwoFactor(db as any, authResult.user.id.toString());
 
     if (success) {
@@ -393,7 +397,7 @@ export async function deleteAccountHandler(request: Request, env: Env): Promise<
       });
     }
 
-    const db = createDatabase(env.DATABASE_URL);
+    const db = neon(env.DATABASE_URL);
 
     // Log the action before deletion
     await logAccountAction(db as any, {
@@ -439,7 +443,7 @@ export async function logSessionHandler(request: Request, env: Env): Promise<Res
       });
     }
 
-    const db = createDatabase(env.DATABASE_URL);
+    const db = neon(env.DATABASE_URL);
 
     // Extract session info
     const session = await logUserSession(db as any, {


### PR DESCRIPTION
Wires the frontend unit suite into CI (it never ran before — lint+typecheck+build only). Non-blocking initially because ~79/3523 tests are pre-existing stale-mock failures; plan is to burn those down then flip to gating. First half of the 'make tests gate + contract tests' workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)