### PR TITLE
feat(production-nav): retire Projects + Pipeline from nav (park routes)

### DIFF
--- a/frontend/src/shared/components/layout/EnhancedProductionNav.tsx
+++ b/frontend/src/shared/components/layout/EnhancedProductionNav.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import {
-  Home, Activity, Film, Upload,
+  Home, Activity, Upload,
   Bookmark, Users, GitBranch,
   MessageSquare, Settings, UserPlus, Shield, FileText
 } from 'lucide-react';
@@ -28,13 +28,11 @@ export const productionNavigationSections: NavigationSection[] = [
       { label: 'Verification', path: PRODUCTION_ROUTES.verification, icon: Shield },
     ],
   },
-  {
-    title: 'Projects',
-    items: [
-      { label: 'All Projects', path: PRODUCTION_ROUTES.projects, icon: Film },
-      { label: 'Pipeline', path: PRODUCTION_ROUTES.pipeline, icon: GitBranch },
-    ],
-  },
+  // "Projects" + "Pipeline" retired from nav 2026-06-03 (activity-feed pivot follow-up) —
+  // pages/routes parked, not deleted (still reachable by direct URL via PRODUCTION_ROUTES.projects
+  // / .pipeline). Production project-management surface is on hold; revive by restoring a
+  // { title: 'Projects', items: [All Projects, Pipeline] } section here. Same park-don't-delete
+  // treatment as the "Submissions" review pipeline below.
   {
     // "Submissions" review pipeline retired 2026-06-01 (activity-feed pivot, Phase 3) —
     // pages/routes parked, not deleted. Activity now lives in the Activity + Following


### PR DESCRIPTION
## What

Removes the **Projects** nav section (All Projects + Pipeline) from the live production portal sidebar (`EnhancedProductionNav` via `PortalLayout`).

## Why

Follow-up to the activity-feed pivot. The production project-management surface is on hold; nav was still surfacing it.

## Park, don't delete

Routes and pages are **kept and reachable by direct URL** via `PRODUCTION_ROUTES.projects` / `.pipeline` — same park-don't-delete treatment as the Submissions review pipeline (commit `2aa67011`). Revive by restoring a `{ title: 'Projects', items: [...] }` section in `EnhancedProductionNav.tsx`.

## Notes

- The two other nav files referencing production Projects/Pipeline are dead paths and were left untouched: `EnhancedNavigation` (dev-only `/test/navigation`) and `EnhancedNavigationShadcn` (chains to unmounted `EnhancedPitchForm`).
- Dropped now-unused `Film` icon import. `tsc --noEmit` clean.
- Already manually deployed to prod (`pitchey-5o8.pages.dev`, bundle `index-EYg4IsbX.js`); this PR re-syncs `main` with CI so the next CI deploy doesn't revert it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)