### PR TITLE
test burn-down: 82 → 0 failures + gate CI on vitest (+ real NDAModal bug)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -74,14 +74,11 @@ jobs:
       - name: 🔧 Type checking
         run: npm run type-check
 
-      # Unit tests now RUN in CI (previously they never executed here, so mocks
-      # silently drifted from the real API). Non-blocking for now: ~79 of 3523
-      # are pre-existing stale-mock failures. Burn-down plan: drive failures to 0,
-      # then remove continue-on-error so this gates. New/contract tests should be
-      # kept green from the start.
+      # Unit tests RUN and GATE in CI. The stale-mock backlog (82 failures that
+      # accumulated while tests never executed here) was burned down to 0, so this
+      # step now blocks on any failure — keeping mocks honest with the real API.
       - name: 🧪 Run unit tests
         run: npm run test:run
-        continue-on-error: true
 
       - name: 🏗️ Build frontend
         run: npm run build

--- a/frontend/src/components/__tests__/LoginForm.test.tsx
+++ b/frontend/src/components/__tests__/LoginForm.test.tsx
@@ -52,7 +52,7 @@ describe('LoginForm Components', () => {
         expect(screen.getByText('Creator Portal')).toBeInTheDocument()
         expect(screen.getByText('Sign in to manage your pitches')).toBeInTheDocument()
         expect(screen.getByLabelText(/email address/i)).toBeInTheDocument()
-        expect(screen.getByLabelText(/password/i)).toBeInTheDocument()
+        expect(screen.getByLabelText('Password')).toBeInTheDocument()
         expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument()
       })
 
@@ -92,7 +92,7 @@ describe('LoginForm Components', () => {
       it('should update password field when typing', async () => {
         render(<CreatorLogin />)
 
-        const passwordInput = screen.getByLabelText(/password/i)
+        const passwordInput = screen.getByLabelText('Password')
         await user.type(passwordInput, 'password123')
 
         expect(passwordInput).toHaveValue('password123')
@@ -105,7 +105,7 @@ describe('LoginForm Components', () => {
         await user.click(demoButton)
 
         const emailInput = screen.getByLabelText(/email address/i)
-        const passwordInput = screen.getByLabelText(/password/i)
+        const passwordInput = screen.getByLabelText('Password')
 
         expect(emailInput).toHaveValue('alex.creator@demo.com')
         expect(passwordInput).toHaveValue('Demo123')
@@ -123,7 +123,7 @@ describe('LoginForm Components', () => {
       it('should require password field', async () => {
         render(<CreatorLogin />)
 
-        const passwordInput = screen.getByLabelText(/password/i)
+        const passwordInput = screen.getByLabelText('Password')
         expect(passwordInput).toBeRequired()
       })
 
@@ -137,7 +137,7 @@ describe('LoginForm Components', () => {
       it('should have password input type', () => {
         render(<CreatorLogin />)
 
-        const passwordInput = screen.getByLabelText(/password/i)
+        const passwordInput = screen.getByLabelText('Password')
         expect(passwordInput).toHaveAttribute('type', 'password')
       })
     })
@@ -150,7 +150,7 @@ describe('LoginForm Components', () => {
         render(<CreatorLogin />)
 
         const emailInput = screen.getByLabelText(/email address/i)
-        const passwordInput = screen.getByLabelText(/password/i)
+        const passwordInput = screen.getByLabelText('Password')
         const submitButton = screen.getByRole('button', { name: /sign in/i })
 
         await user.type(emailInput, 'creator@test.com')
@@ -168,7 +168,7 @@ describe('LoginForm Components', () => {
         render(<CreatorLogin />)
 
         const emailInput = screen.getByLabelText(/email address/i)
-        const passwordInput = screen.getByLabelText(/password/i)
+        const passwordInput = screen.getByLabelText('Password')
         const submitButton = screen.getByRole('button', { name: /sign in/i })
 
         await user.type(emailInput, 'creator@test.com')
@@ -213,14 +213,14 @@ describe('LoginForm Components', () => {
         render(<CreatorLogin />)
 
         expect(screen.getByLabelText(/email address/i)).toBeInTheDocument()
-        expect(screen.getByLabelText(/password/i)).toBeInTheDocument()
+        expect(screen.getByLabelText('Password')).toBeInTheDocument()
       })
 
       it('should have proper ARIA attributes', () => {
         render(<CreatorLogin />)
 
         const emailInput = screen.getByLabelText(/email address/i)
-        const passwordInput = screen.getByLabelText(/password/i)
+        const passwordInput = screen.getByLabelText('Password')
 
         expect(emailInput).toHaveAttribute('autocomplete', 'email')
         expect(passwordInput).toHaveAttribute('autocomplete', 'current-password')
@@ -244,7 +244,7 @@ describe('LoginForm Components', () => {
         render(<CreatorLogin />)
 
         const emailInput = screen.getByLabelText(/email address/i)
-        const passwordInput = screen.getByLabelText(/password/i)
+        const passwordInput = screen.getByLabelText('Password')
 
         // Focus on email input first
         emailInput.focus()
@@ -271,7 +271,7 @@ describe('LoginForm Components', () => {
 
       expect(screen.getByText('Investor Portal')).toBeInTheDocument()
       expect(screen.getByLabelText(/email address/i)).toBeInTheDocument()
-      expect(screen.getByLabelText(/password/i)).toBeInTheDocument()
+      expect(screen.getByLabelText('Password')).toBeInTheDocument()
     })
 
     it('should have investor-specific demo credentials', async () => {
@@ -291,7 +291,7 @@ describe('LoginForm Components', () => {
       render(<InvestorLogin />)
 
       const emailInput = screen.getByLabelText(/email address/i)
-      const passwordInput = screen.getByLabelText(/password/i)
+      const passwordInput = screen.getByLabelText('Password')
       const submitButton = screen.getByRole('button', { name: /sign in/i })
 
       await user.type(emailInput, 'investor@test.com')
@@ -308,7 +308,7 @@ describe('LoginForm Components', () => {
       const { navigate } = render(<InvestorLogin />)
 
       const emailInput = screen.getByLabelText(/email address/i)
-      const passwordInput = screen.getByLabelText(/password/i)
+      const passwordInput = screen.getByLabelText('Password')
       const submitButton = screen.getByRole('button', { name: /sign in/i })
 
       await user.type(emailInput, 'investor@test.com')
@@ -327,7 +327,7 @@ describe('LoginForm Components', () => {
 
       expect(screen.getByText('Production Portal')).toBeInTheDocument()
       expect(screen.getByLabelText(/email address/i)).toBeInTheDocument()
-      expect(screen.getByLabelText(/password/i)).toBeInTheDocument()
+      expect(screen.getByLabelText('Password')).toBeInTheDocument()
     })
 
     it('should have production-specific demo credentials', async () => {
@@ -347,7 +347,7 @@ describe('LoginForm Components', () => {
       render(<ProductionLogin />)
 
       const emailInput = screen.getByLabelText(/email address/i)
-      const passwordInput = screen.getByLabelText(/password/i)
+      const passwordInput = screen.getByLabelText('Password')
       const submitButton = screen.getByRole('button', { name: /sign in/i })
 
       await user.type(emailInput, 'production@test.com')
@@ -364,7 +364,7 @@ describe('LoginForm Components', () => {
       const { navigate } = render(<ProductionLogin />)
 
       const emailInput = screen.getByLabelText(/email address/i)
-      const passwordInput = screen.getByLabelText(/password/i)
+      const passwordInput = screen.getByLabelText('Password')
       const submitButton = screen.getByRole('button', { name: /sign in/i })
 
       await user.type(emailInput, 'production@test.com')
@@ -385,7 +385,7 @@ describe('LoginForm Components', () => {
       render(<CreatorLogin />)
 
       const emailInput = screen.getByLabelText(/email address/i)
-      const passwordInput = screen.getByLabelText(/password/i)
+      const passwordInput = screen.getByLabelText('Password')
       const submitButton = screen.getByRole('button', { name: /sign in/i })
 
       await user.type(emailInput, 'creator@test.com')
@@ -422,7 +422,7 @@ describe('LoginForm Components', () => {
     it('should not expose password in DOM', async () => {
       render(<CreatorLogin />)
 
-      const passwordInput = screen.getByLabelText(/password/i)
+      const passwordInput = screen.getByLabelText('Password')
       await user.type(passwordInput, 'secretpassword')
 
       expect(passwordInput).toHaveAttribute('type', 'password')
@@ -448,7 +448,7 @@ describe('LoginForm Components', () => {
       render(<CreatorLogin />)
 
       const emailInput = screen.getByLabelText(/email address/i)
-      const passwordInput = screen.getByLabelText(/password/i)
+      const passwordInput = screen.getByLabelText('Password')
       const submitButton = screen.getByRole('button', { name: /sign in/i })
 
       await user.type(emailInput, '  creator@test.com  ')
@@ -479,7 +479,7 @@ describe('LoginForm Components', () => {
 
       // Form should still be accessible regardless of screen size
       expect(screen.getByLabelText(/email address/i)).toBeInTheDocument()
-      expect(screen.getByLabelText(/password/i)).toBeInTheDocument()
+      expect(screen.getByLabelText('Password')).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument()
     })
   })

--- a/frontend/src/components/__tests__/NDARequestModal.test.tsx
+++ b/frontend/src/components/__tests__/NDARequestModal.test.tsx
@@ -60,6 +60,14 @@ describe('NDAModal', () => {
     authStore.user = mockInvestorUser as any
     authStore.isAuthenticated = true
 
+    // NDAModal fires a best-effort fetch for the platform Standard NDA preview on
+    // mount; give global.fetch a benign default so it doesn't reject (clearAllMocks
+    // resets the setup.ts vi.fn() to return undefined).
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: false }),
+    } as Response)
+
     // Setup default service mocks
     vi.mocked(ndaService.canRequestNDA).mockResolvedValue({ canRequest: true } as any)
     vi.mocked(ndaService.requestNDA).mockResolvedValue({ success: true, ndaId: '123' } as any)

--- a/frontend/src/components/__tests__/PitchForm.test.tsx
+++ b/frontend/src/components/__tests__/PitchForm.test.tsx
@@ -380,7 +380,8 @@ describe('PitchForm (CreatePitch)', () => {
         expect(screen.getByLabelText(/genre/i)).toBeInTheDocument()
         expect(screen.getByLabelText(/format category/i)).toBeInTheDocument()
         expect(screen.getByLabelText(/logline/i)).toBeInTheDocument()
-        expect(screen.getByLabelText(/short synopsis/i)).toBeInTheDocument()
+        // anchored — the form also has "Long Synopsis" and a "Show short synopsis" toggle
+        expect(screen.getByLabelText(/^short synopsis/i)).toBeInTheDocument()
         expect(screen.getByLabelText(/themes/i)).toBeInTheDocument()
         expect(screen.getByLabelText(/world & setting/i)).toBeInTheDocument()
       })
@@ -519,7 +520,8 @@ describe('PitchForm (CreatePitch)', () => {
         expect(screen.getByLabelText(/title/i)).toBeInTheDocument()
       }, { timeout: 1000 })
 
-      const synopsisInput = screen.queryByLabelText(/synopsis/i)
+      // queryAll — multiple synopsis fields exist (short/long/toggle); take the first
+      const synopsisInput = screen.queryAllByLabelText(/synopsis/i)[0]
       if (synopsisInput) {
         await user.type(synopsisInput, 'This is a test synopsis')
         // Character count might not be displayed or in different format

--- a/frontend/src/config/__tests__/subscription-plans.test.ts
+++ b/frontend/src/config/__tests__/subscription-plans.test.ts
@@ -34,13 +34,8 @@ describe('subscription-plans credit utilities', () => {
       expect(getCreditCost('video_link')).toBe(1)
     })
 
-    it('returns 10 for promoted_pitch', () => {
-      expect(getCreditCost('promoted_pitch')).toBe(10)
-    })
-
-    it('returns 10 for view_pitch', () => {
-      expect(getCreditCost('view_pitch')).toBe(10)
-    })
+    // promoted_pitch + view_pitch were removed from CREDIT_COSTS (no backend
+    // mechanism — see Batch B). Their getCreditCost tests were deleted with them.
 
     it('returns 2 for send_message', () => {
       expect(getCreditCost('send_message')).toBe(2)
@@ -112,8 +107,8 @@ describe('subscription-plans credit utilities', () => {
 
   // ── CREDIT_COSTS constants ─────────────────────────────────────
   describe('CREDIT_COSTS', () => {
-    it('contains 10 action entries', () => {
-      expect(CREDIT_COSTS).toHaveLength(10)
+    it('contains 9 action entries', () => {
+      expect(CREDIT_COSTS).toHaveLength(9)
     })
 
     it('every entry has action, credits, and description', () => {

--- a/frontend/src/features/ndas/components/NDAModal.tsx
+++ b/frontend/src/features/ndas/components/NDAModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { X, Upload, FileText, Shield, AlertCircle, CheckCircle, Loader2, ExternalLink } from 'lucide-react';
 import { ndaService } from '../services/nda.service';
+import { API_URL } from '@/config';
 import { useBetterAuthStore } from '@/store/betterAuthStore';
 // eslint-disable-next-line import/no-restricted-paths -- intentional: cross-feature component dependency
 import FileUpload from '@features/uploads/components/FileUpload';
@@ -39,7 +40,7 @@ export default function NDAModal({
   // Fetch the auto-filled platform Standard NDA (project + creator pre-filled from the pitch)
   useEffect(() => {
     if (!isOpen || formData.ndaType !== 'standard') return;
-    fetch(`${import.meta.env.VITE_API_URL}/api/ndas/standard?pitchId=${pitchId}`, { credentials: 'include' })
+    fetch(`${API_URL}/api/ndas/standard?pitchId=${pitchId}`, { credentials: 'include' })
       .then((r) => r.json())
       .then((d) => { if (d?.success && d.data?.content) setStandardNda(d.data.content); })
       .catch(() => { /* preview is best-effort */ });

--- a/frontend/src/features/notifications/services/__tests__/notifications.service.test.ts
+++ b/frontend/src/features/notifications/services/__tests__/notifications.service.test.ts
@@ -19,6 +19,7 @@ import { NotificationsService, type Notification } from '../notifications.servic
 
 const mockGet = vi.mocked(apiClient.get)
 const mockPut = vi.mocked(apiClient.put)
+const mockPost = vi.mocked(apiClient.post)
 
 const makeNotification = (overrides: Partial<Notification> = {}): Notification => ({
   id: 1,
@@ -200,15 +201,16 @@ describe('NotificationsService', () => {
   // ─── updatePreferences ────────────────────────────────────────────
   describe('updatePreferences', () => {
     it('updates preferences and returns true', async () => {
-      mockPut.mockResolvedValueOnce({ success: true })
+      mockPost.mockResolvedValueOnce({ success: true })
 
       const result = await NotificationsService.updatePreferences({ email: false })
       expect(result).toBe(true)
-      expect(mockPut).toHaveBeenCalledWith('/api/notifications/preferences', { email: false })
+      // Registered verb is POST, not PUT (PUT 404'd) — see updatePreferences impl.
+      expect(mockPost).toHaveBeenCalledWith('/api/notifications/preferences', { email: false })
     })
 
     it('returns false on error', async () => {
-      mockPut.mockRejectedValueOnce(new Error('Network error'))
+      mockPost.mockRejectedValueOnce(new Error('Network error'))
       const result = await NotificationsService.updatePreferences({ email: true })
       expect(result).toBe(false)
     })

--- a/frontend/src/pages/__tests__/BrowseTopRated.test.tsx
+++ b/frontend/src/pages/__tests__/BrowseTopRated.test.tsx
@@ -86,7 +86,8 @@ describe('BrowseTopRated', () => {
           json: async () => ({
             stats: {
               totalRated: 50,
-              averageRating: 3.8,
+              // component reads stats.avgRating (RatingStats type), not averageRating
+              avgRating: 3.8,
               ratingDistribution: { 5: 10, 4: 15, 3: 12, 2: 8, 1: 5 },
             },
           }),
@@ -182,7 +183,7 @@ describe('BrowseTopRated', () => {
       expect(firstSignal.aborted).toBe(false)
 
       // Open filters and change sort — triggers a new fetch which aborts previous
-      fireEvent.click(screen.getByText('Filters & Sorting'))
+      fireEvent.click(screen.getByText('Advanced filters'))
       await waitFor(() => expect(screen.getByText('Most Viewed')).toBeInTheDocument())
       fireEvent.click(screen.getByText('Most Viewed'))
 

--- a/frontend/src/pages/__tests__/CreatePitch.test.tsx
+++ b/frontend/src/pages/__tests__/CreatePitch.test.tsx
@@ -197,10 +197,13 @@ vi.mock('@features/pitches/utils/characterUtils', () => ({
   normalizeCharacters: (chars: any) => chars || [],
 }))
 
-// ─── DocumentUploadHub ───────────────────────────────────────────────
-vi.mock('@features/uploads/components/FileUpload/DocumentUploadHub', () => ({
-  default: ({ onFilesSelected, disabled }: any) => (
-    <div data-testid="document-upload-hub">Document Upload Hub</div>
+// ─── DocumentUpload ──────────────────────────────────────────────────
+// CreatePitch now uses the named DocumentUpload (parity with the edit page),
+// not DocumentUploadHub — mock the component it actually imports so the real
+// one doesn't render (and break the page) in tests.
+vi.mock('@features/uploads/components/DocumentUpload', () => ({
+  DocumentUpload: (_props: any) => (
+    <div data-testid="document-upload-hub">Document Upload</div>
   ),
 }))
 

--- a/frontend/src/pages/__tests__/CreatorNDAManagement.test.tsx
+++ b/frontend/src/pages/__tests__/CreatorNDAManagement.test.tsx
@@ -73,14 +73,16 @@ describe('CreatorNDAManagement', () => {
     expect(screen.getByText('Comprehensive NDA workflow and analytics')).toBeInTheDocument()
   })
 
-  it('renders back button', () => {
+  it('renders the NDA Management heading', () => {
+    // The back button / global chrome now comes from PortalLayout's MinimalHeader,
+    // not this page component (which only renders the heading + content).
     render(
       <MemoryRouter>
         <CreatorNDAManagement />
       </MemoryRouter>
     )
 
-    expect(screen.getByTestId('back-button')).toBeInTheDocument()
+    expect(screen.getByText('NDA Management')).toBeInTheDocument()
   })
 
   it('renders ComprehensiveNDAManagement when authenticated', () => {

--- a/frontend/src/pages/__tests__/CreatorOnboardingPage.test.tsx
+++ b/frontend/src/pages/__tests__/CreatorOnboardingPage.test.tsx
@@ -71,7 +71,7 @@ describe('CreatorOnboardingPage (OnboardingPage)', () => {
   describe('Layout and branding', () => {
     it('renders Pitchey branding', () => {
       renderComponent()
-      expect(screen.getByText('Pitchey')).toBeInTheDocument()
+      expect(screen.getByAltText('Pitchey')).toBeInTheDocument()
     })
 
     it('renders creator-specific subtitle for creator user', () => {
@@ -285,7 +285,7 @@ describe('CreatorOnboardingPage (OnboardingPage)', () => {
       // (avoiding full re-mock cycle; the creator test already covers this path)
       renderComponent()
       // Creator is the fallback — it still renders
-      expect(screen.getByText('Pitchey')).toBeInTheDocument()
+      expect(screen.getByAltText('Pitchey')).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/pages/__tests__/CreatorProfile.test.tsx
+++ b/frontend/src/pages/__tests__/CreatorProfile.test.tsx
@@ -73,37 +73,24 @@ const mockCreatorResponse = {
   },
 }
 
+// The component fetches /api/pitches?userId=N — the server filters by creator,
+// and the component reads body.data as the array directly (no client-side filter).
 const mockPitchesResponse = {
-  data: {
-    pitches: [
-      {
-        id: 10,
-        title: 'Midnight Run',
-        logline: 'A detective chases a fugitive',
-        genre: 'Thriller',
-        format: 'Feature Film',
-        status: 'published',
-        view_count: 3000,
-        like_count: 150,
-        created_at: '2026-01-15T00:00:00Z',
-        nda_required: false,
-        user_id: '5',
-      },
-      {
-        id: 11,
-        title: 'Other Creator Pitch',
-        logline: 'Not by this creator',
-        genre: 'Comedy',
-        format: 'Short Film',
-        status: 'published',
-        view_count: 100,
-        like_count: 5,
-        created_at: '2026-01-20T00:00:00Z',
-        nda_required: false,
-        user_id: '99',
-      },
-    ],
-  },
+  data: [
+    {
+      id: 10,
+      title: 'Midnight Run',
+      logline: 'A detective chases a fugitive',
+      genre: 'Thriller',
+      format: 'Feature Film',
+      status: 'published',
+      view_count: 3000,
+      like_count: 150,
+      created_at: '2026-01-15T00:00:00Z',
+      nda_required: false,
+      user_id: '5',
+    },
+  ],
 }
 
 // ─── Component import ────────────────────────────────────────────────────────
@@ -129,7 +116,7 @@ describe('CreatorProfile', () => {
           json: () => Promise.resolve(mockCreatorResponse),
         })
       }
-      if (url.includes('/api/pitches/public/search')) {
+      if (url.includes('/api/pitches?userId') || url.includes('/api/pitches/public/search')) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve(mockPitchesResponse),
@@ -156,12 +143,12 @@ describe('CreatorProfile', () => {
     })
   })
 
-  it('calls GET /api/pitches/public/search for creator pitches', async () => {
+  it('calls GET /api/pitches?userId for creator pitches', async () => {
     render(<MemoryRouter><Component /></MemoryRouter>)
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('/api/pitches/public/search'),
+        expect.stringContaining('/api/pitches?userId=5'),
         expect.objectContaining({ credentials: 'include' })
       )
     })
@@ -190,7 +177,8 @@ describe('CreatorProfile', () => {
       expect(screen.getByText('1,200')).toBeInTheDocument()
     })
     expect(screen.getByText('Followers')).toBeInTheDocument()
-    expect(screen.getByText('8')).toBeInTheDocument()
+    // "Pitches" count is pitches.length (the fetched list), not a stored total.
+    expect(screen.getByText('1')).toBeInTheDocument()
     expect(screen.getByText('Pitches')).toBeInTheDocument()
   })
 

--- a/frontend/src/pages/__tests__/Homepage.test.tsx
+++ b/frontend/src/pages/__tests__/Homepage.test.tsx
@@ -113,9 +113,10 @@ describe('Homepage', () => {
     vi.useRealTimers()
   })
 
-  it('renders the Pitchey brand name', () => {
+  it('renders the Pitchey brand logo', () => {
     renderHomepage()
-    expect(screen.getAllByText('Pitchey').length).toBeGreaterThan(0)
+    // Brand is a logotype image now, not text — match its alt text.
+    expect(screen.getAllByAltText('Pitchey').length).toBeGreaterThan(0)
   })
 
   it('renders the hero headline', () => {

--- a/frontend/src/pages/__tests__/InvestorDiscover.test.tsx
+++ b/frontend/src/pages/__tests__/InvestorDiscover.test.tsx
@@ -151,14 +151,15 @@ describe('InvestorDiscover', () => {
     })
   })
 
-  it('renders Back to Dashboard link', async () => {
+  it('renders the discover header', async () => {
+    // Back/nav chrome now lives in the portal layout, not this page.
     render(
       <MemoryRouter>
         <InvestorDiscover />
       </MemoryRouter>
     )
     await waitFor(() => {
-      expect(screen.getByText('Back to Dashboard')).toBeInTheDocument()
+      expect(screen.getByText('Discover Investment Opportunities')).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/pages/__tests__/MarketplaceEnhanced.test.tsx
+++ b/frontend/src/pages/__tests__/MarketplaceEnhanced.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+// custom render wraps with BrowserRouter + providers (component uses <Link>)
+import { render, screen, waitFor } from '../../test/utils'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import MarketplaceEnhanced from '../MarketplaceEnhanced'
@@ -139,6 +140,10 @@ const createMockPitch = (id: number, overrides = {}) => ({
 describe('MarketplaceEnhanced', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Reset the URL — the shared BrowserRouter history leaks ?q=/filter params
+    // between tests (e.g. the search-typing test), which otherwise puts later
+    // tests into search mode and hides the browse results.
+    window.history.pushState({}, '', '/')
     Object.defineProperty(navigator, 'onLine', { writable: true, value: true })
 
     const defaultPitches = [createMockPitch(1), createMockPitch(2), createMockPitch(3)]
@@ -260,7 +265,9 @@ describe('MarketplaceEnhanced', () => {
       render(<MarketplaceEnhanced />)
 
       await waitFor(() => {
-        expect(screen.getByText('NDA')).toBeInTheDocument()
+        // The pitch card renders an `<Shield/> NDA` badge when hasNDA is set.
+        // getAllByText (not getByText) — "NDA" also appears as a filter label.
+        expect(screen.getAllByText('NDA').length).toBeGreaterThan(0)
       })
     })
   })

--- a/frontend/src/pages/__tests__/Messages.test.tsx
+++ b/frontend/src/pages/__tests__/Messages.test.tsx
@@ -53,7 +53,8 @@ vi.mock('../../lib/api-client', () => ({
 }))
 
 vi.mock('../../config/subscription-plans', () => ({
-  getCreditCost: () => ({ credits: 2, description: 'Send message' }),
+  // getCreditCost returns a NUMBER (the credit cost), not an object — matching the real impl.
+  getCreditCost: () => 2,
 }))
 
 // Mock the messaging types import (resolves to backend types)

--- a/frontend/src/pages/__tests__/PaymentMethods.test.tsx
+++ b/frontend/src/pages/__tests__/PaymentMethods.test.tsx
@@ -18,92 +18,53 @@ vi.mock('@/components/ErrorBoundary/PortalErrorBoundary', () => ({
   withPortalErrorBoundary: (Component: any) => Component,
 }))
 
+// StripePortalCard pulls in the billing stack (auth + API); stub it so this
+// stays a focused unit test of the PaymentMethods page shell.
+vi.mock('@features/billing/components/StripePortalCard', () => ({
+  default: () => <div data-testid="stripe-portal-card">Stripe portal</div>,
+}))
+
 let PaymentMethods: React.ComponentType
 beforeAll(async () => {
   const mod = await import('@portals/investor/pages/PaymentMethods')
   PaymentMethods = mod.default
 })
 
+// The page was rewritten to delegate cards/invoices/billing to Stripe's hosted
+// Customer Portal (StripePortalCard); the old ACH/wire/"coming soon" mock UI was
+// removed. These tests assert the current shell.
 describe('PaymentMethods', () => {
-  it('renders page heading', () => {
+  const renderPage = () =>
     render(
       <MemoryRouter>
         <PaymentMethods />
       </MemoryRouter>
     )
+
+  it('renders page heading', () => {
+    renderPage()
     expect(screen.getByText('Payment Methods')).toBeInTheDocument()
   })
 
   it('renders subtitle description', () => {
-    render(
-      <MemoryRouter>
-        <PaymentMethods />
-      </MemoryRouter>
-    )
-    expect(screen.getByText('Manage your payment methods for investments and transactions')).toBeInTheDocument()
+    renderPage()
+    expect(
+      screen.getByText('Manage your payment methods and billing for investments and subscriptions')
+    ).toBeInTheDocument()
   })
 
-  it('renders security notice', () => {
-    render(
-      <MemoryRouter>
-        <PaymentMethods />
-      </MemoryRouter>
-    )
-    expect(screen.getByText('Bank-Level Security')).toBeInTheDocument()
+  it('renders the Stripe customer portal card', () => {
+    renderPage()
+    expect(screen.getByTestId('stripe-portal-card')).toBeInTheDocument()
   })
 
-  it('renders coming soon message', () => {
-    render(
-      <MemoryRouter>
-        <PaymentMethods />
-      </MemoryRouter>
-    )
-    expect(screen.getByText('Payment integration coming soon')).toBeInTheDocument()
+  it('renders the security notice about not storing card details', () => {
+    renderPage()
+    expect(screen.getByText(/We never store sensitive card details/i)).toBeInTheDocument()
   })
 
-  it('renders Payment Information section', () => {
-    render(
-      <MemoryRouter>
-        <PaymentMethods />
-      </MemoryRouter>
-    )
-    expect(screen.getByText('Payment Information')).toBeInTheDocument()
-  })
-
-  it('renders accepted payment methods info', () => {
-    render(
-      <MemoryRouter>
-        <PaymentMethods />
-      </MemoryRouter>
-    )
-    expect(screen.getByText('Accepted Payment Methods')).toBeInTheDocument()
-  })
-
-  it('renders processing times section', () => {
-    render(
-      <MemoryRouter>
-        <PaymentMethods />
-      </MemoryRouter>
-    )
-    expect(screen.getByText('Processing Times')).toBeInTheDocument()
-  })
-
-  it('renders ACH and wire transfer info', () => {
-    render(
-      <MemoryRouter>
-        <PaymentMethods />
-      </MemoryRouter>
-    )
-    expect(screen.getByText(/ACH Transfers/)).toBeInTheDocument()
-    expect(screen.getByText(/Wire Transfers/)).toBeInTheDocument()
-  })
-
-  it('renders Stripe integration notice', () => {
-    render(
-      <MemoryRouter>
-        <PaymentMethods />
-      </MemoryRouter>
-    )
-    expect(screen.getByText(/Stripe/i)).toBeInTheDocument()
+  it('explains that billing is handled in the Stripe portal', () => {
+    renderPage()
+    expect(screen.getByText(/handled in the secure Stripe portal/i)).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/__tests__/ProductionSettingsBilling.test.tsx
+++ b/frontend/src/pages/__tests__/ProductionSettingsBilling.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import React from 'react'
 
@@ -45,6 +45,12 @@ vi.mock('../../components/ui/badge', () => ({
   Badge: ({ children, ...props }: any) => <span {...props}>{children}</span>,
 }))
 
+// StripePortalCard pulls in the billing/auth/API stack; stub it so this stays a
+// focused unit test of the billing page shell.
+vi.mock('@features/billing/components/StripePortalCard', () => ({
+  default: () => <div data-testid="stripe-portal-card">Stripe portal</div>,
+}))
+
 const mockToast = { success: vi.fn(), error: vi.fn(), loading: vi.fn() }
 vi.mock('react-hot-toast', () => ({
   default: mockToast,
@@ -69,72 +75,34 @@ function renderComponent() {
   )
 }
 
+// The page was rewritten to delegate all real billing (cards, invoices, billing
+// address, cancellation) to Stripe's hosted Customer Portal via StripePortalCard.
+// The old stub tabbed UI (Overview / Payment Methods / Billing Info / Invoices)
+// was removed, so the tests now assert the current shell.
 describe('ProductionSettingsBilling', () => {
-  it('renders the page title', () => {
+  it('renders the page title and subtitle', () => {
     renderComponent()
     expect(screen.getByText('Billing & Payments')).toBeInTheDocument()
-    expect(screen.getByText('Manage your subscription, payment methods, and billing information')).toBeInTheDocument()
+    expect(
+      screen.getByText('Manage your subscription, payment methods, and invoices.')
+    ).toBeInTheDocument()
   })
 
-  it('renders tab navigation', () => {
+  it('renders the Stripe customer portal card', () => {
     renderComponent()
-    expect(screen.getByText('Overview')).toBeInTheDocument()
-    expect(screen.getByText('Payment Methods')).toBeInTheDocument()
-    expect(screen.getByText('Billing Info')).toBeInTheDocument()
-    expect(screen.getByText('Invoices')).toBeInTheDocument()
+    expect(screen.getByTestId('stripe-portal-card')).toBeInTheDocument()
   })
 
-  it('shows the overview tab by default with plan info', () => {
+  it('explains that billing is managed in the secure Stripe portal', () => {
     renderComponent()
-    expect(screen.getByText('Current Plan')).toBeInTheDocument()
-    expect(screen.getByText('Free Plan')).toBeInTheDocument()
-    expect(screen.getByText('Active')).toBeInTheDocument()
+    expect(screen.getByText(/managed in the\s+secure billing portal above/i)).toBeInTheDocument()
   })
 
-  it('displays coming soon message for paid plans in overview', () => {
+  it('no longer renders the old stub tabbed UI', () => {
     renderComponent()
-    expect(screen.getByText(/Paid plans with premium features are coming soon/)).toBeInTheDocument()
-  })
-
-  it('does not show old plan feature rows', () => {
-    renderComponent()
-    expect(screen.queryByText('Unlimited')).not.toBeInTheDocument()
-    expect(screen.queryByText('per month')).not.toBeInTheDocument()
-  })
-
-  it('does not show Upgrade Plan or Change Plan buttons', () => {
-    renderComponent()
-    expect(screen.queryByText('Upgrade Plan')).not.toBeInTheDocument()
-    expect(screen.queryByText('Change Plan')).not.toBeInTheDocument()
-  })
-
-  it('switches to Payment Methods tab', () => {
-    renderComponent()
-    fireEvent.click(screen.getByText('Payment Methods'))
-    expect(screen.getByText('Add Payment Method')).toBeInTheDocument()
-  })
-
-  it('shows payment methods with card info', () => {
-    renderComponent()
-    fireEvent.click(screen.getByText('Payment Methods'))
-    // No payment methods by default — only the Add Payment Method button is shown
-    expect(screen.getByText('Add Payment Method')).toBeInTheDocument()
-  })
-
-  it('switches to Invoices tab and shows invoice list', () => {
-    renderComponent()
-    fireEvent.click(screen.getByText('Invoices'))
-    expect(screen.getByText('Invoice History')).toBeInTheDocument()
-    // No invoices by default — only the empty table is shown
-    expect(screen.queryByText('INV-2024-001')).not.toBeInTheDocument()
-  })
-
-  it('switches to Billing Info tab and shows form fields', () => {
-    renderComponent()
-    fireEvent.click(screen.getByText('Billing Info'))
-    expect(screen.getByText('Billing Information')).toBeInTheDocument()
-    // Company starts empty; email is pre-filled from user session
-    expect(screen.getByText('Company Name')).toBeInTheDocument()
-    expect(screen.getByDisplayValue('production@test.com')).toBeInTheDocument()
+    expect(screen.queryByText('Overview')).not.toBeInTheDocument()
+    expect(screen.queryByText('Billing Info')).not.toBeInTheDocument()
+    expect(screen.queryByText('Add Payment Method')).not.toBeInTheDocument()
+    expect(screen.queryByText('Current Plan')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/__tests__/PublicPitchView.test.tsx
+++ b/frontend/src/pages/__tests__/PublicPitchView.test.tsx
@@ -285,7 +285,10 @@ describe('PublicPitchView', () => {
     })
   })
 
-  it('shows Back to Marketplace link', async () => {
+  it('shows a Back to Marketplace button in the error state', async () => {
+    // The standalone header "Back to Marketplace" chrome was removed (PortalTopNav
+    // provides it now); the button now lives only in the not-found/error state.
+    mockGetPublicById.mockResolvedValueOnce(null)
     render(
       <MemoryRouter>
         <PublicPitchView />
@@ -297,7 +300,8 @@ describe('PublicPitchView', () => {
     })
   })
 
-  it('shows Dashboard button for authenticated user', async () => {
+  it('shows a Go to Dashboard button for an authenticated investor', async () => {
+    // mockUser is an authenticated investor viewing someone else's pitch.
     render(
       <MemoryRouter>
         <PublicPitchView />
@@ -305,7 +309,7 @@ describe('PublicPitchView', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByText('Dashboard')).toBeInTheDocument()
+      expect(screen.getByText('Go to Dashboard')).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/pages/__tests__/SettingsProfile.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsProfile.test.tsx
@@ -127,10 +127,10 @@ describe('SettingsProfile', () => {
       expect(lastNameInput).toBeInTheDocument()
     })
 
-    it('pre-populates email field (disabled)', () => {
+    it('pre-populates email field (editable — sign-in email can be changed)', () => {
       renderComponent()
       const emailInput = screen.getByDisplayValue('jane@example.com')
-      expect(emailInput).toBeDisabled()
+      expect(emailInput).toBeEnabled()
     })
 
     it('pre-populates username', () => {

--- a/frontend/src/services/__tests__/user.service.test.ts
+++ b/frontend/src/services/__tests__/user.service.test.ts
@@ -10,6 +10,14 @@ vi.mock('../../lib/api-client', () => ({
   },
 }))
 
+// prepareImageForUpload wraps browser-image-compression (canvas/Image) which never
+// resolves in jsdom; stub it to pass the file through so the upload-fetch logic is
+// what's under test, not the compression.
+vi.mock('../../utils/imageUpload', () => ({
+  prepareImageForUpload: vi.fn(async (file: File) => file),
+  PRE_COMPRESSION_MAX_BYTES: 30 * 1024 * 1024,
+}))
+
 import { apiClient } from '../../lib/api-client'
 import { UserService } from '../user.service'
 
@@ -151,7 +159,7 @@ describe('UserService', () => {
       mockApiClient.post.mockResolvedValue({ success: true })
       await expect(UserService.changePassword({ currentPassword: 'old', newPassword: 'new', confirmPassword: 'new' }))
         .resolves.toBeUndefined()
-      expect(mockApiClient.post).toHaveBeenCalledWith('/api/user/change-password', expect.any(Object))
+      expect(mockApiClient.post).toHaveBeenCalledWith('/api/auth/change-password', expect.any(Object))
     })
 
     it('throws on failure', async () => {

--- a/frontend/src/store/__tests__/betterAuthStore.test.ts
+++ b/frontend/src/store/__tests__/betterAuthStore.test.ts
@@ -133,7 +133,7 @@ describe('betterAuthStore', () => {
 
       await expect(
         useBetterAuthStore.getState().loginCreator('test@example.com', 'pass')
-      ).rejects.toThrow('User data not received');
+      ).rejects.toThrow('Login response was incomplete');
     });
 
     it('handles response.data.user format', async () => {


### PR DESCRIPTION
## Vitest burn-down — 82 → 0, then flip the gate

The frontend suite ran non-blocking in CI (it had never executed there before, so mocks silently drifted from the real API). This drives the **82 accumulated failures to 0** and removes `continue-on-error` so the suite now **gates** the build.

Final: **187 files, 3507 tests, 0 failures.**

### Real production bug found + fixed
- **NDAModal** fetched `${import.meta.env.VITE_API_URL}/api/ndas/standard` with no fallback → `undefined/api/...` whenever the env var is unset. Switched to the lazy `API_URL` from `@/config` (same-origin in prod), the codebase-standard pattern.

### Test fixes (grouped by root cause — all stale-vs-current, not behavior changes)
- **Query drift**: LoginForm password label collided with the show/hide toggle (exact `'Password'`); brand is now an `<img alt="Pitchey">` (Homepage, Onboarding); PitchForm gained Long Synopsis + a toggle (anchored `/^short synopsis/i`).
- **Components rewritten to delegate to Stripe**: PaymentMethods + ProductionSettingsBilling dropped their stub UIs for `StripePortalCard` — tests realigned + mock the portal.
- **Chrome moved to PortalLayout**: CreatorNDAManagement / InvestorDiscover / PublicPitchView no longer render their own back/nav; assert the page heading (or the error-state button) instead.
- **Endpoint/shape drift**: CreatorProfile now calls `/api/pitches?userId=` (server-filtered, `body.data` is the array); BrowseTopRated reads `stats.avgRating` and the filter is "Advanced filters".
- **Mock/setup fixes**: getCreditCost returns a number (Messages); `prepareImageForUpload` stubbed (jsdom canvas hang); CreatePitch mocks the named `DocumentUpload` it actually imports; NDAModal best-effort fetch given a benign mock.
- **Test isolation**: MarketplaceEnhanced reset `window.history` in `beforeEach` — the shared BrowserRouter URL leaked `?q=` from the search-typing test into later tests (this was what hid the NDA-badge result).

frontend tsc 0 errors, build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)