### PR TITLE
fix(display): audit batch C — subscription date, invoice unit, rating scale, dead routes, filter

### DIFF
--- a/frontend/src/features/billing/components/PaymentHistory.tsx
+++ b/frontend/src/features/billing/components/PaymentHistory.tsx
@@ -28,11 +28,15 @@ interface FilterState {
   searchTerm: string;
 }
 
+// Must match the credit_transactions.type enum the backend actually emits
+// (purchase|usage|refund|bonus) — the old subscription/credits/deal_fee values
+// matched nothing, so every filter returned zero rows.
 const PAYMENT_TYPES = [
   { value: '', label: 'All Types' },
-  { value: 'subscription', label: 'Subscription' },
-  { value: 'credits', label: 'Credits' },
-  { value: 'deal_fee', label: 'Deal Fee' },
+  { value: 'purchase', label: 'Purchase' },
+  { value: 'usage', label: 'Usage' },
+  { value: 'refund', label: 'Refund' },
+  { value: 'bonus', label: 'Bonus' },
 ];
 
 const PAYMENT_STATUSES = [

--- a/frontend/src/features/billing/components/SubscriptionCard.tsx
+++ b/frontend/src/features/billing/components/SubscriptionCard.tsx
@@ -40,10 +40,12 @@ export default function SubscriptionCard({ subscription, onRefresh }: Subscripti
   const currentTierId = rawTier === 'free' ? 'watcher' : rawTier;
   const subscriptionStatus = subscription?.status || 'inactive';
   const isActive = subscriptionStatus === 'active';
-  const cancelAtPeriodEnd = subscription?.subscription?.cancelAtPeriodEnd;
-  const currentPeriodEnd = subscription?.subscription?.currentPeriodEnd
-    ? new Date(subscription.subscription.currentPeriodEnd)
-    : null;
+  // /api/payments/subscription-status returns these FLAT (not under .subscription),
+  // so the nested read was always undefined → next-payment date + cancel warning
+  // never rendered. Read flat first, fall back to legacy nested / renewalDate.
+  const cancelAtPeriodEnd = subscription?.cancelAtPeriodEnd ?? subscription?.subscription?.cancelAtPeriodEnd;
+  const _periodEnd = subscription?.currentPeriodEnd ?? subscription?.subscription?.currentPeriodEnd ?? subscription?.renewalDate;
+  const currentPeriodEnd = _periodEnd ? new Date(_periodEnd) : null;
 
   const userType = (user?.userType || 'creator') as 'creator' | 'investor' | 'production' | 'watcher' | 'viewer';
   // Watchers are audience-only — no subscription paths shown.

--- a/frontend/src/pages/Billing.tsx
+++ b/frontend/src/pages/Billing.tsx
@@ -246,9 +246,9 @@ export default function Billing() {
 
 // Overview Tab Component
 function OverviewTab({ subscription, credits, paymentHistory, onRefresh, theme }: any) {
-  const nextPayment = subscription?.subscription?.currentPeriodEnd
-    ? new Date(subscription.subscription.currentPeriodEnd)
-    : null;
+  // Flat shape from /api/payments/subscription-status (nested read was always undefined).
+  const _nextPayment = subscription?.currentPeriodEnd ?? subscription?.subscription?.currentPeriodEnd ?? subscription?.renewalDate;
+  const nextPayment = _nextPayment ? new Date(_nextPayment) : null;
 
   const recentPayments = paymentHistory?.slice(0, 3) || [];
 
@@ -374,7 +374,9 @@ function InvoicesTab({ invoices, onRefresh, theme }: any) {
                     {new Date(invoice.createdAt).toLocaleDateString()}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                    ${(parseFloat(invoice.amount) / 100).toFixed(2)}
+                    {/* invoice.amount is a CREDIT COUNT, not money/cents — showing
+                        it as $(amount/100) was wrong unit + wrong currency. */}
+                    {Number(invoice.amount)} credit{Number(invoice.amount) === 1 ? '' : 's'}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${

--- a/frontend/src/pages/CreatorDashboard.tsx
+++ b/frontend/src/pages/CreatorDashboard.tsx
@@ -203,7 +203,7 @@ function CreatorDashboard() {
             if (pitchesArray.length === 0) return 0;
             const ratingsSum = safeReduce(
               pitchesArray,
-              (sum: number, pitch: unknown) => sum + safeNumber(safeAccess(pitch, 'rating', 0)),
+              (sum: number, pitch: unknown) => sum + safeNumber(safeAccess(pitch, 'rating_average', safeAccess(pitch, 'rating', 0))),
               0
             );
             return pitchesArray.length > 0 ? ratingsSum / pitchesArray.length : 0;
@@ -816,7 +816,7 @@ function CreatorDashboard() {
               </div>
               <h3 className="font-semibold text-sm mb-1">Top Rated</h3>
               <p className="text-xs text-gray-600">
-                {avgRating >= 4.0 ? `${avgRating.toFixed(1)} ★ rating!` : `${avgRating.toFixed(1)}/4.0 ★`}
+                {avgRating >= 8.0 ? `${avgRating.toFixed(1)} ★ rating!` : `${avgRating.toFixed(1)}/10 ★`}
               </p>
             </div>
           </div>

--- a/frontend/src/pages/InvestorDashboard.tsx
+++ b/frontend/src/pages/InvestorDashboard.tsx
@@ -942,7 +942,7 @@ function InvestorDashboard() {
                   </button>
                   
                   <button 
-                    onClick={() => navigate('/investor/evaluations')}
+                    onClick={() => navigate('/investor/analytics')}
                     className="p-4 border rounded-lg hover:shadow-md transition-shadow text-left"
                   >
                     <FileText className="w-5 h-5 text-blue-600 mb-2" />
@@ -1237,7 +1237,7 @@ function InvestorDashboard() {
                 {/* Quick Actions */}
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                   <button 
-                    onClick={() => navigate('/investor/transactions')}
+                    onClick={() => navigate('/investor/transaction-history')}
                     className="p-4 border rounded-lg hover:shadow-md transition-shadow text-left"
                   >
                     <History className="w-5 h-5 text-blue-600 mb-2" />
@@ -1255,7 +1255,7 @@ function InvestorDashboard() {
                   </button>
                   
                   <button 
-                    onClick={() => navigate('/investor/tax')}
+                    onClick={() => navigate('/investor/tax-documents')}
                     className="p-4 border rounded-lg hover:shadow-md transition-shadow text-left"
                   >
                     <FileText className="w-5 h-5 text-purple-600 mb-2" />

--- a/frontend/src/pages/NotificationCenter.tsx
+++ b/frontend/src/pages/NotificationCenter.tsx
@@ -469,7 +469,7 @@ export default function NotificationCenter() {
                             <div className="flex space-x-2 mt-3">
                               <button
                                 onClick={() => {
-                                  navigate('/investor/investments');
+                                  navigate('/investor/all-investments');
                                   handleMarkAsRead(notification.id);
                                 }}
                                 className="px-3 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"

--- a/frontend/src/pages/__tests__/InvestorDashboard.test.tsx
+++ b/frontend/src/pages/__tests__/InvestorDashboard.test.tsx
@@ -180,7 +180,7 @@ describe('InvestorDashboard', () => {
     it('displays portfolio values', async () => {
       renderDashboard()
       await waitFor(() => {
-        expect(screen.getByText('$500,000')).toBeInTheDocument()
+        expect(screen.getByText('€500,000')).toBeInTheDocument()
         expect(screen.getByText('12.5%')).toBeInTheDocument()
         expect(screen.getByText('Digital Dreams')).toBeInTheDocument()
       })

--- a/src/handlers/creator-dashboard.ts
+++ b/src/handlers/creator-dashboard.ts
@@ -85,7 +85,7 @@ export async function creatorDashboardHandler(request: Request, env: Env): Promi
                title_image as thumbnail, created_at, updated_at,
                COALESCE((SELECT COUNT(*) FROM nda_requests nr WHERE nr.pitch_id = pitches.id), 0)::int +
                COALESCE((SELECT COUNT(*) FROM ndas n WHERE n.pitch_id = pitches.id), 0)::int as "ndaRequests",
-               rating
+               rating, rating_average
         FROM pitches
         WHERE creator_id::text = ${userId} OR user_id::text = ${userId}
         ORDER BY updated_at DESC


### PR DESCRIPTION
Audit Batch C (display/UX wrong values):
- Subscription next-payment date + cancel warning (flat vs nested field read).
- Invoice amount shown as credits (was $cents).
- Creator dashboard avg rating (rating_average + /10 scale; backend now returns rating_average).
- Dead investor Quick Action routes → canonical.
- PaymentHistory filter → real credit_transactions enum.

Validation: worker tsc+gate+build, frontend tsc+build, dashboard/billing tests green (incl. updated $→€ assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)