### PR TITLE
audit batch D pt2c: RBAC permissions served in session payload

### DIFF
--- a/frontend/src/features/auth/hooks/usePermissions.ts
+++ b/frontend/src/features/auth/hooks/usePermissions.ts
@@ -202,16 +202,21 @@ export interface UsePermissionsResult {
  * matching the backend RBAC service exactly.
  */
 export function usePermissions(): UsePermissionsResult {
-  const { isAuthenticated } = useBetterAuthStore();
+  const { isAuthenticated, user } = useBetterAuthStore();
 
   const userRole = useMemo(() => {
     if (!isAuthenticated) return 'viewer' as UserRole;
     return getUserRole();
   }, [isAuthenticated]);
 
+  // Prefer the backend-served permission set (single source of truth from the
+  // RBAC service via the session payload). Fall back to the local role→permission
+  // map for first paint / offline / older payloads that don't carry permissions.
   const permissions = useMemo(() => {
+    const served = isAuthenticated ? user?.permissions : undefined;
+    if (served && served.length > 0) return served as Permission[];
     return rolePermissions[userRole] || rolePermissions.viewer;
-  }, [userRole]);
+  }, [isAuthenticated, user?.permissions, userRole]);
 
   const hasPermission = useMemo(() => {
     const permSet = new Set<string>(permissions);

--- a/frontend/src/shared/types/index.ts
+++ b/frontend/src/shared/types/index.ts
@@ -41,6 +41,7 @@ export interface User {
   createdAt: string;
   updatedAt: string;
   password?: string; // Only included in auth responses
+  permissions?: string[]; // RBAC permission set from the session payload (backend authority); usePermissions falls back to its local map when absent
 }
 
 // ========== PITCH TYPES ==========

--- a/src/services/rbac.service.ts
+++ b/src/services/rbac.service.ts
@@ -410,3 +410,15 @@ export class RBACService {
 
 // Export for use in middleware
 export const rbac = RBACService;
+
+/**
+ * Single source for "what can a user of this type do" — maps a DB user_type to
+ * its role and returns that role's permission set (as plain strings). Served in
+ * the session/login payload so the frontend can consume the backend's authority
+ * instead of maintaining its own drift-prone copy (its local map is kept only
+ * as a first-paint/offline fallback). 'watcher'/'viewer' both resolve to VIEWER.
+ */
+export function getPermissionsForUserType(userType?: string): string[] {
+  const role = RBACService.getRoleFromUserType(userType);
+  return [...(rolePermissions[role] || rolePermissions[UserRole.VIEWER])];
+}

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -27,6 +27,7 @@ import { verifyTurnstileToken } from './utils/turnstile';
 import { createJWT, verifyJWT, extractJWT } from './utils/worker-jwt';
 import { hashPassword, verifyPassword, isHashedPassword } from './utils/worker-password';
 import { StripeService } from './services/stripe.service';
+import { getPermissionsForUserType } from './services/rbac.service';
 import { CREDIT_PACKAGES, SUBSCRIPTION_TIERS, CREDIT_COSTS, getCreditCost } from './config/subscription-plans';
 import { currencyForCountry, normalizeCurrency, MULTI_CURRENCY_ENABLED, SUPPORTED_CURRENCIES, BASE_CURRENCY } from './config/currency';
 import { createSessionStore, type SessionStore, type SessionStoreEnv } from './auth/session-store';
@@ -5247,7 +5248,8 @@ pitchey_analytics_datapoints_per_minute 1250
                         bio: userResult.bio,
                         companyName: userResult.company_name,
                         profileImage: userResult.profile_image,
-                        subscriptionTier: userResult.subscription_tier
+                        subscriptionTier: userResult.subscription_tier,
+                        permissions: getPermissionsForUserType(userResult.user_type)
                       },
                       success: true
                     }),
@@ -5280,7 +5282,8 @@ pitchey_analytics_datapoints_per_minute 1250
                   bio: sessionData.bio,
                   companyName: sessionData.company_name,
                   profileImage: sessionData.profile_image,
-                  subscriptionTier: sessionData.subscription_tier
+                  subscriptionTier: sessionData.subscription_tier,
+                  permissions: getPermissionsForUserType(sessionData.user_type as string | undefined)
                 },
                 success: true
               }),


### PR DESCRIPTION
## Batch D part 2c — RBAC via session payload (backend authoritative, frontend fallback)

Completes Batch D. The frontend's role→permission map was a hand-maintained mirror of the backend RBAC service — in sync today, but drift-prone (the exact failure class this audit targets). This makes the backend authoritative.

**Backend** (`rbac.service.ts`): new `getPermissionsForUserType()` maps `user_type` → role → permission set (single source). Injected into both `handleSession` user payloads (KV-cached + DB paths). `watcher`/`viewer` both resolve to VIEWER.

**Frontend**: `User` type carries optional `permissions[]`; `usePermissions` **prefers** the backend-served set and **falls back** to its local map for first paint / offline / older payloads.

### Safety
Purely additive — no behavior change when `permissions` is absent. The 95 existing permission tests still pass (fallback intact). tsc 0 both sides, build ✓.

### Follow-up (not in this PR)
Login payloads still build their own user objects without `permissions`; the session check (which runs at startup and right after login) hydrates them, so the store converges. Adding `permissions` to the login payloads directly is a minor future tidy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)