### PR TITLE
audit batch D pt2a: SubscriptionCard + CreditPurchase read /api/plans

### DIFF
--- a/frontend/src/features/billing/components/CreditPurchase.tsx
+++ b/frontend/src/features/billing/components/CreditPurchase.tsx
@@ -14,7 +14,7 @@ import {
   Lock
 } from 'lucide-react';
 import { paymentsAPI } from '@/lib/apiServices';
-import { CREDIT_PACKAGES, CREDIT_COSTS } from '@config/subscription-plans';
+import { usePlans } from '@/services/plans.service';
 import { useCurrency } from '@config/currency';
 
 interface CreditPurchaseProps {
@@ -35,33 +35,37 @@ const CURRENCY_SYMBOLS: Record<string, string> = {
 const currencySymbol = (currency?: string) =>
   CURRENCY_SYMBOLS[(currency || 'EUR').toUpperCase()] ?? (currency || 'EUR');
 
-// Adapt centralized credit packages for UI display
-const UI_CREDIT_PACKAGES = CREDIT_PACKAGES.map((pkg, index) => {
-  const icons = [Zap, TrendingUp, Star, Crown];
-  const descriptions = [
-    'Perfect for getting started',
-    'Great for growing creators',
-    'Best value for professionals',
-    'Maximum value for power users'
-  ];
+// Adapt centralized credit packages for UI display. Built at render-time from
+// usePlans() (backend /api/plans single source) so the displayed packages can't
+// drift from what checkout charges.
+type CreditPackageInput = { credits: number; price: number; bonus?: number; currency?: string; description?: string };
+const buildUiCreditPackages = (packages: CreditPackageInput[]) =>
+  packages.map((pkg, index) => {
+    const icons = [Zap, TrendingUp, Star, Crown];
+    const descriptions = [
+      'Perfect for getting started',
+      'Great for growing creators',
+      'Best value for professionals',
+      'Maximum value for power users'
+    ];
 
-  const symbol = currencySymbol(pkg.currency);
+    const symbol = currencySymbol(pkg.currency);
 
-  return {
-    id: `package_${index}`,
-    name: `${pkg.credits} Credit${pkg.credits === 1 ? '' : 's'}${pkg.bonus ? ` + ${pkg.bonus} Bonus` : ''}`,
-    credits: pkg.credits,
-    price: pkg.price,
-    symbol,
-    // Per-credit cost over the EFFECTIVE credits (incl. bonus), to 2 decimals —
-    // 3 decimals read as "a fraction of a pence" and were incomprehensible.
-    value: `${symbol}${(pkg.price / (pkg.credits + (pkg.bonus ?? 0))).toFixed(2)} per credit`,
-    icon: icons[index] || Coins,
-    description: pkg.description || descriptions[index] || 'Credit package',
-    popular: index === 1, // Make second package popular
-    bonus: pkg.bonus || 0
-  };
-});
+    return {
+      id: `package_${index}`,
+      name: `${pkg.credits} Credit${pkg.credits === 1 ? '' : 's'}${pkg.bonus ? ` + ${pkg.bonus} Bonus` : ''}`,
+      credits: pkg.credits,
+      price: pkg.price,
+      symbol,
+      // Per-credit cost over the EFFECTIVE credits (incl. bonus), to 2 decimals —
+      // 3 decimals read as "a fraction of a pence" and were incomprehensible.
+      value: `${symbol}${(pkg.price / (pkg.credits + (pkg.bonus ?? 0))).toFixed(2)} per credit`,
+      icon: icons[index] || Coins,
+      description: pkg.description || descriptions[index] || 'Credit package',
+      popular: index === 1, // Make second package popular
+      bonus: pkg.bonus || 0
+    };
+  });
 
 // Derived from the backend's single source of truth (CREDIT_COSTS in
 // subscription-plans.ts) so the "How Credits Work" guide can never drift from
@@ -79,15 +83,17 @@ const CREDIT_ACTION_META: Record<string, { label: string; icon: typeof Coins }> 
   nda_request: { label: 'NDA Access Request', icon: Lock },
 };
 
-const CREDIT_USAGE = CREDIT_COSTS.map((c) => {
-  const meta = CREDIT_ACTION_META[c.action];
-  return {
-    action: meta?.label ?? c.action,
-    cost: c.credits,
-    icon: meta?.icon ?? Coins,
-    description: c.description,
-  };
-});
+type CreditCostInput = { action: string; credits: number; description?: string };
+const buildCreditUsage = (costs: CreditCostInput[]) =>
+  costs.map((c) => {
+    const meta = CREDIT_ACTION_META[c.action];
+    return {
+      action: meta?.label ?? c.action,
+      cost: c.credits,
+      icon: meta?.icon ?? Coins,
+      description: c.description,
+    };
+  });
 
 export default function CreditPurchase({ credits, onRefresh }: CreditPurchaseProps) {
   const [loading, setLoading] = useState(false);
@@ -96,6 +102,11 @@ export default function CreditPurchase({ credits, onRefresh }: CreditPurchasePro
   // Same numeric amount across currencies (owner decision) — only the symbol
   // changes by selected currency. EUR while multi-currency is disabled.
   const { symbol: displaySymbol, currency } = useCurrency();
+  // Packages + usage guide from the backend (/api/plans single source), bundled
+  // fallback for first paint.
+  const { creditPackages, creditCosts } = usePlans();
+  const UI_CREDIT_PACKAGES = buildUiCreditPackages(creditPackages);
+  const CREDIT_USAGE = buildCreditUsage(creditCosts);
   const perCredit = (pkg: { price: number; credits: number; bonus: number }) =>
     `${displaySymbol}${(pkg.price / (pkg.credits + (pkg.bonus ?? 0))).toFixed(2)} per credit`;
 

--- a/frontend/src/features/billing/components/SubscriptionCard.tsx
+++ b/frontend/src/features/billing/components/SubscriptionCard.tsx
@@ -8,11 +8,8 @@ import {
 } from 'lucide-react';
 import { paymentsAPI } from '@/lib/apiServices';
 import { useBetterAuthStore } from '@/store/betterAuthStore';
-import {
-  getSubscriptionTiersByUserType,
-  getSubscriptionTier,
-  type SubscriptionTier,
-} from '@/config/subscription-plans';
+import { type SubscriptionTier } from '@/config/subscription-plans';
+import { usePlans } from '@/services/plans.service';
 import { useCurrency } from '@/config/currency';
 
 interface SubscriptionCardProps {
@@ -29,6 +26,9 @@ const POPULAR_TIER_BY_PORTAL: Record<string, string> = {
 
 export default function SubscriptionCard({ subscription, onRefresh }: SubscriptionCardProps) {
   const { symbol: currencySymbol, currency } = useCurrency();
+  // Plans from the backend (/api/plans single source) with bundled fallback.
+  const { tiers, forUserType } = usePlans();
+  const findTier = (id: string): SubscriptionTier | null => tiers.find((t) => t.id === id) ?? null;
   const { user } = useBetterAuthStore();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -51,14 +51,14 @@ export default function SubscriptionCard({ subscription, onRefresh }: Subscripti
   // Watchers are audience-only — no subscription paths shown.
   // Fall back to creator tiers for viewer (legacy alias).
   const portalForTiers = userType === 'viewer' ? 'watcher' : userType;
-  const availableTiers: SubscriptionTier[] = getSubscriptionTiersByUserType(portalForTiers);
+  const availableTiers: SubscriptionTier[] = forUserType(portalForTiers);
   const popularTierId = POPULAR_TIER_BY_PORTAL[portalForTiers] || '';
 
-  const currentTierDef = currentTierId ? getSubscriptionTier(currentTierId) : null;
+  const currentTierDef = currentTierId ? findTier(currentTierId) : null;
   const currentTierName = currentTierDef?.name || 'Free';
 
   const handleUpgrade = async (planKey: string) => {
-    const plan = getSubscriptionTier(planKey);
+    const plan = findTier(planKey);
     if (!plan || plan.price.monthly === 0) return; // free tier — nothing to subscribe to
 
     try {


### PR DESCRIPTION
## Batch D part 2a — authed pricing displays read the single source

Migrates the two authed billing components off static module-level config imports onto the `usePlans()` hook (GET /api/plans, backend single source, bundled fallback for first paint). Completes the genres-pattern migration started in pt1 (Pricing page).

- **SubscriptionCard** (`0d9dc82c`): tiers via `usePlans().forUserType()` + `findTier()` instead of `getSubscriptionTiersByUserType`/`getSubscriptionTier`.
- **CreditPurchase**: `UI_CREDIT_PACKAGES` + `CREDIT_USAGE` builders moved to render-time from `usePlans().creditPackages`/`.creditCosts`. Presentation-only metadata (icons/labels) stays module-level.

Net effect: the backend config is authoritative at runtime for every pricing surface; the bundled frontend config can no longer silently drift.

tsc 0 errors, build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)