### PR TITLE
feat(production): hybrid per-pitch workspace + NDA evaluator gate + UI/UX pass

### DIFF
--- a/docs/sessions/2026-06-04-company-shared-production-workspace-scope.md
+++ b/docs/sessions/2026-06-04-company-shared-production-workspace-scope.md
@@ -1,0 +1,88 @@
+# Scope — Production workspace + NDA model (Karl-aligned)
+
+**Date:** 2026-06-04 (revised to Karl's model)
+**Status:** SCOPE ONLY — no code. Awaiting confirm on the one flagged decision (NDA scope) before Phase 1.
+
+## Karl's intent (the model we're aligning to)
+
+1. **Only producers can sign NDAs.**
+2. A production company that has signed an NDA can **view all** of a pitch's Feasibility, Team, and Notes — but **not edit** them.
+3. **The team *behind* the pitch edits the workspace.** A producer shares a join code (B3); creators redeem it to become seated members of the producer's company team; that team (producer + joined creators) builds the Feasibility/Team/Notes on the producer's pitches.
+
+So there is **ONE canonical production workspace per pitch**, owned/edited by the pitch's company team, and **read-only** to NDA-signed producers. This *replaces* the earlier "each viewing company keeps its own private silo" idea.
+
+---
+
+## Current state (verified)
+
+- `production_notes(user_id, pitch_id, content, category, author, shared, …)`, `production_checklists` + `production_team_assignments` each `UNIQUE(user_id, pitch_id)` → **private per person**.
+- Write gate `canWriteProductionData`: **any** production user OR seated member of pitch owner's company team. (The blanket "any production user can write" is what lets *external* producers edit — must change.)
+- NDA: `signNDA` requires `Permission.NDA_SIGN` ("investors/production can sign"); `canRequestNDA` blocks only `watcher`. So **creators + investors + production** can currently request/sign.
+- Frontend `ProductionPitchView`: Team/Notes view-gated `isOwner || hasSignedNDA || isCompanyMember`; checklist editable only by `isOwner`; reads hit per-user endpoints (so an external producer sees their own empty set, not the pitch's).
+- B3 substrate (097): `teams(owner_id, is_company_team, join_code, seat_limit)`, `team_members(team_id, user_id, role∈owner|editor|viewer|member)`.
+
+---
+
+## Target — two workstreams
+
+### A. NDA: producers only  ⚠ needs one confirm (see Decisions)
+
+- `signNDA`, `requestNDA`, `canRequestNDA`: gate to `userType === 'production'`. Creators/investors/watchers → `canRequest:false` / 403.
+- RBAC: tighten `Permission.NDA_SIGN` to production role only (today investors hold it).
+- Frontend: the "Request NDA Access" CTA shows only for production users; others see a "NDA access is for production companies" note instead of a dead button.
+
+### B. Production workspace: ONE canonical set per pitch
+
+| | Today | Target |
+|---|---|---|
+| Key | `(user_id, pitch_id)` | `(pitch_id)` — one canonical set; `author_id` on notes for attribution |
+| Edit | any producer + pitch-owner's members | **pitch owner + seated members of the pitch owner's company team** only |
+| View | per-user (sees own) | **the pitch's canonical set**, to: editors + NDA-signed producers (read-only) |
+
+- New authz helpers:
+  - `canEditPitchWorkspace(sql, userId, pitchId)` = `userId == pitch.user_id` OR member (`role IN ('owner','editor','member')`) of the team owned by `pitch.user_id`. (Drops the blanket "any production user".)
+  - `canViewPitchWorkspace(...)` = `canEdit` OR NDA-signed on the pitch.
+- Reads return the canonical set (`WHERE pitch_id = X`) to any viewer who passes `canView`.
+- Writes upsert `ON CONFLICT (pitch_id)` (checklist/team); notes insert `(pitch_id, author_id, …)`; gated by `canEdit`.
+
+---
+
+## Migration `098_canonical_production_workspace.sql` (Phase 1)
+
+Backward-compatible, Neon-branch first:
+1. `ALTER … ADD COLUMN author_id INT REFERENCES users(id)` on `production_notes`; backfill `author_id = user_id`.
+2. **Collapse to one row per pitch** for checklist/team: keep the **pitch owner's** row if present, else most-recently-updated; delete the rest (these were external producers' private evals, no longer a concept). Preserve deleted rows in a `*_archive` table (no hard loss — D3).
+3. For notes: **keep only notes authored by the pitch's team** (owner + its members); archive external-producer notes. (D3)
+4. Swap constraints: drop `UNIQUE(user_id,pitch_id)` → add `UNIQUE(pitch_id)` on checklist + team. Index `production_notes(pitch_id)`.
+5. Keep `user_id` one release (reversibility), drop later.
+
+## Handler changes (`production-pitch-data.ts`)
+
+- Replace `canWriteProductionData` with `canEditPitchWorkspace` (above) + add `canViewPitchWorkspace`.
+- 3 readers: gate on `canView`, scope `WHERE pitch_id` (drop `user_id`).
+- `createProductionNote`/`updateProductionChecklist`/`updateProductionTeam`: gate `canEdit`, key on `pitch_id`, `ON CONFLICT (pitch_id)`.
+- `deleteProductionNote`/`toggleNoteShared`: gate `canEdit`, scope `WHERE pitch_id` (any team member; D4).
+- `getCreatorPitchFeedback`: unchanged (creator sees `shared=true`).
+
+## Frontend changes (`ProductionPitchView.tsx`)
+
+- Compute `canEdit = isOwner || isCompanyMember`. Checklist `isOwner ? button : span` → `canEdit ? button : span`.
+- Team "Save Team Configuration" + Notes "Add Note": render only when `canEdit`; NDA-signed-only producers see the populated tabs **read-only** (the whole point of Karl's ask).
+- View gate stays `isOwner || hasSignedNDA || isCompanyMember`; reads now return the pitch's canonical set.
+- NDA CTA: production-only (workstream A).
+
+## Rollout (stop between phases)
+
+- **Phase 1 — DB:** migration `098` on a Neon branch → verify → prod.
+- **Phase 2 — Backend:** authz helpers + re-point 9 handlers + NDA producer gate. Deploy. Smoke: owner + a seated member co-edit one workspace; an NDA-signed external producer sees it read-only (no Save/Add); a non-NDA producer & non-producers blocked.
+- **Phase 3 — Frontend:** canEdit gating, read-only render for NDA viewers, NDA CTA. Build + deploy.
+- **Phase 4 — Cleanup:** drop `production_*.user_id`.
+
+## Decisions
+
+- **D-NDA — RESOLVED: investors + producers (no creators/watchers).** Turned out RBAC already enforced exactly this — `NDA_REQUEST`/`NDA_SIGN` are held only by INVESTOR + PRODUCTION; `requestNDA`/`signNDA` enforce them; creators have approve/reject (as owners) not sign. **Workstream A shipped** = one consistency fix in `canRequestNDA` (was watcher-only) so the can-request pre-check matches the enforcement and the UI stops offering a dead CTA to creators. Worker `a5adc372`. Verified live: creator `canRequest:false`, investor passes the role gate. No investor regression.
+- D1 canonical company team when a producer owns several `is_company_team` → lowest-id + one-time demote of extras. **(default)**
+- D2 auto-provision a company team for a producer who has none, on first edit. **(default: yes)**
+- D3 collapsed checklist/team/external notes → archived, not hard-deleted. **(default)**
+- D4 note delete → any team member. **(default)**
+- D5 NDA-signed viewers stay read-only (no edit). **(Karl's explicit ask — locked)**

--- a/frontend/src/portals/production/pages/ProductionPitchView.tsx
+++ b/frontend/src/portals/production/pages/ProductionPitchView.tsx
@@ -5,7 +5,7 @@ import {
   Shield, MessageSquare, Clock, Calendar, User, Tag,
   Film, DollarSign, Briefcase, TrendingUp, Users,
   FileText, Download, Calculator, MapPin, Camera,
-  Clapperboard, Settings, CheckSquare, Square,
+  Clapperboard, Settings,
   AlertCircle, CheckCircle, XCircle, Star, ChevronRight,
   Truck, Home, Globe, Mic, Edit3, Package, Upload, Sparkles, Heart
 } from 'lucide-react';
@@ -136,6 +136,29 @@ const ProductionPitchView: React.FC = () => {
   const canEditWorkspace = ownerIsProduction
     ? (isOwner || !!pitch?.isCompanyMember)
     : (authUser?.userType === 'production');
+
+  // --- Workspace access affordances (UI/UX) -------------------------------
+  // A quiet "who am I here" system shared across the Feasibility/Team/Notes
+  // tabs, so the edit-vs-view split reads as intentional rather than as a
+  // disabled form.
+  const accessChip = canEditWorkspace ? (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-indigo-50 px-2.5 py-1 text-xs font-semibold text-indigo-700 ring-1 ring-inset ring-indigo-200">
+      <Edit3 className="h-3.5 w-3.5" /> Editor
+    </span>
+  ) : (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-500 ring-1 ring-inset ring-slate-200">
+      <Eye className="h-3.5 w-3.5" /> View only
+    </span>
+  );
+  const workspaceScopeNote = ownerIsProduction
+    ? (canEditWorkspace ? 'Shared workspace — visible to your whole company team.' : 'Read-only access granted by your signed NDA.')
+    : 'Private workspace — only you can see these notes.';
+  const teamStatusMeta: Record<string, { label: string; cls: string }> = {
+    confirmed:   { label: 'Confirmed',   cls: 'bg-emerald-100 text-emerald-700 ring-emerald-200' },
+    considering: { label: 'Considering', cls: 'bg-amber-100 text-amber-700 ring-amber-200' },
+    pending:     { label: 'Open',        cls: 'bg-slate-100 text-slate-500 ring-slate-200' },
+  };
+
   const [isLiked, setIsLiked] = useState(false);
   const [isLiking, setIsLiking] = useState(false);
   const [autoFillLoading, setAutoFillLoading] = useState(false);
@@ -872,91 +895,115 @@ const ProductionPitchView: React.FC = () => {
 
                   {/* Production Checklist */}
                   <div className="flex items-center justify-between mb-4">
-                    <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">Production Checklist</h3>
-                    <span className="text-sm text-gray-500">{getChecklistProgress().toFixed(0)}% Complete</span>
+                    <div className="flex items-center gap-2.5">
+                      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-700">Production Checklist</h3>
+                      {accessChip}
+                    </div>
+                    <span className="text-sm font-medium text-gray-500">{getChecklistProgress().toFixed(0)}% Complete</span>
                   </div>
-                  <div className="grid grid-cols-2 gap-3">
-                    {Object.entries(productionChecklist).map(([key, value]) => (
-                      <div key={key} className="flex items-center">
-                        {canEditWorkspace ? (
-                          <button
-                            onClick={() => handleChecklistUpdate(key as keyof typeof productionChecklist)}
-                            className="mr-2"
-                          >
-                            {value ? (
-                              <CheckSquare className="h-5 w-5 text-green-600" />
-                            ) : (
-                              <Square className="h-5 w-5 text-gray-400" />
-                            )}
-                          </button>
-                        ) : (
-                          <span className="mr-2">
-                            {value ? (
-                              <CheckSquare className="h-5 w-5 text-green-600" />
-                            ) : (
-                              <Square className="h-5 w-5 text-gray-400" />
-                            )}
-                          </span>
-                        )}
-                        <label className="text-gray-700 capitalize">
-                          {key.replace(/([A-Z])/g, ' $1').trim()}
-                        </label>
-                      </div>
-                    ))}
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    {Object.entries(productionChecklist).map(([key, value]) => {
+                      const label = key.replace(/([A-Z])/g, ' $1').trim();
+                      const indicator = value ? (
+                        <CheckCircle className="h-5 w-5 shrink-0 text-emerald-500" />
+                      ) : (
+                        <span className="h-5 w-5 shrink-0 rounded-full ring-1 ring-inset ring-gray-300" />
+                      );
+                      const textCls = value ? 'font-medium text-gray-900' : 'text-gray-500';
+                      const boxCls = value
+                        ? 'border-emerald-200 bg-emerald-50/60'
+                        : 'border-gray-200 bg-gray-50/60';
+                      return canEditWorkspace ? (
+                        <button
+                          key={key}
+                          onClick={() => handleChecklistUpdate(key as keyof typeof productionChecklist)}
+                          className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 text-left transition hover:border-emerald-300 hover:bg-emerald-50/80 ${boxCls}`}
+                        >
+                          {indicator}
+                          <span className={`text-sm capitalize ${textCls}`}>{label}</span>
+                        </button>
+                      ) : (
+                        <div key={key} className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 ${boxCls}`}>
+                          {indicator}
+                          <span className={`text-sm capitalize ${textCls}`}>{label}</span>
+                        </div>
+                      );
+                    })}
                   </div>
                 </div>
               </div>
             )}
 
             {activeTab === 'team' && (isOwner || pitch?.hasSignedNDA || pitch?.isCompanyMember) && (
-              <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-8">
-                <div className="flex items-center justify-between mb-6">
-                  <div>
-                    <h2 className="text-2xl font-bold text-gray-900">Team Assembly</h2>
+              <div className="bg-white rounded-2xl shadow-sm ring-1 ring-gray-100 p-6 sm:p-8">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex items-center gap-2.5">
+                    <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 ring-1 ring-inset ring-indigo-100">
+                      <Users className="h-5 w-5" />
+                    </span>
+                    <h2 className="text-xl font-bold tracking-tight text-gray-900">Team Assembly</h2>
                   </div>
+                  {accessChip}
                 </div>
+                <p className="mt-1 mb-6 pl-[3.05rem] text-sm text-gray-500">{workspaceScopeNote}</p>
 
-                <div className="space-y-4">
-                  {teamMembers.map((member, index) => (
-                    <div key={index} className={`p-4 rounded-lg ${member.status === 'confirmed' && member.name ? 'bg-green-50 border border-green-200' : 'bg-gray-50'}`}>
-                      <div className="flex items-center space-x-4">
-                        <div className="flex-1">
-                          <label className="block text-sm font-medium text-gray-700 mb-1 flex items-center gap-2">
-                            {member.role}
-                            {member.status === 'confirmed' && member.name && (
-                              <span className="text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded-full">Confirmed</span>
-                            )}
-                          </label>
-                          <input
-                            type="text"
-                            value={member.name}
-                            onChange={(e) => handleTeamUpdate(index, 'name', e.target.value)}
-                            placeholder="Enter name"
-                            disabled={!canEditWorkspace}
-                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:bg-gray-100 disabled:text-gray-500"
-                          />
+                <div className="space-y-2.5">
+                  {teamMembers.map((member, index) => {
+                    const meta = teamStatusMeta[member.status] || teamStatusMeta.pending;
+                    const initials = member.name
+                      ? member.name.trim().split(/\s+/).map((w) => w[0]).slice(0, 2).join('').toUpperCase()
+                      : '';
+                    return (
+                      <div
+                        key={index}
+                        className={`flex items-center gap-4 rounded-xl border p-3.5 transition ${
+                          member.status === 'confirmed' && member.name
+                            ? 'border-emerald-200 bg-emerald-50/60'
+                            : 'border-gray-100 bg-gray-50/60'
+                        }`}
+                      >
+                        <span className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-semibold ${
+                          initials ? 'bg-indigo-600 text-white' : 'bg-gray-200 text-gray-400'
+                        }`}>
+                          {initials || <Users className="h-4 w-4" />}
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          <p className="text-[0.7rem] font-semibold uppercase tracking-wide text-gray-400">{member.role}</p>
+                          {canEditWorkspace ? (
+                            <input
+                              type="text"
+                              value={member.name}
+                              onChange={(e) => handleTeamUpdate(index, 'name', e.target.value)}
+                              placeholder="Add a name…"
+                              className="mt-0.5 w-full bg-transparent text-sm font-medium text-gray-900 placeholder:text-gray-400 placeholder:font-normal focus:outline-none"
+                            />
+                          ) : (
+                            <p className={`mt-0.5 text-sm font-medium ${member.name ? 'text-gray-900' : 'italic text-gray-400'}`}>
+                              {member.name || 'Unassigned'}
+                            </p>
+                          )}
                         </div>
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 mb-1">
-                            Status
-                          </label>
+                        {canEditWorkspace ? (
                           <select
                             value={member.status}
                             onChange={(e) => handleTeamUpdate(index, 'status', e.target.value)}
-                            disabled={!canEditWorkspace}
-                            className="px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:bg-gray-100 disabled:text-gray-500"
+                            className={`shrink-0 cursor-pointer appearance-none rounded-full border-0 px-3 py-1 text-xs font-semibold ring-1 ring-inset focus:outline-none focus:ring-2 focus:ring-indigo-400 ${meta.cls}`}
                           >
-                            <option value="pending">Pending</option>
+                            <option value="pending">Open</option>
                             <option value="considering">Considering</option>
                             <option value="confirmed">Confirmed</option>
                           </select>
-                        </div>
+                        ) : (
+                          <span className={`shrink-0 rounded-full px-3 py-1 text-xs font-semibold ring-1 ring-inset ${meta.cls}`}>
+                            {meta.label}
+                          </span>
+                        )}
                       </div>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
-                
-                {canEditWorkspace ? (
+
+                {canEditWorkspace && (
                   <button
                     onClick={async () => {
                       try {
@@ -967,20 +1014,27 @@ const ProductionPitchView: React.FC = () => {
                         toast.error(e.message);
                       }
                     }}
-                    className="mt-4 w-full px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
+                    className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700"
                   >
-                    Save Team Configuration
+                    <CheckCircle className="h-4 w-4" /> Save Team Configuration
                   </button>
-                ) : (
-                  <p className="mt-4 text-sm text-gray-400 text-center">View-only — your NDA grants read access to this team.</p>
                 )}
               </div>
             )}
 
             {activeTab === 'notes' && (isOwner || pitch?.hasSignedNDA || pitch?.isCompanyMember) && (
-              <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-8">
-                <h2 className="text-2xl font-bold text-gray-900 mb-6">Production Notes</h2>
-                
+              <div className="bg-white rounded-2xl shadow-sm ring-1 ring-gray-100 p-6 sm:p-8">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex items-center gap-2.5">
+                    <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 ring-1 ring-inset ring-indigo-100">
+                      <FileText className="h-5 w-5" />
+                    </span>
+                    <h2 className="text-xl font-bold tracking-tight text-gray-900">Production Notes</h2>
+                  </div>
+                  {accessChip}
+                </div>
+                <p className="mt-1 mb-6 pl-[3.05rem] text-sm text-gray-500">{workspaceScopeNote}</p>
+
                 {/* Add Note Form — editors only (owner + company members). NDA
                     viewers see the notes list below, read-only. */}
                 {canEditWorkspace && (

--- a/frontend/src/portals/production/pages/ProductionPitchView.tsx
+++ b/frontend/src/portals/production/pages/ProductionPitchView.tsx
@@ -54,6 +54,9 @@ interface Pitch {
   updatedAt: string;
   hasSignedNDA?: boolean;
   isCompanyMember?: boolean;
+  creatorType?: string;            // owner's user_type — selects workspace mode
+  creator_type?: string;           // snake-case as returned by getPitch
+  creator?: { id?: number; name?: string; userType?: string };
   ndaCount?: number;
   thumbnail?: string;
   pitchDeck?: string;
@@ -124,6 +127,15 @@ const ProductionPitchView: React.FC = () => {
   ]);
 
   const isOwner = !!(pitch?.userId && authUser?.id && String(pitch.userId) === String(authUser.id));
+  // Hybrid production workspace (Karl option B), mirrors the backend's resolveWorkspace:
+  //  • production-OWNED pitch → owner + seated company members edit the one
+  //    canonical workspace; NDA-signed producers VIEW read-only.
+  //  • creator-OWNED pitch → any production user edits their OWN private workspace.
+  const ownerIsProduction =
+    (pitch?.creatorType || pitch?.creator_type || pitch?.creator?.userType) === 'production';
+  const canEditWorkspace = ownerIsProduction
+    ? (isOwner || !!pitch?.isCompanyMember)
+    : (authUser?.userType === 'production');
   const [isLiked, setIsLiked] = useState(false);
   const [isLiking, setIsLiking] = useState(false);
   const [autoFillLoading, setAutoFillLoading] = useState(false);
@@ -866,7 +878,7 @@ const ProductionPitchView: React.FC = () => {
                   <div className="grid grid-cols-2 gap-3">
                     {Object.entries(productionChecklist).map(([key, value]) => (
                       <div key={key} className="flex items-center">
-                        {isOwner ? (
+                        {canEditWorkspace ? (
                           <button
                             onClick={() => handleChecklistUpdate(key as keyof typeof productionChecklist)}
                             className="mr-2"
@@ -920,7 +932,8 @@ const ProductionPitchView: React.FC = () => {
                             value={member.name}
                             onChange={(e) => handleTeamUpdate(index, 'name', e.target.value)}
                             placeholder="Enter name"
-                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                            disabled={!canEditWorkspace}
+                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:bg-gray-100 disabled:text-gray-500"
                           />
                         </div>
                         <div>
@@ -930,7 +943,8 @@ const ProductionPitchView: React.FC = () => {
                           <select
                             value={member.status}
                             onChange={(e) => handleTeamUpdate(index, 'status', e.target.value)}
-                            className="px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                            disabled={!canEditWorkspace}
+                            className="px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:bg-gray-100 disabled:text-gray-500"
                           >
                             <option value="pending">Pending</option>
                             <option value="considering">Considering</option>
@@ -942,20 +956,24 @@ const ProductionPitchView: React.FC = () => {
                   ))}
                 </div>
                 
-                <button
-                  onClick={async () => {
-                    try {
-                      await ProductionService.updatePitchTeam(parseInt(id!, 10), teamMembers);
-                      toast.success('Team configuration saved');
-                    } catch (err) {
-                      const e = err instanceof Error ? err : new Error(String(err));
-                      toast.error(e.message);
-                    }
-                  }}
-                  className="mt-4 w-full px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
-                >
-                  Save Team Configuration
-                </button>
+                {canEditWorkspace ? (
+                  <button
+                    onClick={async () => {
+                      try {
+                        await ProductionService.updatePitchTeam(parseInt(id!, 10), teamMembers);
+                        toast.success('Team configuration saved');
+                      } catch (err) {
+                        const e = err instanceof Error ? err : new Error(String(err));
+                        toast.error(e.message);
+                      }
+                    }}
+                    className="mt-4 w-full px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
+                  >
+                    Save Team Configuration
+                  </button>
+                ) : (
+                  <p className="mt-4 text-sm text-gray-400 text-center">View-only — your NDA grants read access to this team.</p>
+                )}
               </div>
             )}
 
@@ -963,7 +981,9 @@ const ProductionPitchView: React.FC = () => {
               <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-8">
                 <h2 className="text-2xl font-bold text-gray-900 mb-6">Production Notes</h2>
                 
-                {/* Add Note Form */}
+                {/* Add Note Form — editors only (owner + company members). NDA
+                    viewers see the notes list below, read-only. */}
+                {canEditWorkspace && (
                 <div className="mb-6 p-4 bg-gray-50 rounded-lg">
                   <div className="flex space-x-2 mb-3">
                     {(['casting', 'location', 'budget', 'schedule', 'team', 'general'] as const).map((cat) => (
@@ -994,6 +1014,7 @@ const ProductionPitchView: React.FC = () => {
                     Add Note
                   </button>
                 </div>
+                )}
 
                 {/* Notes List */}
                 <div className="space-y-3">
@@ -1010,6 +1031,7 @@ const ProductionPitchView: React.FC = () => {
                               </p>
                             </div>
                           </div>
+                          {canEditWorkspace ? (
                           <div className="flex items-center gap-2 flex-shrink-0 ml-2">
                             <button
                               onClick={() => handleToggleShare(note.id)}
@@ -1030,6 +1052,11 @@ const ProductionPitchView: React.FC = () => {
                               <XCircle className="h-4 w-4" />
                             </button>
                           </div>
+                          ) : note.shared ? (
+                            <span className="flex items-center gap-1 px-2 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700 flex-shrink-0 ml-2">
+                              <Share2 className="h-3 w-3" /> Shared
+                            </span>
+                          ) : null}
                         </div>
                       </div>
                     ))

--- a/src/db/migrations/098_canonical_production_workspace.sql
+++ b/src/db/migrations/098_canonical_production_workspace.sql
@@ -1,0 +1,16 @@
+-- 098_canonical_production_workspace.sql
+--
+-- Hybrid production workspace (Karl-aligned, option B). ADDITIVE ONLY — no data
+-- is moved, collapsed, or deleted; the existing (user_id, pitch_id) schema
+-- already supports both modes, and the handlers resolve which user_id to target:
+--
+--   • Production-OWNED pitch  → ONE canonical workspace, keyed on the pitch
+--     owner's user_id. The owner + seated B3 team members read/write that single
+--     row (checklist/team) and the team's notes; NDA-signed producers view it
+--     read-only. (Handler-enforced — see src/handlers/production-pitch-data.ts.)
+--   • Creator-OWNED pitch     → per-producer PRIVATE workspace (unchanged): each
+--     evaluating production user keeps their own notes/checklist/team.
+--
+-- This index speeds the new "all team notes for a pitch" read used on
+-- production-owned pitches (WHERE pitch_id = $1 AND user_id = ANY(team)).
+CREATE INDEX IF NOT EXISTS idx_production_notes_pitch ON production_notes(pitch_id);

--- a/src/handlers/production-pitch-data.ts
+++ b/src/handlers/production-pitch-data.ts
@@ -29,27 +29,81 @@ function extractPitchId(request: Request): number {
 }
 
 /**
- * S2 authorization gate. Production notes/checklist/team are production-side
- * tools, but the write handlers keyed only on the requester's user_id — so ANY
- * authenticated user could write production data onto ANY pitchId (live evidence:
- * a creator wrote a note on a production-owned pitch). The writer must be either a
- * production user (evaluating a pitch) or a seated B3 company member of the pitch
- * owner's company.
+ * Hybrid production workspace resolution (Karl-aligned, option B).
+ *
+ * - Production-OWNED pitch: ONE canonical workspace keyed on the pitch owner's
+ *   user_id. The owner + seated B3 team members (role owner|editor|member of the
+ *   team owned by the pitch owner) co-edit it; NDA-signed producers VIEW it
+ *   read-only.
+ * - Creator-OWNED pitch: per-producer PRIVATE workspace keyed on the acting
+ *   user — each evaluating production user keeps their own (unchanged behavior).
+ *
+ * Returns null if the pitch doesn't exist. `workspaceUserId` is the row key for
+ * the single-blob checklist/team; `teamUserIds` scopes note reads on production
+ * pitches so external producers' historical private notes never leak.
  */
-async function canWriteProductionData(sql: any, userId: number, pitchId: number): Promise<boolean> {
+interface WorkspaceCtx {
+  ownerId: number;
+  isProductionPitch: boolean;
+  workspaceUserId: number;
+  teamUserIds: number[];
+  canEdit: boolean;
+  canView: boolean;
+}
+
+/** Defensive "has this user signed/been-granted an NDA on this pitch" — tolerant
+ *  of the signer_id / requester_id / pitch_access schema drift (see CLAUDE.md). */
+async function hasSignedNda(sql: any, userId: number, pitchId: number): Promise<boolean> {
   try {
-    const [me] = await sql`SELECT user_type FROM users WHERE id = ${userId}`;
-    if (me?.user_type === 'production') return true;
-    const member = await sql`
-      SELECT 1 FROM team_members tm
-      JOIN teams t ON t.id = tm.team_id
-      JOIN pitches p ON p.user_id = t.owner_id
-      WHERE p.id = ${pitchId} AND tm.user_id = ${userId} AND tm.role = 'member'
-      LIMIT 1`;
-    return member.length > 0;
-  } catch {
-    return false;
+    const r = await sql`SELECT 1 FROM ndas WHERE pitch_id = ${pitchId} AND signer_id = ${userId} AND (status = 'approved' OR status = 'signed') LIMIT 1`;
+    if (r.length > 0) return true;
+  } catch { /* signer_id may not exist in older envs */ }
+  try {
+    const r = await sql`SELECT 1 FROM ndas WHERE pitch_id = ${pitchId} AND requester_id = ${userId} AND (status = 'approved' OR status = 'signed') LIMIT 1`;
+    if (r.length > 0) return true;
+  } catch { /* requester_id fallback */ }
+  try {
+    const r = await sql`SELECT 1 FROM pitch_access WHERE pitch_id = ${pitchId} AND user_id = ${userId} LIMIT 1`;
+    if (r.length > 0) return true;
+  } catch { /* pitch_access may not exist */ }
+  return false;
+}
+
+async function resolveWorkspace(sql: any, actingUserId: number, pitchId: number): Promise<WorkspaceCtx | null> {
+  let owner: any;
+  try {
+    [owner] = await sql`
+      SELECT p.user_id AS owner_id, u.user_type AS owner_type
+      FROM pitches p JOIN users u ON u.id = p.user_id
+      WHERE p.id = ${pitchId} LIMIT 1`;
+  } catch { return null; }
+  if (!owner) return null;
+
+  const ownerId = Number(owner.owner_id);
+  const isProductionPitch = owner.owner_type === 'production';
+
+  let myType: string | undefined;
+  try { const [me] = await sql`SELECT user_type FROM users WHERE id = ${actingUserId}`; myType = me?.user_type; } catch { /* default below */ }
+
+  if (isProductionPitch) {
+    let teamUserIds = [ownerId];
+    try {
+      const members = await sql`
+        SELECT tm.user_id FROM team_members tm JOIN teams t ON t.id = tm.team_id
+        WHERE t.owner_id = ${ownerId} AND tm.role IN ('owner','editor','member')`;
+      teamUserIds = [ownerId, ...members.map((m: any) => Number(m.user_id))];
+    } catch { /* team_members drift — owner-only */ }
+    const isTeam = teamUserIds.includes(actingUserId);
+    let canView = isTeam;
+    if (!canView && myType === 'production') {
+      canView = await hasSignedNda(sql, actingUserId, pitchId); // NDA producer → read-only
+    }
+    return { ownerId, isProductionPitch, workspaceUserId: ownerId, teamUserIds, canEdit: isTeam, canView };
   }
+
+  // Creator-owned pitch — private per-producer workspace.
+  const canEdit = myType === 'production';
+  return { ownerId, isProductionPitch, workspaceUserId: actingUserId, teamUserIds: [actingUserId], canEdit, canView: canEdit };
 }
 
 // ---------------------------------------------------------------------------
@@ -71,12 +125,24 @@ export async function getProductionNotes(request: Request, env: Env): Promise<Re
   if (!sql) return jsonResponse({ success: true, data: { notes: [] } }, origin);
 
   try {
-    const notesResult = await safeQuery(() => sql`
-      SELECT id, content, category, author, shared, created_at, updated_at
-      FROM production_notes
-      WHERE user_id = ${Number(userId)} AND pitch_id = ${pitchId}
-      ORDER BY created_at ASC
-    `, { fallback: [], context: 'production-pitch-data.notes.list' });
+    const ws = await resolveWorkspace(sql, Number(userId), pitchId);
+    if (!ws || !ws.canView) return jsonResponse({ success: true, data: { notes: [] } }, origin);
+
+    // Production pitch → the team's shared notes (scoped to team authors so
+    // external producers' private notes never leak). Creator pitch → my own.
+    const notesResult = ws.isProductionPitch
+      ? await safeQuery(() => sql`
+          SELECT id, content, category, author, shared, user_id, created_at, updated_at
+          FROM production_notes
+          WHERE pitch_id = ${pitchId} AND user_id = ANY(${ws.teamUserIds})
+          ORDER BY created_at ASC
+        `, { fallback: [], context: 'production-pitch-data.notes.list' })
+      : await safeQuery(() => sql`
+          SELECT id, content, category, author, shared, user_id, created_at, updated_at
+          FROM production_notes
+          WHERE pitch_id = ${pitchId} AND user_id = ${Number(userId)}
+          ORDER BY created_at ASC
+        `, { fallback: [], context: 'production-pitch-data.notes.list' });
 
     return jsonResponse({ success: true, data: { notes: notesResult.rows } }, origin);
   } catch (err) {
@@ -100,7 +166,8 @@ export async function createProductionNote(request: Request, env: Env): Promise<
   const sql = getDb(env);
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
-  if (!(await canWriteProductionData(sql, Number(userId), pitchId))) {
+  const ws = await resolveWorkspace(sql, Number(userId), pitchId);
+  if (!ws || !ws.canEdit) {
     return errorResponse('Not authorized to add production notes to this pitch', origin, 403);
   }
 
@@ -144,18 +211,28 @@ export async function deleteProductionNote(request: Request, env: Env): Promise<
   const url = new URL(request.url);
   const parts = url.pathname.split('/');
   // /api/production/pitches/:pitchId/notes/:noteId
+  const pitchId = parseInt(parts[4] || '0', 10);
   const noteId = parseInt(parts[6] || '0', 10);
   if (!noteId) return errorResponse('Invalid note ID', origin);
 
   const sql = getDb(env);
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
+  const ws = await resolveWorkspace(sql, Number(userId), pitchId);
+  if (!ws || !ws.canEdit) return errorResponse('Not authorized to delete this note', origin, 403);
+
   try {
-    const result = await sql`
-      DELETE FROM production_notes
-      WHERE id = ${noteId} AND user_id = ${Number(userId)}
-      RETURNING id
-    `;
+    // Production pitch → any team member may delete a team note (D4). Creator
+    // pitch → only your own private note.
+    const result = ws.isProductionPitch
+      ? await sql`
+          DELETE FROM production_notes
+          WHERE id = ${noteId} AND pitch_id = ${pitchId} AND user_id = ANY(${ws.teamUserIds})
+          RETURNING id`
+      : await sql`
+          DELETE FROM production_notes
+          WHERE id = ${noteId} AND pitch_id = ${pitchId} AND user_id = ${Number(userId)}
+          RETURNING id`;
 
     if (result.length === 0) {
       return errorResponse('Note not found', origin, 404);
@@ -188,9 +265,12 @@ export async function getProductionChecklist(request: Request, env: Env): Promis
   if (!sql) return jsonResponse({ success: true, data: { checklist: {} } }, origin);
 
   try {
+    const ws = await resolveWorkspace(sql, Number(userId), pitchId);
+    if (!ws || !ws.canView) return jsonResponse({ success: true, data: { checklist: {} } }, origin);
+
     const result = await safeQuery<{ checklist: Record<string, unknown> }>(() => sql`
       SELECT checklist FROM production_checklists
-      WHERE user_id = ${Number(userId)} AND pitch_id = ${pitchId}
+      WHERE user_id = ${ws.workspaceUserId} AND pitch_id = ${pitchId}
     `, { fallback: [], context: 'production-pitch-data.checklist.read' });
 
     const checklist = result.rows.length > 0 ? result.rows[0].checklist : {};
@@ -216,7 +296,8 @@ export async function updateProductionChecklist(request: Request, env: Env): Pro
   const sql = getDb(env);
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
-  if (!(await canWriteProductionData(sql, Number(userId), pitchId))) {
+  const ws = await resolveWorkspace(sql, Number(userId), pitchId);
+  if (!ws || !ws.canEdit) {
     return errorResponse('Not authorized to update production data on this pitch', origin, 403);
   }
 
@@ -229,9 +310,11 @@ export async function updateProductionChecklist(request: Request, env: Env): Pro
 
     const checklistJson = JSON.stringify(checklist);
 
+    // Production pitch → members write the owner's canonical row
+    // (workspaceUserId = ownerId). Creator pitch → my own private row.
     await sql`
       INSERT INTO production_checklists (user_id, pitch_id, checklist)
-      VALUES (${Number(userId)}, ${pitchId}, ${checklistJson}::jsonb)
+      VALUES (${ws.workspaceUserId}, ${pitchId}, ${checklistJson}::jsonb)
       ON CONFLICT (user_id, pitch_id)
       DO UPDATE SET checklist = ${checklistJson}::jsonb, updated_at = NOW()
     `;
@@ -263,9 +346,12 @@ export async function getProductionTeam(request: Request, env: Env): Promise<Res
   if (!sql) return jsonResponse({ success: true, data: { team: [] } }, origin);
 
   try {
+    const ws = await resolveWorkspace(sql, Number(userId), pitchId);
+    if (!ws || !ws.canView) return jsonResponse({ success: true, data: { team: [] } }, origin);
+
     const result = await safeQuery<{ team: unknown[] }>(() => sql`
       SELECT team FROM production_team_assignments
-      WHERE user_id = ${Number(userId)} AND pitch_id = ${pitchId}
+      WHERE user_id = ${ws.workspaceUserId} AND pitch_id = ${pitchId}
     `, { fallback: [], context: 'production-pitch-data.team.read' });
 
     const team = result.rows.length > 0 ? result.rows[0].team : [];
@@ -291,7 +377,8 @@ export async function updateProductionTeam(request: Request, env: Env): Promise<
   const sql = getDb(env);
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
-  if (!(await canWriteProductionData(sql, Number(userId), pitchId))) {
+  const ws = await resolveWorkspace(sql, Number(userId), pitchId);
+  if (!ws || !ws.canEdit) {
     return errorResponse('Not authorized to update production data on this pitch', origin, 403);
   }
 
@@ -304,9 +391,10 @@ export async function updateProductionTeam(request: Request, env: Env): Promise<
 
     const teamJson = JSON.stringify(team);
 
+    // Production pitch → owner's canonical row; creator pitch → my private row.
     await sql`
       INSERT INTO production_team_assignments (user_id, pitch_id, team)
-      VALUES (${Number(userId)}, ${pitchId}, ${teamJson}::jsonb)
+      VALUES (${ws.workspaceUserId}, ${pitchId}, ${teamJson}::jsonb)
       ON CONFLICT (user_id, pitch_id)
       DO UPDATE SET team = ${teamJson}::jsonb, updated_at = NOW()
     `;
@@ -334,22 +422,30 @@ export async function toggleNoteShared(request: Request, env: Env): Promise<Resp
 
   const url = new URL(request.url);
   const parts = url.pathname.split('/');
+  const pitchId = parseInt(parts[4] || '0', 10);
   const noteId = parseInt(parts[6] || '0', 10);
   if (!noteId) return errorResponse('Invalid note ID', origin);
 
   const sql = getDb(env);
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
+  const ws = await resolveWorkspace(sql, Number(userId), pitchId);
+  if (!ws || !ws.canEdit) return errorResponse('Not authorized to share this note', origin, 403);
+
   try {
     const body = await request.json() as Record<string, unknown>;
     const shared = body.shared === true;
 
-    const result = await sql`
-      UPDATE production_notes
-      SET shared = ${shared}, updated_at = NOW()
-      WHERE id = ${noteId} AND user_id = ${Number(userId)}
-      RETURNING id, shared
-    `;
+    // Production pitch → any team note; creator pitch → my own note.
+    const result = ws.isProductionPitch
+      ? await sql`
+          UPDATE production_notes SET shared = ${shared}, updated_at = NOW()
+          WHERE id = ${noteId} AND pitch_id = ${pitchId} AND user_id = ANY(${ws.teamUserIds})
+          RETURNING id, shared`
+      : await sql`
+          UPDATE production_notes SET shared = ${shared}, updated_at = NOW()
+          WHERE id = ${noteId} AND pitch_id = ${pitchId} AND user_id = ${Number(userId)}
+          RETURNING id, shared`;
 
     if (result.length === 0) {
       return errorResponse('Note not found', origin, 404);

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -8621,11 +8621,19 @@ pitchey_analytics_datapoints_per_minute 1250
     const authResult = await this.requireAuth(request);
     if (!authResult.authorized) return authResult.response!;
 
-    // Watchers cannot request NDAs
-    if (authResult.user?.userType === 'watcher') {
+    // NDA access is for evaluators only: investors + production companies hold
+    // NDA_REQUEST/NDA_SIGN (rbac.service.ts). Creators OWN pitches — they approve
+    // or reject NDA requests, they don't request access — and watchers are
+    // audience-only. requestNDA already 403s these via Permission.NDA_REQUEST;
+    // this keeps the can-request pre-check consistent so the UI never shows a
+    // dead "Request NDA Access" CTA to a creator/watcher.
+    const ndaRole = authResult.user?.userType;
+    if (ndaRole !== 'investor' && ndaRole !== 'production') {
       return builder.success({
         canRequest: false,
-        reason: 'Watchers cannot sign NDAs. Upgrade your account to request NDA access.',
+        reason: ndaRole === 'creator'
+          ? 'Creators own pitches and review NDA requests — they don\'t request access themselves.'
+          : 'NDA access is available to investors and production companies.',
         existingNDA: null
       });
     }


### PR DESCRIPTION
Karl-aligned production workspace rework. **Already deployed to prod** (worker `9f17d763`, frontend `index-BDhCfHpM.js`, migration `098` applied) — this PR lands it on main.

## A — NDA gating (`7a2a0213`)
Only **investors + production** can request/sign NDAs (creators/watchers blocked). RBAC already enforced this; the fix was `canRequestNDA` (was watcher-only) so the UI stops offering a dead "Request NDA" CTA to creators.

## B — Hybrid per-pitch workspace (`199f34de` backend, `01bf6f1a` frontend)
The Feasibility/Team/Notes tabs, reworked. **No destructive migration** — the existing `(user_id, pitch_id)` schema supports both modes; `resolveWorkspace()` picks the row key.

| | Production-OWNED pitch | Creator-OWNED pitch |
|---|---|---|
| Workspace | ONE canonical set (owner's row) | private per-producer |
| Edit | owner + seated B3 members | the producer (own) |
| View | editors + NDA-signed producers (read-only) | just that producer |

- `resolveWorkspace()` + drift-tolerant `hasSignedNda()` replace the old blanket "any producer can write". All 9 handlers gate reads on `canView`, writes on `canEdit`. Production-pitch notes are scoped to team authors (`user_id = ANY(team)`) so external producers' old private notes never leak.
- Migration `098`: a single additive `idx_production_notes_pitch` (applied + recorded).

## UI/UX pass (`0a0fa8fa`)
Refined elevation on the indigo system (not a reskin):
- **Editor** (indigo) / **View only** (slate) access chip + scope note on each workspace tab.
- **Team** → premium roster cards (initials avatar, role, inline name, status-as-pill); viewers get a clean read-only roster, not greyed inputs.
- **Feasibility** checklist → emerald-check / hollow-ring toggle chips.

## Verified live
Pitch 229 (creator-owned) as a production user: Team tab shows the **Editor** chip + **"Private workspace — only you can see these notes"** (correct private lane); checklist write persists; reads/writes 200; health green. Frontend tsc + build clean; worker dry-run clean; catch-swallow gate 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)