### PR TITLE
fix(billing): 'Free' not 'The Watcher' for no-subscription users

### DIFF
--- a/frontend/src/features/billing/components/SubscriptionCard.tsx
+++ b/frontend/src/features/billing/components/SubscriptionCard.tsx
@@ -55,7 +55,12 @@ export default function SubscriptionCard({ subscription, onRefresh }: Subscripti
   const popularTierId = POPULAR_TIER_BY_PORTAL[portalForTiers] || '';
 
   const currentTierDef = currentTierId ? findTier(currentTierId) : null;
-  const currentTierName = currentTierDef?.name || 'Free';
+  // Show the tier name only for a real PAID subscription. Free / no-subscription
+  // (incl. the 'free'→'watcher' mapping above, used for price comparison) reads
+  // "Free" — not "The Watcher", which leaked onto non-watcher portals.
+  const currentTierName = (currentTierDef && (currentTierDef.price?.monthly ?? 0) > 0)
+    ? currentTierDef.name
+    : 'Free';
 
   const handleUpgrade = async (planKey: string) => {
     const plan = findTier(planKey);


### PR DESCRIPTION
Cosmetic billing fix spotted during the launch-readiness sweep. **Already deployed** (frontend `index-BUYYoNKI.js`).

`SubscriptionCard` maps a `'free'`/no-subscription tier id to `'watcher'` (used for the upgrade/downgrade *price comparison*). That mapping leaked into the **display name**, so the "Current Subscription" card showed the watcher tier's name **"The Watcher"** for production/creator/investor users on the free tier.

Fix: the display name now reads **"Free"** unless there's a real **paid** tier (`price.monthly > 0`). The price-comparison mapping is untouched, so Upgrade/Downgrade still resolve correctly.

Verified live on the production subscription tab (now "Current Subscription · Free"); Billing tests 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)