### PR TITLE
fix(invites): repair dead link host + branch redeem into pitch-create

### DIFF
--- a/frontend/src/pages/CreatePitch.tsx
+++ b/frontend/src/pages/CreatePitch.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useOnlineStatus } from '@/shared/hooks/useOnlineStatus';
-import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, Upload, X, FileText, Video, Image as ImageIcon, Shield, AlertCircle, WifiOff, CheckCircle, Circle } from 'lucide-react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { ArrowLeft, Upload, X, FileText, Video, Image as ImageIcon, Shield, AlertCircle, WifiOff, CheckCircle, Circle, UserPlus } from 'lucide-react';
 import { useToast } from '@shared/components/feedback/ToastProvider';
 import LoadingSpinner from '@shared/components/feedback/LoadingSpinner';
 import { pitchService } from '@features/pitches/services/pitch.service';
@@ -38,9 +38,19 @@ import {
 
 export default function CreatePitch() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { success, error } = useToast();
   const { user } = useBetterAuthStore();
   const isProduction = user?.userType === 'production';
+
+  // When a creator lands here via a producer's invite link (InviteLanding redirect, or the
+  // post-verification return-to for new sign-ups), surface who they're pitching to. The actual
+  // producer→creator attribution is the auto-follow recorded at invite redemption; this banner
+  // just makes that intent visible. Source: nav state (logged-in redirect) or ?invitedBy= (new-user
+  // return-to, which survives the email-verification round-trip that nav state cannot).
+  const invitedBy = ((location.state as { invitedBy?: string } | null)?.invitedBy
+    || new URLSearchParams(location.search).get('invitedBy')
+    || '').trim();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [currentStep, setCurrentStep] = useState<'form' | 'creating' | 'uploading' | 'complete'>('form');
   const isOnline = useOnlineStatus();
@@ -640,6 +650,20 @@ export default function CreatePitch() {
           </div>
         </div>
       </header>
+
+      {invitedBy && (
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-4">
+          <div className="flex items-center gap-3 rounded-lg border border-purple-200 bg-purple-50 px-4 py-3">
+            <span className="flex-shrink-0 w-8 h-8 rounded-full bg-purple-100 flex items-center justify-center">
+              <UserPlus className="w-4 h-4 text-purple-600" />
+            </span>
+            <p className="text-sm text-purple-900">
+              You're pitching to <strong>{invitedBy}</strong>. They'll see your pitch in their feed as
+              soon as you publish.
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Pitch Completeness Bar */}
       <div className="sticky top-0 z-40 bg-white/95 backdrop-blur border-b">

--- a/frontend/src/pages/InviteLanding.tsx
+++ b/frontend/src/pages/InviteLanding.tsx
@@ -3,11 +3,21 @@ import { useParams, Link, useNavigate } from 'react-router-dom';
 import { UserPlus, AlertCircle, CheckCircle, Lock, Mail, User, Shield, BarChart3, Eye, Globe } from 'lucide-react';
 import { useBetterAuthStore } from '@/store/betterAuthStore';
 import { apiClient } from '@/lib/api-client';
+import { setPendingReturnTo } from '@/utils/postLoginRedirect';
+
+// Where to land a redeemer so they can pitch straight to the inviting producer. Pitch-capable
+// roles go to their create-pitch flow; everyone else (investor/watcher) just redeems and lands
+// on a dashboard — the redeem still records the producer→creator follow either way.
+function pitchTargetFor(userType: string | undefined): string {
+  if (userType === 'production') return '/production/pitch/new';
+  if (userType === 'creator') return '/creator/pitch/new';
+  return '/creator/dashboard';
+}
 
 export default function InviteLanding() {
   const { code } = useParams<{ code: string }>();
   const navigate = useNavigate();
-  const { isAuthenticated, register, loading: authLoading, error: authError } = useBetterAuthStore();
+  const { isAuthenticated, user, register, loading: authLoading, error: authError } = useBetterAuthStore();
 
   const [invite, setInvite] = useState<{
     inviterName: string;
@@ -59,19 +69,26 @@ export default function InviteLanding() {
   // If already authenticated, redeem THEN redirect — only navigate on success.
   // (Previously the redeem was fire-and-forgotten and we navigated regardless, so a
   // failed redeem sent the user to the dashboard as if they'd joined the team.)
+  // Pitch-capable roles land straight in the create-pitch flow with the inviter's name in
+  // nav state (so CreatePitch can show "You're pitching to {producer}"); others fall back to
+  // a dashboard. The redeem auto-follows the creator on the producer's behalf regardless.
   useEffect(() => {
     if (isAuthenticated && code && invite?.valid) {
       void (async () => {
         try {
           await apiClient.post(`/api/invites/${code}/redeem`, {});
-          navigate('/creator/dashboard', { replace: true });
+          const target = pitchTargetFor(user?.userType);
+          navigate(target, {
+            replace: true,
+            state: target.endsWith('/pitch/new') ? { invitedBy: invite.inviterName } : undefined,
+          });
         } catch (err) {
           const e = err instanceof Error ? err : new Error(String(err));
           setError(`Could not redeem this invite: ${e.message}`);
         }
       })();
     }
-  }, [isAuthenticated, code, invite, navigate]);
+  }, [isAuthenticated, user, code, invite, navigate]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -84,6 +101,13 @@ export default function InviteLanding() {
       // Store invite code before registering
       localStorage.setItem('pendingInviteCode', code || '');
       localStorage.setItem('pendingVerificationEmail', formData.email);
+
+      // New sign-ups register as creators (below); land them in the create-pitch flow after
+      // they verify + log in. The ?invitedBy survives the email round-trip that nav state can't.
+      // betterAuthStore redeems the pendingInviteCode once the session is established.
+      setPendingReturnTo(
+        `/creator/pitch/new?invitedBy=${encodeURIComponent(invite?.inviterName || '')}`,
+      );
 
       await register({
         email: formData.email,

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -20708,7 +20708,8 @@ Signatures: [To be completed upon signing]
         VALUES ($1, $2, $3, $4)
       `, [code, userId, userName, body.email || null]);
 
-      const inviteUrl = `https://pitchey.com/invite/${code}`;
+      const frontendUrl = this.env.FRONTEND_URL || 'https://pitchey-5o8.pages.dev';
+      const inviteUrl = `${frontendUrl}/invite/${code}`;
 
       // Send invite email if an email address was provided
       if (body.email && this.emailService) {


### PR DESCRIPTION
## The bug

Invite links were built against `https://pitchey.com` — the **coming-soon marketing stub**, not the live app. Every emailed/copied invite link dead-ended on a page that can't redeem (`pitchey.com/invite/x` → 200 `<title>Pitchey — Coming Soon</title>`). The producer-driven creator-acquisition loop was broken at the delivery step. Fixed to source `env.FRONTEND_URL` (`pitchey-5o8.pages.dev`), matching the canonical pattern already used elsewhere in the worker.

## The feature — "both, with branching"

One invite link, branched on whether the recipient already has an account, landing both in the create-pitch flow with the inviting producer attached:

- **Logged-in** recipient → redeem, then route to `/creator/pitch/new` (or `/production/pitch/new`) with the inviter's name in nav state. Was: dumped on `/creator/dashboard`. Investor/watcher roles redeem and fall back to dashboard.
- **New** recipient → `pendingReturnTo=/creator/pitch/new?invitedBy=…` so they land in pitch-create after email-verify + login (query param survives the round-trip nav state can't). Redeem still fires in `betterAuthStore`.
- **CreatePitch** shows a "You're pitching to **{producer}**" banner (nav state or `?invitedBy=`).

## Attribution — no schema change

"Pitch to this producer" = the **auto-follow already recorded at redemption** (producer follows creator). When the creator publishes, it surfaces in the producer's Following/Activity feed — the pivot's model. No new tables.

## Verification

- frontend `tsc` clean, worker `--dry-run` bundles, 32 CreatePitch tests pass
- Already deployed to prod: worker `4acaf0c0`, frontend `index-C3jq36Lp.js`. This PR re-syncs `main` so CI doesn't revert the manual deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)