### PR TITLE
fix(login): demo accounts log in directly on /login (Turnstile bypass)

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -55,7 +55,7 @@ export default function Login() {
     }
   };
 
-  const setDemoCredentials = () => {
+  const setDemoCredentials = async () => {
     if (!selectedPortal) {
       alert('Please select a portal type first');
       return;
@@ -69,6 +69,25 @@ export default function Login() {
 
     const demo = demoAccounts[selectedPortal];
     setFormData({ email: demo.email, password: demo.password });
+
+    // Demo accounts bypass Turnstile on the backend, so log in directly instead of just
+    // pre-filling — otherwise the user is stranded behind the Turnstile gate. Mirrors the
+    // dedicated /login/<portal> pages.
+    try {
+      if (selectedPortal === 'creator') {
+        await loginCreator(demo.email, demo.password, turnstileToken);
+        void navigate(resolvePostLoginRedirect(rawFrom, '/creator/dashboard'));
+      } else if (selectedPortal === 'investor') {
+        await loginInvestor(demo.email, demo.password, turnstileToken);
+        void navigate(resolvePostLoginRedirect(rawFrom, '/investor/dashboard'));
+      } else if (selectedPortal === 'production') {
+        await loginProduction(demo.email, demo.password, turnstileToken);
+        void navigate(resolvePostLoginRedirect(rawFrom, '/production/dashboard'));
+      }
+    } catch (err) {
+      console.error('Demo login failed:', err);
+      resetTurnstile();
+    }
   };
 
   // Accent classes are full literal strings per portal. The old code interpolated
@@ -296,8 +315,9 @@ export default function Login() {
                 <p className="text-purple-200 text-xs text-center mb-3">Try our demo account</p>
                 <button
                   type="button"
-                  onClick={setDemoCredentials}
-                  className="w-full py-2 bg-purple-500/30 hover:bg-purple-500/40 text-purple-100 rounded-lg text-sm font-medium transition border border-purple-400/30"
+                  disabled={loading}
+                  onClick={() => { void setDemoCredentials(); }}
+                  className="w-full py-2 bg-purple-500/30 hover:bg-purple-500/40 text-purple-100 rounded-lg text-sm font-medium transition border border-purple-400/30 disabled:opacity-50"
                 >
                   Use Demo {selectedPortal === 'creator' ? 'Creator' : selectedPortal === 'investor' ? 'Investor' : 'Production'} Account
                 </button>


### PR DESCRIPTION
On the canonical `/login` chooser, **"Use Demo X Account" only pre-filled the form**, so the user was stranded behind the Turnstile gate (Sign in stays disabled until a token issues). The dedicated `/login/<portal>` pages auto-submit instead — demo accounts bypass Turnstile on the backend.

`/login` now does the same: clicking the demo button **logs in directly** (creator / investor / production) and redirects, honouring the return-path.

**Verified on prod**: "Use Demo Production Account" → `/production/dashboard`.

## Separate issue (owner action, not code)
Real (non-demo) Turnstile errors **`600010`** on `pitchey-5o8.pages.dev`. This is almost always the sitekey's **allowed-hostnames** not including the domain. In the Cloudflare **Turnstile dashboard**, sitekey `0x4AAAAAACzpFR_oniI4M7PI` needs `pitchey-5o8.pages.dev` (and `pitchey.com` for the cutover) added — or issue a fresh sitekey and update `frontend/.env.production`. (The CF token available here lacks Turnstile permission, so I couldn't read/patch it.)

tsc clean; 17 Login tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)