### PR TITLE
fix(production-dashboard): drop stray /api/production/projects fetch

### DIFF
--- a/frontend/src/pages/ProductionDashboard.tsx
+++ b/frontend/src/pages/ProductionDashboard.tsx
@@ -87,7 +87,6 @@ function ProductionDashboard() {
     { label: 'Share Profile', icon: Share2, accent: 'indigo', onClick: () => setShowShareModal(true) },
   ];
   const [myPitches, setMyPitches] = useState<Pitch[]>([]);
-  const [pipelineCount, setPipelineCount] = useState(0);
   const [followingPitches, setFollowingPitches] = useState<Pitch[]>([]);
   const [followingCreators, setFollowingCreators] = useState<any[]>([]);
   const [followingSortBy, setFollowingSortBy] = useState('recent');
@@ -319,12 +318,9 @@ function ProductionDashboard() {
         }
       }
 
-      // Fetch user's own pitches and pipeline projects in parallel
+      // Fetch the user's own pitches
       try {
-        const [pitchesResponse, pipelineResponse] = await Promise.all([
-          apiClient.get<any>(`/api/pitches?status=all&userId=${user?.id}&limit=100`),
-          apiClient.get<any>('/api/production/projects'),
-        ]);
+        const pitchesResponse = await apiClient.get<any>(`/api/pitches?status=all&userId=${user?.id}&limit=100`);
 
         if (pitchesResponse.success) {
           const userPitches = safeArray(pitchesResponse.data?.pitches || pitchesResponse.data || []);
@@ -344,11 +340,6 @@ function ProductionDashboard() {
             }
           }));
           setMyPitches(dashboardPitches);
-        }
-
-        if (pipelineResponse.success) {
-          const projects = safeArray(pipelineResponse.data?.projects || []);
-          setPipelineCount(projects.filter((p: any) => p.status === 'active').length);
         }
       } catch (err) {
         const e = err instanceof Error ? err : new Error(String(err));


### PR DESCRIPTION
The production dashboard still called `/api/production/projects` to compute `pipelineCount`, which nothing reads anymore (the projects analytics were removed in #194) — so it just produced a `401 (Unauthorized)` in the console.

Removed the call (collapsed the `Promise.all` to the single pitches fetch), the `pipelineResponse` handling, and the now-dead `pipelineCount` state. Pure cleanup — no UI change.

`tsc` clean; 21 ProductionDashboard tests pass.

(Context: the Turnstile `600010` was resolved separately by adding `www.pitchey.com` to the widget's hostnames — a proxied CNAME → `pitchey.com` that Turnstile treats as a distinct host. No code change needed for that.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)