### PR TITLE
feat(production): remove archived project analytics + consolidate nav

### DIFF
--- a/frontend/src/features/analytics/components/Analytics/EnhancedProductionAnalytics.tsx
+++ b/frontend/src/features/analytics/components/Analytics/EnhancedProductionAnalytics.tsx
@@ -4,11 +4,7 @@ import {
   FileCheck,
   Shield,
   Users,
-  Building2,
   RefreshCw,
-  DollarSign,
-  CheckCircle,
-  TrendingUp,
   BarChart3,
 } from 'lucide-react';
 
@@ -29,20 +25,12 @@ interface PitchEvaluationProps {
   ndaRequestsSent: number;
   ndasSigned: number;
   creatorsFollowing: number;
-  projectsStarted: number;
 }
 
 interface ChartData {
   genreDistribution: { genre: string; count: number }[];
   pipelineByStage: { stage: string; count: number }[];
   monthlyActivity: { date: string; value: number }[];
-  // Project management data (only meaningful when projects exist)
-  projectMetrics: {
-    totalBudget: number;
-    completionRate: number;
-    totalRevenue: number;
-  };
-  projectTimelines: { project: string; planned: number; actual: number; status: string }[];
 }
 
 export const EnhancedProductionAnalytics: React.FC<PitchEvaluationProps> = (props) => {
@@ -96,17 +84,14 @@ export const EnhancedProductionAnalytics: React.FC<PitchEvaluationProps> = (prop
   const transformChartData = (apiData: any): ChartData => {
     const genreData = apiData.genrePerformance || [];
     const trendsData = apiData.monthlyTrends || [];
-    const metrics = apiData.productionMetrics || {};
-    const successData = apiData.successMetrics || {};
 
     // Build pipeline from props (more accurate than backend pipeline stages)
-    const underReview = Math.max(0, props.savedPitchCount - props.ndasSigned - props.projectsStarted);
+    const underReview = Math.max(0, props.savedPitchCount - props.ndasSigned);
     const pipelineByStage = [
       { stage: 'Saved', count: props.savedPitchCount },
       { stage: 'Under Review', count: underReview },
       { stage: 'NDA Requested', count: props.ndaRequestsSent },
       { stage: 'NDA Signed', count: props.ndasSigned },
-      { stage: 'Project Started', count: props.projectsStarted },
     ].filter(s => s.count > 0);
 
     return {
@@ -119,29 +104,17 @@ export const EnhancedProductionAnalytics: React.FC<PitchEvaluationProps> = (prop
         date: t.month || '',
         value: Number(t.views) || Number(t.projects_created) || 0,
       })),
-      projectMetrics: {
-        totalBudget: Number(metrics.total_budget) || 0,
-        completionRate: Number(metrics.avg_completion_rate) || 0,
-        totalRevenue: Number(successData.total_revenue) || 0,
-      },
-      projectTimelines: apiData.projectTimelines?.map((t: any) => ({
-        project: t.project || t.title || 'Unknown',
-        planned: Number(t.planned) || 0,
-        actual: Number(t.actual) || 0,
-        status: t.status || 'Unknown',
-      })) || [],
     };
   };
 
   // KPI cards use props directly — no loading state needed for them
-  const underReview = Math.max(0, props.savedPitchCount - props.ndasSigned - props.projectsStarted);
+  const underReview = Math.max(0, props.savedPitchCount - props.ndasSigned);
 
   const exportData = [{
     pitchesSaved: props.savedPitchCount,
     underReview,
     ndasActive: props.ndasSigned,
     creatorsFollowing: props.creatorsFollowing,
-    projectsStarted: props.projectsStarted,
   }];
 
   return (
@@ -187,7 +160,7 @@ export const EnhancedProductionAnalytics: React.FC<PitchEvaluationProps> = (prop
       </div>
 
       {/* KPI Cards — always rendered from props, no loading dependency */}
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <AnalyticCard
           title="Pitches Saved"
           value={props.savedPitchCount}
@@ -215,13 +188,6 @@ export const EnhancedProductionAnalytics: React.FC<PitchEvaluationProps> = (prop
           change={0}
           icon={<Users className="w-5 h-5 text-indigo-500" />}
           variant="secondary"
-        />
-        <AnalyticCard
-          title="Projects Started"
-          value={props.projectsStarted}
-          change={0}
-          icon={<Building2 className="w-5 h-5 text-orange-500" />}
-          variant="warning"
         />
       </div>
 
@@ -294,82 +260,6 @@ export const EnhancedProductionAnalytics: React.FC<PitchEvaluationProps> = (prop
           </ChartContainer>
         </div>
       ) : null}
-
-      {/* Project Management — only shown when projects exist */}
-      {props.projectsStarted > 0 && chartData && (
-        <div className="space-y-6">
-          <div className="border-t pt-6">
-            <h2 className="text-xl font-bold text-gray-900 mb-1">Active Projects</h2>
-            <p className="text-gray-500 text-sm mb-4">Tracking projects converted from pitches</p>
-          </div>
-
-          {/* Project KPIs */}
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <AnalyticCard
-              title="Total Budget"
-              value={chartData.projectMetrics.totalBudget}
-              change={0}
-              icon={<DollarSign className="w-5 h-5 text-green-500" />}
-              variant="success"
-              format="currency"
-            />
-            <AnalyticCard
-              title="Completion Rate"
-              value={chartData.projectMetrics.completionRate}
-              change={0}
-              icon={<CheckCircle className="w-5 h-5 text-purple-500" />}
-              variant="primary"
-              format="percentage"
-            />
-            <AnalyticCard
-              title="Total Revenue"
-              value={chartData.projectMetrics.totalRevenue}
-              change={0}
-              icon={<TrendingUp className="w-5 h-5 text-orange-500" />}
-              variant="warning"
-              format="currency"
-            />
-          </div>
-
-          {/* Project Timelines Table */}
-          {chartData.projectTimelines.length > 0 && (
-            <div className="bg-white rounded-xl border p-6">
-              <h3 className="text-lg font-semibold text-gray-900 mb-4">Project Timelines</h3>
-              <div className="overflow-x-auto">
-                <table className="w-full">
-                  <thead>
-                    <tr className="text-left border-b border-gray-200">
-                      <th className="pb-3 text-sm font-medium text-gray-600">Project</th>
-                      <th className="pb-3 text-sm font-medium text-gray-600">Planned (Days)</th>
-                      <th className="pb-3 text-sm font-medium text-gray-600">Actual (Days)</th>
-                      <th className="pb-3 text-sm font-medium text-gray-600">Status</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {chartData.projectTimelines.map((project, index) => (
-                      <tr key={index} className="border-b border-gray-100">
-                        <td className="py-3 font-medium text-gray-900">{project.project}</td>
-                        <td className="py-3 text-gray-600">{project.planned || '—'}</td>
-                        <td className="py-3 text-gray-600">{project.actual || 'In Progress'}</td>
-                        <td className="py-3">
-                          <span className={`px-2 py-1 rounded-full text-xs font-medium ${
-                            project.status === 'Completed' ? 'bg-green-100 text-green-800' :
-                            project.status === 'Post-Production' ? 'bg-purple-100 text-purple-800' :
-                            project.status === 'Production' ? 'bg-blue-100 text-blue-800' :
-                            'bg-gray-100 text-gray-800'
-                          }`}>
-                            {project.status}
-                          </span>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          )}
-        </div>
-      )}
     </div>
   );
 };

--- a/frontend/src/pages/ProductionDashboard.tsx
+++ b/frontend/src/pages/ProductionDashboard.tsx
@@ -977,7 +977,6 @@ function ProductionDashboard() {
               ndaRequestsSent={outgoingNDARequests?.length || 0}
               ndasSigned={signedNDAs?.length || 0}
               creatorsFollowing={followingCreators?.length || 0}
-              projectsStarted={pipelineCount || 0}
             />
 
             {/* Notifications Widget */}

--- a/frontend/src/shared/components/layout/EnhancedProductionNav.tsx
+++ b/frontend/src/shared/components/layout/EnhancedProductionNav.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import {
   Home, Activity, Upload,
-  Bookmark, Users, GitBranch,
+  Bookmark, Users, Handshake,
   MessageSquare, Settings, UserPlus, Shield, FileText
 } from 'lucide-react';
 import { PRODUCTION_ROUTES } from '@/config/navigation.routes';
@@ -28,40 +28,28 @@ export const productionNavigationSections: NavigationSection[] = [
       { label: 'Verification', path: PRODUCTION_ROUTES.verification, icon: Shield },
     ],
   },
-  // "Projects" + "Pipeline" retired from nav 2026-06-03 (activity-feed pivot follow-up) —
-  // pages/routes parked, not deleted (still reachable by direct URL via PRODUCTION_ROUTES.projects
-  // / .pipeline). Production project-management surface is on hold; revive by restoring a
-  // { title: 'Projects', items: [All Projects, Pipeline] } section here. Same park-don't-delete
-  // treatment as the "Submissions" review pipeline below.
-  {
-    // "Submissions" review pipeline retired 2026-06-01 (activity-feed pivot, Phase 3) —
-    // pages/routes parked, not deleted. Activity now lives in the Activity + Following
-    // feeds. Acquisition loop ("Invite Creators") stays.
-    title: 'Creators',
-    items: [
-      { label: 'Invite Creators', path: PRODUCTION_ROUTES.invites, icon: UserPlus },
-    ],
-  },
   {
     title: 'Pitches',
     items: [
       { label: 'My Pitches', path: PRODUCTION_ROUTES.pitches, icon: FileText },
       { label: 'Create Pitch', path: PRODUCTION_ROUTES.pitchNew, icon: Upload },
       { label: 'Saved Pitches', path: PRODUCTION_ROUTES.saved, icon: Bookmark },
+    ],
+  },
+  // Nav consolidation 2026-06-03 — merged the single-item Creators/Team sections and the
+  // Operations section into one "People" group. PARKED from the nav (routes + pages still
+  // reachable by direct URL, not deleted):
+  //   • "Members"          (internal crew — PRODUCTION_ROUTES.teamManagement)
+  //   • "My Collaborations" (your seat on other companies' projects — .myCollaborations)
+  // Both hang off the projects/pipeline surface that's on hold. Revive by re-adding their
+  // items here. ("Projects"/"Pipeline" and the "Submissions" review pipeline were parked
+  // earlier the same way.) "Collaborations" (external business partners) stays.
+  {
+    title: 'People',
+    items: [
+      { label: 'Invite Creators', path: PRODUCTION_ROUTES.invites, icon: UserPlus },
       { label: 'Following', path: PRODUCTION_ROUTES.following, icon: Users },
-    ],
-  },
-  {
-    title: 'Team',
-    items: [
-      { label: 'Members', path: PRODUCTION_ROUTES.teamManagement, icon: Users },
-    ],
-  },
-  {
-    title: 'Operations',
-    items: [
-      { label: 'Collaborations', path: PRODUCTION_ROUTES.collaborations, icon: GitBranch },
-      { label: 'My Collaborations', path: PRODUCTION_ROUTES.myCollaborations, icon: GitBranch },
+      { label: 'Collaborations', path: PRODUCTION_ROUTES.collaborations, icon: Handshake },
     ],
   },
   {


### PR DESCRIPTION
Projects/pipeline are archived, so this cleans up what hung off them.

## Dashboard analytics (`EnhancedProductionAnalytics`)
- Removed the **Projects Started** KPI card, the **Active Projects** block (Total Budget / Completion Rate / Total Revenue), and the **Project Timelines** table.
- Dropped the `projectsStarted` prop, `projectMetrics` / `projectTimelines` chart data, the "Project Started" pipeline stage, and now-unused `metrics`/`successMetrics` + icon imports. KPI grid 5 → 4 cards.

## Nav consolidation (`EnhancedProductionNav`)
Merged the single-item **Creators**/**Team** sections and **Operations** into one **People** group:
- **People** = Invite Creators · Following · Collaborations
- **Parked from the nav** (routes + pages still reachable by URL, not deleted): **Members** (internal crew) and **My Collaborations** (your seat on other companies' projects) — both hang off the on-hold projects surface.
- Kept **Collaborations** (external business partners); swapped its confusing git-branch icon for a Handshake.

New sidebar: Dashboard (Overview·Activity·Verification) / Pitches (My·Create·Saved) / People (Invite Creators·Following·Collaborations) / Messages·Settings.

`tsc` clean; 21 ProductionDashboard tests pass. Verified live in dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)