### PR TITLE
feat+fix: locale-aware currency + audit batch B (misleading claims)

### DIFF
--- a/docs/sessions/2026-06-02-karl-backlog-multicurrency-ui-audit.md
+++ b/docs/sessions/2026-06-02-karl-backlog-multicurrency-ui-audit.md
@@ -1,0 +1,37 @@
+# Session 2026-06-02 — Karl backlog, multi-currency, UI↔backend drift audit
+
+Branch `docs/coverage-notes-scope-and-next-actions` → main, deployed via CI (worker + Pages) per PR. All verified against live prod (`pitchey-5o8.pages.dev` / `pitchey-api-prod.ndlovucavelle.workers.dev`).
+
+## Reconciliation (Step 0)
+Found a **split-brain prod**: the activity-feed pivot worker was a local-only `wrangler deploy`, frontend was main. Pushed + merged the pivot (PR #160) so CI redeploys both from one main. (Detail: any push to main auto-deploys both surfaces — never leave prod on a manual deploy of an unmerged branch.)
+
+## Karl feedback backlog (P1–P7) — shipped + verified
+- **P1 persistence** (#161): profile cache footgun (`public,max-age=300`→`private,no-store`), pitch docs FREE (was 10cr/doc, 402'd first upload), upload linkage surfaced (`mutateOrThrow`), PitchEdit loads existing docs.
+- **P2** (#162): pitch documents moved out from under the cover image into their own section.
+- **P3** (#163): shared `QuickActionsPanel` on creator/production/investor + Share Profile (creator/production).
+- **P6** (#164): public `/pricing` (from `subscription-plans`), footer (Pricing→/pricing, removed dead Format, tagline "Connecting stories since 2026."), Contact form now emails info@ via new `POST /api/contact`. Terms/Privacy already real legal copy.
+- **P4** (#165): credits currency coherence — `getCreditsBalance` USD→EUR; per-credit cost 2dp over effective credits.
+- **P5** (#166/#167): feedback names follow the reviewer's `is_anonymous` choice (dropped owner/NDA viewer gate); email-shaped reviewer names masked to local part.
+- **P4 "first time free"** (#170): was the static `"First month free (12 month contract)"` plan bullet (untrue at checkout — no trial); removed from all tiers.
+- **P7 verification** (#167): OpenCorporates lookup for non-UK/US ('other') companies; gated on `OPENCORPORATES_API_KEY` (unset → manual fallback).
+- **P7 multi-currency** (#168 build, #169 activate): EUR/GBP/USD, same numeric amount, via Stripe `currency_options` prices (created by `scripts/stripe-create-multicurrency-prices.mjs`). `MULTI_CURRENCY_ENABLED=true`; `/api/locale` geo-detects; verified GBP/USD/EUR `cs_live_` sessions.
+
+## NDA "Enhanced Information" gating (#171)
+Teaser/Request-NDA was shown on every pitch regardless of content → signing dead-ended at "Unavailable". Backend `getPitch` now returns `hasProtectedContent`; PitchDetail gates the section on `requireNDA || hasProtectedContent || protectedContent`. (NB: `PublicPitchView` still unguarded — Batch B below.)
+
+## UI↔backend drift audit + fixes
+5-agent read-only audit of "UI claims something the backend doesn't back." Prevention: vitest now RUNS in CI (was never executed — lint+typecheck+build only), non-blocking until the ~79 stale-mock failures are burned down (#172).
+
+**Batch A — Critical (shipped #172, verified):** settings-save 500 (`settings.ts` `createDatabase`→`neon` ×8; PUT settings 500→200), Request-NDA 404 (`lib/api.ts`→`/api/ndas/request`), currency `$`→`€` (`formatters.ts` + InvestorStats + investor-sidebar), notification-prefs frontend routing.
+
+**Locale-aware currency:** `formatCurrency`/`formatBudgetCompact` now follow the user's selected currency via `getActiveCurrency()` (presentation/symbol only — NOT FX-converted; exact for pricing, symbol-only for stored EUR figures).
+
+## Open / pending
+- **notification_preferences schema drift** — `/api/notifications/preferences` GET+POST still 500: `notification.service.ts` writes columns (`email_notifications`, `nda_notifications`, `quiet_hours_enabled`, `user_id UUID`) that don't match the actual table (mig 011: `email_enabled`, JSONB `*_alerts`, integer id). Needs prod-schema introspection + alignment.
+- **Audit Batch B** (misleading claims): gate `PublicPitchView` NDA teaser; remove fictional `view_pitch`/`promoted_pitch` credit costs; tiered-analytics overclaim.
+- **Audit Batch C** (display): subscription next-payment nesting, invoice unit/currency, dashboard avg-rating scale, dead investor Quick Action routes, payment-history filter statuses.
+- **Audit Batch D** (structural): `/api/plans` single source for plans/credit-costs/limits; RBAC via session payload (kills the duplicated-config drift class).
+- **FX conversion** if locale-aware data figures (not just pricing) need true converted amounts.
+- **OpenCorporates** + (re-flip) gating: set `OPENCORPORATES_API_KEY`.
+
+See memory: `project_karl_backlog_jun2026`, `project_ui_backend_drift_audit`, `project_p1_persistence_fixes`, `project_activity_feed_pivot`.

--- a/frontend/src/config/currency.ts
+++ b/frontend/src/config/currency.ts
@@ -53,6 +53,29 @@ async function fetchLocale(): Promise<LocaleInfo> {
   return inFlight;
 }
 
+// Warm the locale cache at module load so the synchronous getActiveCurrency()
+// below works app-wide even on pages with no useCurrency() consumer mounted.
+void fetchLocale();
+
+/**
+ * Synchronous "what currency should we DISPLAY in right now" for non-React
+ * formatters. Only honours a non-EUR currency when /api/locale confirms
+ * multi-currency is enabled AND it's supported; otherwise EUR.
+ *
+ * IMPORTANT: this is a presentation/symbol choice — amounts are NOT FX-converted.
+ * It is exact for subscription/credit pricing (we hold real per-currency prices),
+ * but for stored EUR data figures (budgets, portfolio, ROI) it only swaps the
+ * symbol. Wire an FX-rate source if true converted amounts are ever needed.
+ */
+export function getActiveCurrency(): string {
+  if (!cached?.multiCurrencyEnabled) return 'EUR';
+  try {
+    const override = localStorage.getItem(STORAGE_KEY);
+    if (override && cached.supportedCurrencies.includes(override)) return override;
+  } catch { /* no localStorage */ }
+  return cached.currency || 'EUR';
+}
+
 /**
  * Returns the active display/charge currency, the supported set, and a setter.
  * Default = geo-detected currency from /api/locale; a user override is persisted

--- a/frontend/src/config/subscription-plans.ts
+++ b/frontend/src/config/subscription-plans.ts
@@ -46,16 +46,9 @@ export const CREDIT_COSTS: CreditCost[] = [
     credits: 1,
     description: 'Video link'
   },
-  {
-    action: 'promoted_pitch',
-    credits: 10,
-    description: 'Promoted pitch (top of search for 3 months)'
-  },
-  {
-    action: 'view_pitch',
-    credits: 10,
-    description: 'View a pitch (refunded if license not agreed)'
-  },
+  // 'promoted_pitch' and 'view_pitch' removed: both advertised mechanisms that
+  // don't exist in the backend (no search-promotion purchase, no view-charge or
+  // license-refund flow). Re-add only when actually implemented + charged.
   {
     action: 'send_message',
     credits: 2,
@@ -109,7 +102,7 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
     features: [
       '30 Creator Credits per month',
       'Enhanced Analytics',
-      'Who viewed, time spent, location/device',
+      'Who viewed, time spent, device',
     ],
     userType: 'creator'
   },
@@ -121,7 +114,7 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
     analytics: 'customizable',
     features: [
       'Unlimited Creator Credits per month',
-      'Enhanced & Customizable Analytics',
+      'Enhanced Analytics',
     ],
     userType: 'creator'
   },
@@ -149,7 +142,7 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
     features: [
       '40 Creator Credits per month',
       'Enhanced Analytics',
-      'Who viewed, time spent, location/device',
+      'Who viewed, time spent, device',
     ],
     userType: 'production'
   },
@@ -161,8 +154,7 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
     analytics: 'customizable',
     features: [
       'Unlimited Creator Credits per month',
-      'Enhanced & Customizable Analytics',
-      'Choose what to track, export, or monitor in real time',
+      'Enhanced Analytics',
     ],
     userType: 'production'
   },
@@ -189,8 +181,7 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
     analytics: 'customizable',
     features: [
       'Unlimited Credits per month',
-      'Enhanced & Customizable Analytics',
-      'Choose what to track, export, or monitor in real time',
+      'Enhanced Analytics',
     ],
     userType: 'exec'
   }

--- a/frontend/src/pages/PublicPitchView.tsx
+++ b/frontend/src/pages/PublicPitchView.tsx
@@ -376,8 +376,10 @@ export default function PublicPitchView() {
                   </div>
                 </div>
               </div>
-            ) : (
-              // Show NDA required message or access restrictions
+            ) : ((pitch as any).requiresNDA ?? pitch.requireNDA) ? (
+              // NDA teaser / request — only when the pitch actually requires an
+              // NDA. Previously shown on every pitch, advertising protected
+              // content + an NDA on pitches that have neither.
               <div className="bg-gradient-to-br from-purple-50 to-blue-50 rounded-xl shadow-sm p-6 border-2 border-purple-200">
                 <div className="flex items-start space-x-3">
                   <Lock className="w-6 h-6 text-purple-600 mt-1" />
@@ -544,7 +546,7 @@ export default function PublicPitchView() {
                   </div>
                 </div>
               </div>
-            )}
+            ) : null}
 
             {/* Feedback & Ratings — shown to everyone (incl. anonymous). The
                 section self-gates internally: the written-feedback form only

--- a/frontend/src/shared/utils/formatters.ts
+++ b/frontend/src/shared/utils/formatters.ts
@@ -1,31 +1,39 @@
 import { safeNumber as defensiveSafeNumber, isValidDate, safeDate } from './defensive';
+import { getActiveCurrency } from '../../config/currency';
 
 // Safe number formatting utilities to prevent $NaN values
 export const safeNumber = defensiveSafeNumber;
 
+// Currency display is locale-aware: it follows the user's active/selected
+// currency (getActiveCurrency) rather than a fixed symbol. Pass an explicit
+// `currency` to override. NOTE: presentation only — amounts are NOT FX-converted
+// (exact for pricing where we hold per-currency prices; symbol-only for stored
+// EUR figures). Default base is EUR.
 export const formatCurrency = (value: unknown, options?: {
   minimumFractionDigits?: number;
   maximumFractionDigits?: number;
+  currency?: string;
 }): string => {
   const safeValue = safeNumber(value, 0);
-  
+
   return new Intl.NumberFormat('en-US', {
     style: 'currency',
-    currency: 'EUR', // platform base currency (was USD — wrong symbol on every figure)
+    currency: options?.currency ?? getActiveCurrency(),
     minimumFractionDigits: options?.minimumFractionDigits ?? 0,
     maximumFractionDigits: options?.maximumFractionDigits ?? 0,
   }).format(safeValue);
 };
 
 /**
- * Compact budget display using Intl compact notation: $12M, $500K, $1.5B
+ * Compact budget display using Intl compact notation: €12M, £500K, $1.5B
+ * (symbol follows the active currency; amounts are not FX-converted).
  */
-export const formatBudgetCompact = (value: unknown): string => {
+export const formatBudgetCompact = (value: unknown, currency?: string): string => {
   const n = safeNumber(value, 0);
   if (n === 0) return '';
   return new Intl.NumberFormat('en-US', {
     style: 'currency',
-    currency: 'EUR', // platform base currency (was USD — wrong symbol on every figure)
+    currency: currency ?? getActiveCurrency(),
     notation: 'compact',
     compactDisplay: 'short',
     minimumFractionDigits: 0,

--- a/frontend/src/utils/__tests__/formatters.test.ts
+++ b/frontend/src/utils/__tests__/formatters.test.ts
@@ -12,20 +12,22 @@ import {
 // formatCurrency
 // ============================================================================
 describe('formatCurrency', () => {
+  // Default display currency is EUR (platform base) when multi-currency is off —
+  // see getActiveCurrency(). Pass { currency } to override.
   it('formats positive integer', () => {
-    expect(formatCurrency(1000)).toBe('$1,000');
+    expect(formatCurrency(1000)).toBe('€1,000');
   });
 
   it('formats zero', () => {
-    expect(formatCurrency(0)).toBe('$0');
+    expect(formatCurrency(0)).toBe('€0');
   });
 
   it('formats negative number', () => {
-    expect(formatCurrency(-500)).toBe('-$500');
+    expect(formatCurrency(-500)).toBe('-€500');
   });
 
   it('formats large number', () => {
-    expect(formatCurrency(1000000)).toBe('$1,000,000');
+    expect(formatCurrency(1000000)).toBe('€1,000,000');
   });
 
   it('formats with custom fraction digits', () => {
@@ -33,23 +35,27 @@ describe('formatCurrency', () => {
       minimumFractionDigits: 2,
       maximumFractionDigits: 2,
     });
-    expect(result).toBe('$1,234.57');
+    expect(result).toBe('€1,234.57');
   });
 
-  it('formats null as $0', () => {
-    expect(formatCurrency(null)).toBe('$0');
+  it('formats null as €0', () => {
+    expect(formatCurrency(null)).toBe('€0');
   });
 
-  it('formats undefined as $0', () => {
-    expect(formatCurrency(undefined)).toBe('$0');
+  it('formats undefined as €0', () => {
+    expect(formatCurrency(undefined)).toBe('€0');
   });
 
-  it('formats NaN as $0', () => {
-    expect(formatCurrency(NaN)).toBe('$0');
+  it('formats NaN as €0', () => {
+    expect(formatCurrency(NaN)).toBe('€0');
   });
 
   it('formats string number', () => {
-    expect(formatCurrency('2500')).toBe('$2,500');
+    expect(formatCurrency('2500')).toBe('€2,500');
+  });
+
+  it('honours an explicit currency override', () => {
+    expect(formatCurrency(1000, { currency: 'GBP' })).toBe('£1,000');
   });
 });
 

--- a/src/config/subscription-plans.ts
+++ b/src/config/subscription-plans.ts
@@ -59,16 +59,9 @@ export const CREDIT_COSTS: CreditCost[] = [
     credits: 1,
     description: 'Video link'
   },
-  {
-    action: 'promoted_pitch',
-    credits: 10,
-    description: 'Promoted pitch (top of search for 3 months)'
-  },
-  {
-    action: 'view_pitch',
-    credits: 10,
-    description: 'View a pitch (refunded if license not agreed)'
-  },
+  // 'promoted_pitch' and 'view_pitch' removed: both advertised mechanisms that
+  // don't exist in the backend (no search-promotion purchase, no view-charge or
+  // license-refund flow). Re-add only when actually implemented + charged.
   {
     action: 'send_message',
     credits: 2,
@@ -132,7 +125,7 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
     features: [
       '30 Creator Credits per month',
       'Enhanced Analytics',
-      'Who viewed, time spent, location/device',
+      'Who viewed, time spent, device',
     ],
     userType: 'creator'
   },
@@ -145,7 +138,7 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
     analytics: 'customizable',
     features: [
       'Unlimited Creator Credits per month',
-      'Enhanced & Customizable Analytics',
+      'Enhanced Analytics',
     ],
     userType: 'creator'
   },
@@ -176,7 +169,7 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
     features: [
       '40 Credits per month',
       'Enhanced Analytics',
-      'Who viewed, time spent, location/device',
+      'Who viewed, time spent, device',
       'Company verification required'
     ],
     userType: 'production'
@@ -190,8 +183,7 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
     analytics: 'customizable',
     features: [
       'Unlimited Credits per month',
-      'Enhanced & Customizable Analytics',
-      'Choose what to track, export, or monitor in real time',
+      'Enhanced Analytics',
       'Company verification required'
     ],
     userType: 'production'
@@ -221,8 +213,7 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
     analytics: 'customizable',
     features: [
       'Unlimited Credits per month',
-      'Enhanced & Customizable Analytics',
-      'Choose what to track, export, or monitor in real time',
+      'Enhanced Analytics',
     ],
     userType: 'exec'
   }


### PR DESCRIPTION
**Locale-aware currency:** formatCurrency/formatBudgetCompact follow the user's selected currency via getActiveCurrency() (override-able). Presentation only — not FX-converted (exact for pricing, symbol-only for stored EUR figures). +session doc, +formatters test fixed (clears 9 CI failures).

**Audit Batch B (misleading claims):**
- PublicPitchView NDA teaser now gated on requiresNDA (was unconditional — the unfixed half of the PitchDetail gate).
- Removed fictional CREDIT_COSTS rows (promoted_pitch, view_pitch) — no backend mechanism.
- Analytics plan bullets de-overclaimed (removed 'location', 'export/real-time/customizable').

Validation: worker tsc+gate+build, frontend tsc+build, formatters 40/40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)