### PR TITLE
feat(plans): audit batch D pt1 — /api/plans single source + usePlans

### DIFF
--- a/frontend/src/pages/Pricing.tsx
+++ b/frontend/src/pages/Pricing.tsx
@@ -1,17 +1,14 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Check, Sparkles } from 'lucide-react';
-import {
-  SUBSCRIPTION_TIERS,
-  CREDIT_PACKAGES,
-  getSubscriptionTiersByUserType,
-} from '../config/subscription-plans';
+import type { SubscriptionTier } from '../config/subscription-plans';
+import { usePlans } from '../services/plans.service';
 import { useCurrency } from '../config/currency';
 
-// Public pricing page. Sourced entirely from config/subscription-plans so it
-// can't drift from what checkout actually charges. Amounts are the same numeric
-// value across currencies (owner decision); only the symbol changes by locale,
-// driven by the worker's /api/locale (P7).
+// Public pricing page. Sourced from the backend via usePlans() (GET /api/plans,
+// single source of truth) with the bundled config as fallback — so it can't
+// drift from what checkout charges. Amounts are the same numeric value across
+// currencies (owner decision); only the symbol changes by locale (P7 /api/locale).
 
 const GROUPS: { key: string; label: string; blurb: string }[] = [
   { key: 'creator', label: 'For Creators', blurb: 'Pitch your stories and reach investors and production companies.' },
@@ -23,8 +20,9 @@ export default function Pricing() {
   const navigate = useNavigate();
   const [billing, setBilling] = useState<'monthly' | 'annual'>('monthly');
   const { symbol: CURRENCY, currency, enabled: multiCurrency, supported, setCurrency } = useCurrency();
+  const { creditPackages, forUserType } = usePlans();
 
-  const price = (tier: typeof SUBSCRIPTION_TIERS[number]) =>
+  const price = (tier: SubscriptionTier) =>
     billing === 'monthly' ? tier.price.monthly : tier.price.annual;
 
   return (
@@ -76,7 +74,7 @@ export default function Pricing() {
         </div>
 
         {GROUPS.map((group) => {
-          const tiers = getSubscriptionTiersByUserType(group.key);
+          const tiers = forUserType(group.key);
           if (!tiers.length) return null;
           return (
             <section key={group.key} className="mb-14">
@@ -134,7 +132,7 @@ export default function Pricing() {
             <p className="text-gray-600">Prefer not to subscribe? Top up credits any time.</p>
           </div>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {CREDIT_PACKAGES.map((pkg) => (
+            {creditPackages.map((pkg) => (
               <div key={pkg.credits} className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 text-center">
                 <p className="text-2xl font-bold text-gray-900">{pkg.credits + (pkg.bonus ?? 0)}</p>
                 <p className="text-sm text-gray-500">credits{pkg.bonus ? ` (incl. ${pkg.bonus} free)` : ''}</p>

--- a/frontend/src/services/plans.service.ts
+++ b/frontend/src/services/plans.service.ts
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+import { API_URL } from '../config';
+import {
+  SUBSCRIPTION_TIERS,
+  CREDIT_PACKAGES,
+  CREDIT_COSTS,
+  type SubscriptionTier,
+  type CreditCost,
+} from '../config/subscription-plans';
+
+type CreditPackage = (typeof CREDIT_PACKAGES)[number];
+
+// Single-source plans/credit config (genres pattern). The backend
+// (GET /api/plans, from src/config/subscription-plans.ts) is authoritative;
+// the bundled frontend config is only a first-paint/offline fallback. This
+// stops the two configs from silently drifting (the backend always wins at
+// runtime). Stripe price IDs are intentionally NOT served — checkout is
+// tier-driven server-side.
+
+export interface PlansData {
+  tiers: SubscriptionTier[];
+  creditPackages: CreditPackage[];
+  creditCosts: CreditCost[];
+}
+
+const FALLBACK: PlansData = {
+  tiers: SUBSCRIPTION_TIERS,
+  creditPackages: CREDIT_PACKAGES,
+  creditCosts: CREDIT_COSTS,
+};
+
+let cached: PlansData | null = null;
+let inFlight: Promise<PlansData> | null = null;
+
+async function fetchPlans(): Promise<PlansData> {
+  if (cached) return cached;
+  if (inFlight) return inFlight;
+  inFlight = (async () => {
+    try {
+      const res = await fetch(`${API_URL}/api/plans`, { credentials: 'include' });
+      const body = (await res.json()) as { data?: Partial<PlansData> };
+      const d = body.data ?? {};
+      cached = {
+        tiers: d.tiers?.length ? (d.tiers as SubscriptionTier[]) : FALLBACK.tiers,
+        creditPackages: d.creditPackages?.length ? (d.creditPackages as CreditPackage[]) : FALLBACK.creditPackages,
+        creditCosts: d.creditCosts?.length ? (d.creditCosts as CreditCost[]) : FALLBACK.creditCosts,
+      };
+    } catch {
+      cached = FALLBACK;
+    }
+    return cached;
+  })();
+  return inFlight;
+}
+
+export function tiersByUserType(tiers: SubscriptionTier[], userType: string): SubscriptionTier[] {
+  if (userType === 'creator') return tiers.filter((t) => t.userType === 'creator');
+  if (userType === 'production') return tiers.filter((t) => t.userType === 'production');
+  if (userType === 'investor') return tiers.filter((t) => t.userType === 'exec');
+  if (userType === 'watcher' || userType === 'viewer') return [];
+  return tiers;
+}
+
+/**
+ * Plans/credit config from the backend (with bundled fallback for first paint).
+ * Re-renders when the backend data resolves.
+ */
+export function usePlans() {
+  const [data, setData] = useState<PlansData>(cached ?? FALLBACK);
+  useEffect(() => {
+    let alive = true;
+    void fetchPlans().then((d) => { if (alive) setData(d); });
+    return () => { alive = false; };
+  }, []);
+  return {
+    ...data,
+    forUserType: (userType: string) => tiersByUserType(data.tiers, userType),
+  };
+}

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -27,7 +27,7 @@ import { verifyTurnstileToken } from './utils/turnstile';
 import { createJWT, verifyJWT, extractJWT } from './utils/worker-jwt';
 import { hashPassword, verifyPassword, isHashedPassword } from './utils/worker-password';
 import { StripeService } from './services/stripe.service';
-import { CREDIT_PACKAGES } from './config/subscription-plans';
+import { CREDIT_PACKAGES, SUBSCRIPTION_TIERS, CREDIT_COSTS } from './config/subscription-plans';
 import { currencyForCountry, normalizeCurrency, MULTI_CURRENCY_ENABLED, SUPPORTED_CURRENCIES, BASE_CURRENCY } from './config/currency';
 import { createSessionStore, type SessionStore, type SessionStoreEnv } from './auth/session-store';
 import { PortalAccessController, createPortalAccessMiddleware } from './middleware/portal-access-control';
@@ -2661,6 +2661,7 @@ class RouteRegistry {
     this.register('GET', '/api/settings/billing', (req) => this.getPaymentHistory(req));
 
     // === CONFIGURATION ENDPOINTS ===
+    this.register('GET', '/api/plans', this.handleConfigPlans.bind(this));
     this.register('GET', '/api/config/all', this.handleConfigAll.bind(this));
     this.register('GET', '/api/config/genres', this.handleConfigGenres.bind(this));
     this.register('GET', '/api/config/formats', this.handleConfigFormats.bind(this));
@@ -3956,6 +3957,7 @@ class RouteRegistry {
       '/api/ndas/standard',
       '/api/contact',
       '/api/locale',
+      '/api/plans',
       '/api/search',
       '/api/search/autocomplete',
       '/api/search/trending',
@@ -13815,6 +13817,18 @@ pitchey_analytics_datapoints_per_minute 1250
   private async handleConfigAll(request: Request): Promise<Response> {
     const builder = new ApiResponseBuilder(request);
     return builder.success(RouteRegistry.CONFIG_DATA);
+  }
+
+  // Single source of truth for plans/credit pricing the frontend can consume
+  // (genres pattern). Stripe price IDs are stripped — the frontend never needs
+  // them (checkout is tier-driven server-side); keeping them server-only avoids
+  // leaking + drift. This is the authoritative copy; the bundled frontend
+  // config is only a first-paint/offline fallback.
+  private async handleConfigPlans(request: Request): Promise<Response> {
+    const builder = new ApiResponseBuilder(request);
+    const tiers = SUBSCRIPTION_TIERS.map(({ stripePriceId, ...t }) => t);
+    const creditPackages = CREDIT_PACKAGES.map(({ stripePriceId, ...p }) => p);
+    return builder.success({ tiers, creditCosts: CREDIT_COSTS, creditPackages });
   }
 
   private async handleConfigGenres(request: Request): Promise<Response> {


### PR DESCRIPTION
Genres-pattern single source for plans/credit config (kills the frontend↔backend subscription-plans drift):
- Backend GET /api/plans (public; Stripe IDs stripped).
- Frontend usePlans() (fetch + bundled fallback, re-renders).
- Public Pricing page migrated.

Pt2 (next): SubscriptionCard/CreditPurchase migration, backend credit-cost-from-config, RBAC-via-session.

Validation: worker tsc+gate+build, frontend tsc+build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)