### PR TITLE
fix(connectivity): P5 X-Frame align + P6 CSP-ownership doc + P9 WS reconnect churn

### DIFF
--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -3,14 +3,18 @@
 # Global security headers for all pages
 /*
   # Security Headers
-  X-Frame-Options: SAMEORIGIN
+  # DENY (not SAMEORIGIN): the app is never legitimately framed — it frames
+  # Stripe/Turnstile (see frame-src below), not the other way round. Matches the
+  # Worker's DENY + frame-ancestors 'none' (security-fix.ts) so the policy is
+  # consistent across static pages and API. (P5: was SAMEORIGIN, an audit split.)
+  X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   X-XSS-Protection: 1; mode=block
   Permissions-Policy: geolocation=(), microphone=(), camera=()
   
   # Content Security Policy for React apps
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://checkout.stripe.com https://browser.sentry-cdn.com https://challenges.cloudflare.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://pitchey-api-prod.ndlovucavelle.workers.dev wss://pitchey-api-prod.ndlovucavelle.workers.dev https://*.pitchey-5o8.pages.dev wss://*.pitchey-5o8.pages.dev https://api.stripe.com https://*.sentry.io https://*.ingest.sentry.io https://*.ingest.de.sentry.io; frame-src 'self' https://js.stripe.com https://checkout.stripe.com https://challenges.cloudflare.com;
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://checkout.stripe.com https://browser.sentry-cdn.com https://challenges.cloudflare.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://pitchey-api-prod.ndlovucavelle.workers.dev wss://pitchey-api-prod.ndlovucavelle.workers.dev https://*.pitchey-5o8.pages.dev wss://*.pitchey-5o8.pages.dev https://api.stripe.com https://*.sentry.io https://*.ingest.sentry.io https://*.ingest.de.sentry.io; frame-src 'self' https://js.stripe.com https://checkout.stripe.com https://challenges.cloudflare.com; frame-ancestors 'none';
   
   # Performance Headers - don't cache index.html
   Cache-Control: no-cache, no-store, must-revalidate

--- a/frontend/src/features/notifications/hooks/useWebSocketAdvanced.ts
+++ b/frontend/src/features/notifications/hooks/useWebSocketAdvanced.ts
@@ -1221,11 +1221,12 @@ export function useWebSocketAdvanced(options: UseWebSocketAdvancedOptions = {}) 
       };
     }
     
-    // CRITICAL: Disconnect immediately if not authenticated
+    // CRITICAL: Disconnect immediately if not authenticated. disconnect() is
+    // idempotent (it guards every ref/timer), so call it unconditionally instead
+    // of reading connectionStatus — that read is exactly what used to pull
+    // connection state into this effect's deps.
     if (!isAuthenticated || !user) {
-      if (connectionStatus.connected || connectionStatus.connecting) {
-        disconnect();
-      }
+      disconnect();
       // Clear any connection state
       setConnectionStatus(prev => ({
         ...prev,
@@ -1235,11 +1236,15 @@ export function useWebSocketAdvanced(options: UseWebSocketAdvancedOptions = {}) 
         error: null
       }));
     }
-    
+
     return () => {
       disconnect();
     };
-  }, [opts.autoConnect, isAuthenticated, user, connectionStatus.connected, connectionStatus.connecting]); // Include connection state
+    // P9: deps are auth/intent ONLY — NOT connectionStatus.connected/connecting.
+    // With those in the array, a successful connect() (which flips connected
+    // true) re-ran this effect, whose cleanup disconnect()'d the just-opened
+    // socket → connect→disconnect→reconnect churn feeding the circuit breaker.
+  }, [opts.autoConnect, isAuthenticated, user]);
   
   // Guard against browser extension message channel errors
   useEffect(() => {

--- a/src/services/security-fix.ts
+++ b/src/services/security-fix.ts
@@ -142,6 +142,18 @@ export function addSecurityHeaders(response: Response, environment?: string): Re
   const headers = new Headers(response.headers);
 
   // Content Security Policy
+  //
+  // P6 — CSP ownership is split by surface, on purpose:
+  //   • This (Worker) policy covers Worker responses. Those are JSON (where CSP
+  //     is inert — nothing executes) EXCEPT the Swagger docs HTML route
+  //     (routes/documentation.ts), which loads its UI from cdn.jsdelivr.net /
+  //     unpkg.com — hence the only script-src hosts here.
+  //   • The wide policy with Stripe / Turnstile / Sentry lives in
+  //     frontend/public/_headers, because those flows run in the SPA, never in a
+  //     Worker-served HTML page. Don't widen this one to "match" the SPA — the
+  //     Worker has no payment/challenge surface; broadening it only weakens it.
+  // If you ever add a Worker route that returns HTML needing one of those hosts,
+  // add it HERE (and document why), don't copy the whole SPA policy.
   headers.set('Content-Security-Policy',
     "default-src 'self'; " +
     "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://unpkg.com; " +


### PR DESCRIPTION
The last three parked items from the 2026-06-04 connectivity audit. All low-severity, no active failure mode — cleanup + one real React lifecycle bug (P9).

### P9 — WS reconnect churn (real bug)
The auto-connect effect in `useWebSocketAdvanced.ts` listed `connectionStatus.connected/connecting` in its deps. A successful `connect()` flips `connected` true → the effect re-runs → its cleanup `disconnect()`s the just-opened socket → connect→disconnect→reconnect churn that fed the circuit breaker. Deps are now auth/intent only; the `!authenticated` branch calls the idempotent `disconnect()` unconditionally instead of reading connection state.

### P5 — X-Frame-Options alignment
`frontend/public/_headers` was `SAMEORIGIN` while the live Worker (`security-fix.ts`) sends `DENY` + `frame-ancestors 'none'`. Aligned the static headers to `DENY` and added `frame-ancestors 'none'` to the SPA CSP. The app frames Stripe/Turnstile (frame-src), is never itself framed. (`response.ts getSecurityHeaders` SAMEORIGIN is commented-out Deno-era orphan — left as-is.)

### P6 — CSP ownership documented (no behavior change)
The Worker CSP's host-narrow `script-src` (cdn.jsdelivr.net/unpkg.com) is correct — those are for the Swagger docs HTML route; payment/Turnstile/Sentry live in the SPA `_headers` because those flows never run in a Worker-served page. Added a comment explaining the split so it stops reading as config debt. Deliberately did NOT widen the Worker CSP (the Worker has no payment/challenge surface; broadening only weakens it).

### Verification
- Frontend tsc clean; worker dry-run clean.
- Deployed + verified live: apex serves `X-Frame-Options: DENY` + `frame-ancestors 'none'`, bundle `index-BS5HygRL.js`; worker `05682653` healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)