### PR TITLE
consistency: honest analytics copy + pitch-status enum + media size cap

### DIFF
--- a/frontend/src/config/subscription-plans.ts
+++ b/frontend/src/config/subscription-plans.ts
@@ -102,7 +102,7 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
     features: [
       '30 Creator Credits per month',
       'Enhanced Analytics',
-      'Who viewed, time spent, device',
+      'Who viewed, time spent',
     ],
     userType: 'creator'
   },
@@ -142,7 +142,7 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
     features: [
       '40 Creator Credits per month',
       'Enhanced Analytics',
-      'Who viewed, time spent, device',
+      'Who viewed, time spent',
     ],
     userType: 'production'
   },

--- a/frontend/src/shared/types/index.ts
+++ b/frontend/src/shared/types/index.ts
@@ -46,7 +46,10 @@ export interface User {
 
 // ========== PITCH TYPES ==========
 
-export type PitchStatus = 'draft' | 'published' | 'archived' | 'flagged' | 'rejected';
+// Matches the backend pitch statuses (and PitchStatusSchema in zod-schemas.ts).
+// 'flagged'/'rejected' were never pitch statuses (they belong to NDA/collaboration
+// flows); 'under_review' is what the backend + ManagePitches actually use.
+export type PitchStatus = 'draft' | 'published' | 'under_review' | 'archived';
 export type PitchFormat = 'feature' | 'short' | 'tv' | 'web' | 'documentary' | 'animation' | 'other';
 export type PitchGenre = 'action' | 'adventure' | 'comedy' | 'drama' | 'horror' | 'romance' | 
                          'scifi' | 'thriller' | 'fantasy' | 'mystery' | 'documentary' | 'animation';

--- a/src/config/subscription-plans.ts
+++ b/src/config/subscription-plans.ts
@@ -125,7 +125,7 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
     features: [
       '30 Creator Credits per month',
       'Enhanced Analytics',
-      'Who viewed, time spent, device',
+      'Who viewed, time spent',
     ],
     userType: 'creator'
   },
@@ -169,7 +169,7 @@ export const SUBSCRIPTION_TIERS: SubscriptionTier[] = [
     features: [
       '40 Credits per month',
       'Enhanced Analytics',
-      'Who viewed, time spent, device',
+      'Who viewed, time spent',
       'Company verification required'
     ],
     userType: 'production'

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -6798,8 +6798,24 @@ pitchey_analytics_datapoints_per_minute 1250
         return builder.error(ErrorCode.VALIDATION_ERROR, 'Invalid file type for media.');
       }
 
-      // Enforce credit cost: images = extra_image (1), videos = video_link (1)
       const isVideo = file.type.startsWith('video/');
+
+      // Size backstop — the frontend gates uploads client-side (images ~50MB,
+      // video ~500MB), but the backend had no cap, so it would accept (and charge
+      // credits for) an arbitrarily large file. Match the most-generous advertised
+      // per-type limit so no legitimate upload is rejected. Checked BEFORE the
+      // credit deduction so oversized files aren't charged.
+      const MAX_IMAGE_BYTES = 50 * 1024 * 1024;
+      const MAX_VIDEO_BYTES = 500 * 1024 * 1024;
+      const maxBytes = isVideo ? MAX_VIDEO_BYTES : MAX_IMAGE_BYTES;
+      if (file.size > maxBytes) {
+        return builder.error(
+          ErrorCode.VALIDATION_ERROR,
+          `File too large. Maximum ${isVideo ? '500MB for video' : '50MB for images'}.`
+        );
+      }
+
+      // Enforce credit cost: images = extra_image (1), videos = video_link (1)
       const usageType = isVideo ? 'video_link' : 'extra_image';
       const creditResult = await this.deductCreditsInternal(
         authResult.user.id, getCreditCost(usageType), `Media upload: ${file.name}`, usageType


### PR DESCRIPTION
## Consistency fixes (the lower-priority audit tail)

Three independent correctness/consistency fixes:

1. **Analytics copy honesty** — dropped "device" from the Enhanced Analytics feature lists (both configs). `device`/`user_agent` is never captured at view-insert time, so the claim was untrue. Per the product decision: make the copy honest, no tier enforcement, no device capture.

2. **Pitch-status enum alignment** — the `PitchStatus` TS type was `draft|published|archived|flagged|rejected`, but `flagged`/`rejected` are NDA/collaboration statuses (never pitch ones) and `under_review` — which the backend and `ManagePitches.tsx` actually use — was missing. Aligned to `draft|published|under_review|archived`, matching the existing `PitchStatusSchema` (zod) and the backend. tsc clean (nothing referenced the removed values as pitch statuses).

3. **Media upload size cap** — `handleMediaUpload` validated MIME but had **no size limit**, so it would accept (and charge credits for) an arbitrarily large file. Added a backstop — 50MB images / 500MB video (the most-generous advertised limits), checked **before** the credit deduction so oversized files aren't charged.

worker tsc 0, frontend tsc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)