### PR TITLE
fix(signup+nda): clean 400 on bad signup body; no 'Request NDA' on open pitches

### DIFF
--- a/frontend/src/pages/__tests__/ProductionPitchView.test.tsx
+++ b/frontend/src/pages/__tests__/ProductionPitchView.test.tsx
@@ -263,7 +263,9 @@ describe('ProductionPitchView', () => {
   })
 
   it('shows production materials section when documents exist', async () => {
-    mockPitchGetPublicById.mockResolvedValue(mockPitch)
+    // requiresNDA: true → this asserts the NDA-gated state (labels shown as
+    // "Not attached"); a no-NDA pitch would instead show open materials.
+    mockPitchGetPublicById.mockResolvedValue({ ...mockPitch, requiresNDA: true })
 
     render(
       <MemoryRouter>
@@ -299,7 +301,9 @@ describe('ProductionPitchView', () => {
   })
 
   it('shows NDA credit cost when NDA not signed', async () => {
-    mockPitchGetPublicById.mockResolvedValue({ ...mockPitch, hasSignedNDA: false })
+    // requiresNDA: true → the pitch needs an NDA, so the "Request NDA Access ·
+    // N credits" CTA shows. (On a no-NDA pitch we show "No NDA required" instead.)
+    mockPitchGetPublicById.mockResolvedValue({ ...mockPitch, hasSignedNDA: false, requiresNDA: true })
 
     render(
       <MemoryRouter>

--- a/frontend/src/portals/production/pages/ProductionPitchView.tsx
+++ b/frontend/src/portals/production/pages/ProductionPitchView.tsx
@@ -54,6 +54,8 @@ interface Pitch {
   updatedAt: string;
   hasSignedNDA?: boolean;
   isCompanyMember?: boolean;
+  requiresNDA?: boolean;           // pitch was created with NDA protection
+  require_nda?: boolean;           // snake-case fallback
   creatorType?: string;            // owner's user_type — selects workspace mode
   creator_type?: string;           // snake-case as returned by getPitch
   creator?: { id?: number; name?: string; userType?: string };
@@ -137,6 +139,11 @@ const ProductionPitchView: React.FC = () => {
   const canEditWorkspace = ownerIsProduction
     ? (isOwner || !!pitch?.isCompanyMember)
     : (authUser?.userType === 'production');
+
+  // Whether this pitch was created WITH NDA protection. Pitches created without
+  // one are openly accessible — so we don't offer "Request NDA Access" on them.
+  const requiresNda =
+    pitch?.requiresNDA ?? pitch?.require_nda ?? (pitch?.visibility === 'nda_only');
 
   // --- Workspace access affordances (UI/UX) -------------------------------
   // A quiet "who am I here" system shared across the Feasibility/Team/Notes
@@ -1175,7 +1182,12 @@ const ProductionPitchView: React.FC = () => {
             {!isOwner && (
               <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
                 <h3 className="text-lg font-semibold text-gray-900">Access</h3>
-                {pitch?.hasSignedNDA ? (
+                {!requiresNda ? (
+                  <div className="mt-3 flex items-start gap-2.5 rounded-lg bg-emerald-50 px-3.5 py-3 text-emerald-800">
+                    <CheckCircle className="h-5 w-5 shrink-0 text-emerald-600" />
+                    <p className="text-sm font-medium leading-snug">No NDA required — the script &amp; production materials are open below.</p>
+                  </div>
+                ) : pitch?.hasSignedNDA ? (
                   <div className="mt-3 flex items-start gap-2.5 rounded-lg bg-emerald-50 px-3.5 py-3 text-emerald-800">
                     <CheckCircle className="h-5 w-5 shrink-0 text-emerald-600" />
                     <p className="text-sm font-medium leading-snug">NDA signed — the full script &amp; production materials are unlocked below.</p>
@@ -1297,7 +1309,7 @@ const ProductionPitchView: React.FC = () => {
             {/* Documents — show full links post-NDA, attachment status pre-NDA */}
             <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">Production Materials</h3>
-              {(isOwner || pitch.hasSignedNDA) ? (
+              {(isOwner || pitch.hasSignedNDA || !requiresNda) ? (
                 ((pitch as any).documents?.length || pitch.script || pitch.pitchDeck || pitch.trailer) ? (
                   <PitchDocuments
                     documents={(pitch as any).documents}

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -1585,30 +1585,35 @@ class RouteRegistry {
   }
 
   private async handleRegisterSimple(request: Request): Promise<Response> {
-    const body = await request.json() as RegisterBody;
-    const { email, password, name, userType } = body;
     const origin = request.headers.get('Origin');
+    const fail = (code: string, message: string, status: number) => new Response(
+      JSON.stringify({ success: false, error: { code, message } }),
+      { status, headers: { 'Content-Type': 'application/json', ...getCorsHeaders(origin) } },
+    );
+
+    // Validate the body BEFORE touching any field — an empty/malformed body used
+    // to throw on `email.split('@')` and surface as a generic 500 (bots hitting
+    // this with garbage inflated the error rate). Now it's a clean 400.
+    let body: RegisterBody;
+    try {
+      body = (await request.json()) as RegisterBody;
+    } catch {
+      return fail('VALIDATION_ERROR', 'Invalid or missing request body', 400);
+    }
+    const { email, password, name, userType } = body || ({} as RegisterBody);
+    if (!email || !password) {
+      return fail('VALIDATION_ERROR', 'Email and password are required', 400);
+    }
+
     const username = (body as any).username || email.split('@')[0];
     const companyName = (body as any).companyName || null;
 
-    // Verify Turnstile token
+    // Verify Turnstile token (after basic validation so malformed bodies get a
+    // 400, not a 403).
     const clientIP = request.headers.get('CF-Connecting-IP') || undefined;
     const turnstileResult = await verifyTurnstileToken((body as any).turnstileToken, this.env.TURNSTILE_SECRET_KEY, clientIP);
     if (!turnstileResult.success) {
-      return new Response(JSON.stringify({
-        success: false,
-        error: { code: 'TURNSTILE_FAILED', message: turnstileResult.error || 'Bot verification failed' }
-      }), { status: 403, headers: { 'Content-Type': 'application/json', ...getCorsHeaders(origin) } });
-    }
-
-    if (!email || !password) {
-      return new Response(JSON.stringify({
-        success: false,
-        error: { code: 'VALIDATION_ERROR', message: 'Email and password are required' }
-      }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json', ...getCorsHeaders(origin) }
-      });
+      return fail('TURNSTILE_FAILED', turnstileResult.error || 'Bot verification failed', 403);
     }
 
     try {


### PR DESCRIPTION
Launch-readiness sweep findings, fixed. **Already deployed** (worker `6f2ec57e`, frontend `index-DO04ZfxS.js`).

### 1. Signup returns 400 (was 500) on a malformed body
`handleRegisterSimple` computed `email.split('@')` **before** validating that `email`/`password` exist — so an empty/garbage body threw and surfaced as a generic **500** (bots/scanners hitting `/api/auth/sign-up` inflated the error rate). Now: guard `request.json()`, validate fields → **clean 400**, then Turnstile (403). Verified live: `{}` and no-body → `400 VALIDATION_ERROR`. Real signups unaffected.

### 2. "Request NDA Access" no longer shows on pitches with no NDA
On the production pitch view, the Access card offered "Request NDA Access · 10 credits" to any non-owner — even on pitches **created without NDA protection**. Added `requiresNda` (`pitch.requiresNDA ?? require_nda ?? visibility==='nda_only'`); a no-NDA pitch now shows **"No NDA required — materials are open"** and the Production Materials section is open (`isOwner || hasSignedNDA || !requiresNda`) instead of NDA-gated.

### Billing — verified clean across all portals
Drove creator / investor / production in the browser: Stripe "Open portal" card, current plan, credit balance, and recent activity all render correctly; Subscription tabs show the right tiers and prices (£19.99 / £29.99 / £39.99) with working Upgrade/Cancel.
- **One minor cosmetic note (not fixed here):** a no-subscription **production** user's "Current Subscription" card shows the free-tier label **"The Watcher"** instead of "Free". Plans/pricing/portal all work — purely a label fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)