### PR TITLE
RBAC: permissions in login payloads (D pt2c follow-up)

### DIFF
--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -1547,7 +1547,8 @@ class RouteRegistry {
             lastName: result.last_name,
             bio: result.bio,
             companyName: result.company_name,
-            profileImage: result.profile_image
+            profileImage: result.profile_image,
+            permissions: getPermissionsForUserType(result.user_type)
           }
         }
       }), {
@@ -4576,7 +4577,8 @@ class RouteRegistry {
               bio: user.bio,
               companyName: user.company_name,
               profileImage: user.profile_image,
-              subscriptionTier: user.subscription_tier
+              subscriptionTier: user.subscription_tier,
+              permissions: getPermissionsForUserType(portal)
             },
             session: {
               id: sessionId,


### PR DESCRIPTION
Small follow-up to #179. Adds the backend-served `permissions[]` to the login response payloads (`handlePortalLogin` for all 4 portals, `handleLoginSimple` fallback), not just the session check. Closes the one-render gap where, immediately after login, the store had no permissions until the next session validation.

Additive and consistent with #179 — `usePermissions` already prefers the served set and falls back to its local map. `getUserProfile` intentionally skipped (different payload shape, not a store hydration path).

tsc 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)