### PR TITLE
feat(b3): creator entry point to the shared workspace + auto-collaborators

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -567,8 +567,12 @@ function App() {
           } />
           {/* Production Pitch View — outside PortalLayout (full-width, no sidebar) */}
           <Route path="/production/pitch/:id" element={
-            isAuthenticated && userType === 'production' ? <ProductionPitchView /> :
-            <Navigate to="/login/production" />
+            // Any authenticated user may open it (B3: seated creator members need
+            // to reach the shared workspace). Access to Team/Notes/Feasibility is
+            // gated INSIDE the view by isOwner || isCompanyMember || hasSignedNDA;
+            // non-entitled users just see the public overview.
+            isAuthenticated ? <ProductionPitchView /> :
+            <Navigate to="/login" />
           } />
 
           {/* Production Portal Routes - with profile guard + PortalLayout */}

--- a/frontend/src/features/teams/components/CreatorCollaborations.tsx
+++ b/frontend/src/features/teams/components/CreatorCollaborations.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Building2, FileText, ArrowRight } from 'lucide-react';
+import apiClient from '../../../lib/api-client';
+
+interface CollabPitch {
+  id: number;
+  title: string;
+  poster: string | null;
+  genre: string | null;
+  format: string | null;
+  status: string | null;
+}
+interface Company {
+  teamId: number;
+  name: string;
+  company: string;
+  ownerId: number;
+  pitches: CollabPitch[];
+}
+
+/**
+ * Creator-side entry point for B3: the production companies you've joined (via a
+ * code) and their projects. Clicking a project opens its shared workspace
+ * (Team/Notes/Feasibility) — without this, the join code led nowhere for creators.
+ * Renders nothing until you've joined at least one company.
+ */
+export function CreatorCollaborations() {
+  const [companies, setCompanies] = useState<Company[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    let live = true;
+    (async () => {
+      try {
+        const res: any = await apiClient.get('/api/creator/companies');
+        if (!live) return;
+        const data = res?.data ?? res;
+        setCompanies(Array.isArray(data?.companies) ? data.companies : []);
+      } catch {
+        /* degrade quietly */
+      } finally {
+        if (live) setLoaded(true);
+      }
+    })();
+    return () => { live = false; };
+  }, []);
+
+  if (!loaded || companies.length === 0) return null;
+
+  return (
+    <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-gray-100">
+      <div className="mb-1 flex items-center gap-2.5">
+        <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-purple-50 text-purple-600 ring-1 ring-inset ring-purple-100">
+          <Building2 className="h-5 w-5" />
+        </span>
+        <h3 className="text-lg font-semibold text-gray-900">Collaborating With</h3>
+      </div>
+      <p className="mb-5 pl-[3.05rem] text-sm text-gray-500">
+        Production companies you've joined — open a project to co-build its Team, Notes &amp; Feasibility.
+      </p>
+
+      <div className="space-y-5">
+        {companies.map((c) => (
+          <div key={c.teamId}>
+            <div className="mb-2 flex items-center justify-between">
+              <p className="text-sm font-semibold text-gray-800">{c.company}</p>
+              <span className="text-xs text-gray-400">{c.pitches.length} project{c.pitches.length === 1 ? '' : 's'}</span>
+            </div>
+            {c.pitches.length === 0 ? (
+              <p className="rounded-lg border border-dashed border-gray-200 bg-gray-50/60 px-3 py-3 text-xs text-gray-400">
+                No projects yet — they'll appear here when {c.company} adds pitches.
+              </p>
+            ) : (
+              <div className="grid gap-2 sm:grid-cols-2">
+                {c.pitches.map((p) => (
+                  <button
+                    key={p.id}
+                    onClick={() => navigate(`/production/pitch/${p.id}`)}
+                    className="group flex items-center gap-3 rounded-xl border border-gray-100 bg-white p-2.5 text-left transition hover:border-purple-200 hover:shadow-sm"
+                  >
+                    {p.poster ? (
+                      <img src={p.poster} alt="" className="h-10 w-10 shrink-0 rounded-lg object-cover" />
+                    ) : (
+                      <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-purple-50 text-purple-400">
+                        <FileText className="h-5 w-5" />
+                      </span>
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium text-gray-900">{p.title || 'Untitled'}</p>
+                      <p className="truncate text-xs text-gray-400">{[p.format, p.genre].filter(Boolean).join(' · ') || '—'}</p>
+                    </div>
+                    <ArrowRight className="h-4 w-4 shrink-0 text-gray-300 transition group-hover:text-purple-500" />
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/CreatorDashboard.tsx
+++ b/frontend/src/pages/CreatorDashboard.tsx
@@ -13,6 +13,7 @@ import { getSubscriptionTier } from '../config/subscription-plans';
 import { InvestmentService } from '@features/deals/services/investment.service';
 import FundingOverview from '@features/deals/components/Investment/FundingOverview';
 import { JoinCompanyCard } from '@features/teams/components/CompanyTeamCards';
+import { CreatorCollaborations } from '@features/teams/components/CreatorCollaborations';
 // Analytics embedded view removed — users navigate to /creator/analytics instead
 import { withPortalErrorBoundary } from '../components/ErrorBoundary/PortalErrorBoundary';
 import { useSentryPortal } from '@/shared/hooks/useSentryPortal';
@@ -484,8 +485,10 @@ function CreatorDashboard() {
       {showShareModal && <ShareLinksModal onClose={() => setShowShareModal(false)} />}
 
       {/* B3: creators redeem a production company's join code to collaborate */}
-      <div className="mb-8">
+      <div className="mb-8 space-y-6">
         <JoinCompanyCard />
+        {/* …and reach the projects of companies they've already joined */}
+        <CreatorCollaborations />
       </div>
 
       {/* ===== MY PITCHES + NDA QUICK STATUS ===== */}

--- a/frontend/src/portals/production/pages/ProductionPitchView.tsx
+++ b/frontend/src/portals/production/pages/ProductionPitchView.tsx
@@ -101,6 +101,7 @@ const ProductionPitchView: React.FC = () => {
   const [activeTab, setActiveTab] = useState<'overview' | 'production' | 'team' | 'notes'>('overview');
   const [isShortlisted, setIsShortlisted] = useState(false);
   const [savedPitchId, setSavedPitchId] = useState<number | null>(null);
+  const [collaborators, setCollaborators] = useState<{ name: string; userType: string; role: string }[]>([]);
   const [notes, setNotes] = useState<ProductionNote[]>([]);
   const [newNote, setNewNote] = useState('');
   const [noteCategory, setNoteCategory] = useState<ProductionNote['category']>('general');
@@ -179,6 +180,22 @@ const ProductionPitchView: React.FC = () => {
     }
   }, [pitch, productionChecklist, teamMembers]);
 
+  // Auto-list the workspace collaborators (owner + creators who joined via the
+  // company code). Surfaces "who's on this team" without manual entry — distinct
+  // from the manually-curated creative roster below.
+  useEffect(() => {
+    if (!id) return;
+    let live = true;
+    apiClient.get<any>(`/api/production/pitches/${id}/collaborators`)
+      .then((res: any) => {
+        if (!live) return;
+        const d = res?.data ?? res;
+        setCollaborators(Array.isArray(d?.collaborators) ? d.collaborators : []);
+      })
+      .catch(() => { /* degrade quietly */ });
+    return () => { live = false; };
+  }, [id]);
+
   const fetchPitchData = async () => {
     try {
       setLoading(true);
@@ -190,12 +207,13 @@ const ProductionPitchView: React.FC = () => {
         // First try the public endpoint which always works
         response = await pitchAPI.getPublicById(parseInt(id!));
         
-        // For any authenticated production user, fetch the authenticated record so
-        // owner/like state (isLiked) and NDA-gated content paint. Previously this was
-        // gated on response.hasSignedNDA, but the PUBLIC endpoint never emits that flag —
-        // so the upgrade never ran: owners saw no like-state and the heart never filled.
-        // The backend getById enforces access itself; a 403 falls back to public data.
-        if (isAuthenticated && authUser?.userType === 'production') {
+        // For ANY authenticated user, fetch the authenticated record so owner/like
+        // state (isLiked), hasSignedNDA, AND isCompanyMember paint — the public
+        // endpoint emits none of those. This was previously gated to production
+        // users, which locked the Team/Notes tabs for seated creator members (B3)
+        // because isCompanyMember never reached the client. The backend getById
+        // enforces access itself; a 403 falls back to public data.
+        if (isAuthenticated) {
           try {
             const fullResponse = await pitchAPI.getById(parseInt(id!));
             response = fullResponse; // Use the full data if available
@@ -673,7 +691,11 @@ const ProductionPitchView: React.FC = () => {
               <div className="flex border-b">
                 {['overview', 'production', 'team', 'notes'].map((tab) => {
                   const ndaRequired = tab === 'team' || tab === 'notes';
-                  const locked = ndaRequired && !isOwner && !pitch?.hasSignedNDA;
+                  // Seated company members (B3) reach Team/Notes without an NDA —
+                  // matches the tab-content gate (isOwner || hasSignedNDA ||
+                  // isCompanyMember). Without isCompanyMember here the tab button
+                  // stayed locked for members even though the content would render.
+                  const locked = ndaRequired && !isOwner && !pitch?.hasSignedNDA && !pitch?.isCompanyMember;
                   return (
                     <button
                       key={tab}
@@ -945,8 +967,32 @@ const ProductionPitchView: React.FC = () => {
                   </div>
                   {accessChip}
                 </div>
-                <p className="mt-1 mb-6 pl-[3.05rem] text-sm text-gray-500">{workspaceScopeNote}</p>
+                <p className="mt-1 mb-5 pl-[3.05rem] text-sm text-gray-500">{workspaceScopeNote}</p>
 
+                {/* Collaborators — auto-populated from the company join codes
+                    (owner + creators who redeemed a code). NOT the creative roster
+                    below; nobody types these in. */}
+                {collaborators.length > 0 && (
+                  <div className="mb-6 rounded-xl bg-indigo-50/40 p-3.5 ring-1 ring-inset ring-indigo-100">
+                    <p className="mb-2 text-[0.68rem] font-semibold uppercase tracking-wide text-indigo-500">
+                      Collaborators · auto-added when they join your company code
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {collaborators.map((c, i) => {
+                        const initials = (c.name || '?').trim().split(/\s+/).map((w) => w[0]).slice(0, 2).join('').toUpperCase();
+                        return (
+                          <span key={i} className="inline-flex items-center gap-1.5 rounded-full bg-white px-2.5 py-1 text-xs font-medium text-gray-700 ring-1 ring-inset ring-gray-200">
+                            <span className="flex h-5 w-5 items-center justify-center rounded-full bg-indigo-600 text-[0.6rem] font-semibold text-white">{initials}</span>
+                            {c.name}
+                            {c.role === 'owner' && <span className="text-[0.6rem] font-semibold uppercase text-indigo-400">owner</span>}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+
+                <p className="mb-2 pl-0.5 text-[0.68rem] font-semibold uppercase tracking-wide text-gray-400">Creative roster</p>
                 <div className="space-y-2.5">
                   {teamMembers.map((member, index) => {
                     const meta = teamStatusMeta[member.status] || teamStatusMeta.pending;

--- a/src/handlers/teams.ts
+++ b/src/handlers/teams.ts
@@ -1126,3 +1126,105 @@ export async function joinTeamByCodeHandler(request: Request, env: Env): Promise
     return json({ success: false, error: 'Failed to join company' }, 500);
   }
 }
+// ---------------------------------------------------------------------------
+// B3 creator-side surfaces: reach the company workspaces you've joined +
+// auto-list collaborators (so the "team" of people surfaces without manual entry).
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /api/creator/collaborations
+ * For a creator who joined production companies via a code: the companies they're
+ * a seated member of + each company's pitches (the projects they can collaborate
+ * on). This is the entry point so a joined creator can actually reach the shared
+ * workspace — without it the join code led to a dead end.
+ */
+export async function getCreatorCollaborationsHandler(request: Request, env: Env): Promise<Response> {
+  const corsHeaders = getCorsHeaders(request.headers.get('Origin'));
+  const json = (b: unknown, s = 200) => new Response(JSON.stringify(b), { status: s, headers: { 'Content-Type': 'application/json', ...corsHeaders } });
+  try {
+    const auth = await verifyAuth(request, env);
+    if (!auth.success || !auth.user) return json({ success: false, error: 'Unauthorized' }, 401);
+    const sql = getDb(env) as any;
+    if (!sql) return json({ success: true, data: { companies: [] } });
+    const me = auth.user.id;
+
+    // Match what actually grants workspace access (resolveWorkspace): a seated
+    // role on a team owned by a production company. Not gated on is_company_team
+    // (inconsistent across legacy teams) nor role='member' only (editors too).
+    const teams = await sql`
+      SELECT DISTINCT t.id AS team_id, t.name AS team_name, t.owner_id,
+             COALESCE(u.company_name, u.name, u.username, u.email) AS company
+      FROM team_members tm
+      JOIN teams t ON t.id = tm.team_id
+      JOIN users u ON u.id = t.owner_id
+      WHERE tm.user_id = ${me} AND tm.role IN ('member','editor') AND u.user_type = 'production'
+      ORDER BY t.id DESC`;
+
+    const companies = [];
+    for (const t of teams) {
+      const pitches = await sql`
+        SELECT id, title, COALESCE(thumbnail_url, title_image) AS poster, genre, format, status
+        FROM pitches WHERE user_id = ${t.owner_id}
+        ORDER BY updated_at DESC NULLS LAST LIMIT 50`;
+      companies.push({
+        teamId: t.team_id, name: t.team_name, company: t.company, ownerId: t.owner_id,
+        pitches: pitches.map((p: any) => ({ id: p.id, title: p.title, poster: p.poster, genre: p.genre, format: p.format, status: p.status })),
+      });
+    }
+    return json({ success: true, data: { companies } });
+  } catch {
+    return json({ success: true, data: { companies: [] } }); // degrade quietly
+  }
+}
+
+/**
+ * GET /api/production/pitches/:pitchId/collaborators
+ * The people with workspace access on this (production-owned) pitch = the owner +
+ * seated company members. Auto-populated from team_members — the "team" of
+ * collaborators surfaces without anyone typing it into the creative roster.
+ */
+export async function getPitchCollaboratorsHandler(request: Request, env: Env): Promise<Response> {
+  const corsHeaders = getCorsHeaders(request.headers.get('Origin'));
+  const json = (b: unknown, s = 200) => new Response(JSON.stringify(b), { status: s, headers: { 'Content-Type': 'application/json', ...corsHeaders } });
+  try {
+    const auth = await verifyAuth(request, env);
+    if (!auth.success || !auth.user) return json({ success: false, error: 'Unauthorized' }, 401);
+    const sql = getDb(env) as any;
+    if (!sql) return json({ success: true, data: { collaborators: [] } });
+
+    const parts = new URL(request.url).pathname.split('/');
+    const pitchId = parseInt(parts[4] || '0', 10);
+    if (!pitchId) return json({ success: false, error: 'Invalid pitch ID' }, 400);
+
+    const [pitch] = await sql`SELECT user_id FROM pitches WHERE id = ${pitchId}`;
+    if (!pitch) return json({ success: true, data: { collaborators: [] } });
+    const ownerId = pitch.user_id;
+
+    // Only collaborators of this company (owner or seated members) may see the roster.
+    const me = auth.user.id;
+    const isOwner = String(me) === String(ownerId);
+    let isMember = false;
+    if (!isOwner) {
+      const m = await sql`
+        SELECT 1 FROM team_members tm JOIN teams t ON t.id = tm.team_id
+        WHERE t.owner_id = ${ownerId} AND tm.user_id = ${me} AND tm.role IN ('owner','editor','member') LIMIT 1`;
+      isMember = m.length > 0;
+    }
+    if (!isOwner && !isMember) return json({ success: true, data: { collaborators: [] } });
+
+    const owner = await sql`SELECT id, COALESCE(name, username, email) AS name, user_type FROM users WHERE id = ${ownerId}`;
+    const members = await sql`
+      SELECT u.id, COALESCE(u.name, u.username, u.email) AS name, u.user_type, tm.joined_at
+      FROM team_members tm JOIN teams t ON t.id = tm.team_id JOIN users u ON u.id = tm.user_id
+      WHERE t.owner_id = ${ownerId} AND tm.role IN ('member','editor') AND u.id <> ${ownerId}
+      ORDER BY tm.joined_at ASC NULLS LAST`;
+
+    const collaborators = [
+      ...owner.map((o: any) => ({ id: o.id, name: o.name, userType: o.user_type, role: 'owner' })),
+      ...members.map((m: any) => ({ id: m.id, name: m.name, userType: m.user_type, role: 'member' })),
+    ];
+    return json({ success: true, data: { collaborators } });
+  } catch {
+    return json({ success: true, data: { collaborators: [] } });
+  }
+}

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -3078,6 +3078,19 @@ class RouteRegistry {
       return getProductionSlate(req, this.env);
     });
 
+    // B3 creator-side: the companies a creator joined + their pitches (entry
+    // point to the shared workspace), and the auto-listed collaborators on a pitch.
+    // NOTE: /api/creator/collaborations is already taken by the scoped-collaborator
+    // feature — this uses /companies to avoid the route collision.
+    this.register('GET', '/api/creator/companies', async (req) => {
+      const { getCreatorCollaborationsHandler } = await import('./handlers/teams');
+      return getCreatorCollaborationsHandler(req, this.env);
+    });
+    this.register('GET', '/api/production/pitches/:pitchId/collaborators', async (req) => {
+      const { getPitchCollaboratorsHandler } = await import('./handlers/teams');
+      return getPitchCollaboratorsHandler(req, this.env);
+    });
+
     // Project Collaborators — aggregate team view + invitation management + scoped project access
     this.register('GET', '/api/production/team/collaborators', async (req) => {
       const { getAllTeamCollaborators } = await import('./handlers/collaborator');


### PR DESCRIPTION
The B3 company-join-code feature was backend-complete but a **dead end for creators in the UI** — a joined creator had nowhere to open the shared workspace. This wires the creator side and fixes three real gaps found by walking it end-to-end in the browser. **Already deployed to prod** (worker `db4e68ce`, frontend `index-cDyi2S2e.js`).

### New
- **`GET /api/creator/companies`** — the production companies a creator joined (seated member/editor of a production-owned team) + each company's pitches. (Renamed off `/collaborations` — that route is taken by the scoped-collaborator feature; the collision was silently shadowing the handler.)
- **`GET /api/production/pitches/:id/collaborators`** — owner + seated members, auto-listed, gated to company collaborators.
- **`CreatorCollaborations`** card on the creator dashboard: *Collaborating With* → company → pitch cards → open the workspace.
- **Auto "Collaborators" strip** in the Team tab (owner + joined members) — distinct from the manually-curated **Creative roster**. This answers "shouldn't the team auto-set when a creator joins": the *collaborators* do (from the code); the *creative roster* (attaching a specific Director/DP, often not a platform user) stays manual by design.

### Fixes surfaced by the walkthrough
1. **Route guard** — `/production/pitch/:id` was production-only, so seated creator members got bounced to `/creator/dashboard`. Now any authenticated user may open it; the view gates Team/Notes by `isOwner || isCompanyMember || hasSignedNDA`.
2. **Tab lock** — the tab *button* lock condition omitted `isCompanyMember`, so members saw `Team 🔒 NDA required` even though the content gate allowed them. Added it.
3. **Authed fetch** — `fetchPitchData` only loaded the authenticated pitch record (which carries `isCompanyMember`) for *production* users → members kept the public record (no flag) and tabs stayed locked. Now fetched for any authenticated user (backend enforces access; 403 falls back to public).

### Verified live
Alex (creator, seated member of Stellar) opens *Stellar Horizons* from his dashboard → **Editor** on the shared workspace; Collaborators strip shows `stellarproduction (owner)` + `alex.creator`. Bidirectional co-edit confirmed earlier in the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)