### PR TITLE
feat(collab-nda): Phases 2+3 — sign UI, workspace gate, producer per-seat status + signed record

### DIFF
--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -132,6 +132,23 @@ The authoritative list is always `wrangler.toml`. After recreating, update the I
    disaster's RTO is dominated by manually re-obtaining ~10 credentials. *Owner action.*
 2. **Enable R2 versioning** (or a periodic R2→external sync) on the data buckets
    (`pitchey-pitches`, `-ndas`, `-media`) so overwrites/deletes are recoverable.
+   `wrangler` has no versioning subcommand — use the dashboard (bucket → Settings →
+   Object versioning → Enable) or the S3-compatible `PutBucketVersioning` API with
+   R2 S3 credentials:
+   ```bash
+   # Requires an R2 API token's Access Key ID / Secret configured for aws-cli.
+   # account_id = 002bd5c0e90ae753a387c60546cf6869 (ndlovucavelle)
+   for b in pitchey-pitches pitchey-ndas pitchey-media; do
+     aws s3api put-bucket-versioning \
+       --endpoint-url https://002bd5c0e90ae753a387c60546cf6869.r2.cloudflarestorage.com \
+       --bucket "$b" \
+       --versioning-configuration Status=Enabled
+   done
+   ```
+   **Cost note:** versions accumulate on overwrite/delete (rare for documents, so
+   modest), but the org runs a cost-sensitive shared quota (#65) — confirm before
+   enabling, and consider an R2 lifecycle rule to expire noncurrent versions after
+   N days (`wrangler r2 bucket lifecycle`). *Owner action (credentials + billing).*
 3. **Verify Neon retention** in the dashboard and confirm it matches the RPO you want; upgrade
    the plan if the window is too short.
 4. **Audit + fix or delete the local backup scripts** (`database-backup.sh` → AWS S3 not R2;
@@ -140,6 +157,23 @@ The authoritative list is always `wrangler.toml`. After recreating, update the I
    non-functional.
 5. **Test a restore** — branch Neon to a point in time and bring a throwaway worker up against
    it. An untested restore is the same "prayer" the rollback drill exposed.
+
+   **Non-destructive restore drill** (no impact on the live `main` branch; uses brief
+   branch compute — modest, but counts against the shared Neon quota #65, so run
+   deliberately):
+   1. Create a branch from a recent timestamp (Neon dashboard, neonctl, or the Neon MCP
+      `create_branch` with a `point_in_time`). Name it `dr-drill-<date>`.
+   2. Get its connection string and run the smoke queries: `SELECT NOW();`,
+      `SELECT count(*) FROM users;`, `SELECT count(*) FROM pitches;`,
+      `SELECT count(*) FROM subscription_history WHERE status='active';` — confirm
+      counts look sane vs. production.
+   3. (Optional, fuller drill) point a local `wrangler dev` at the branch
+      (`DATABASE_URL=<branch-conn> wrangler dev`) and exercise login + a pitch view +
+      `/api/health`.
+   4. **Delete the branch** (`delete_branch`) to release compute. Record the date +
+      outcome in this file's verification log so the quarterly cadence has evidence.
+
+   A passing drill closes the "untested restore" gap until the next quarterly run.
 
 ---
 

--- a/docs/slo-money-paths-2026-06-08.md
+++ b/docs/slo-money-paths-2026-06-08.md
@@ -1,0 +1,62 @@
+# Money-Path SLOs — 2026-06-08
+
+Part of the money-path-safety work (Phase 3). The research bar: collecting
+telemetry is not operating maturely — the gap is **reliability** SLOs on the
+paths that make money, alerting on user impact rather than only on availability
+("is the DB up?").
+
+## What's monitored
+
+A worker cron (`checkMoneyPathSLOs` in `src/worker-integrated.ts`, wired to the
+hourly `0 * * * *` trigger) reads the Axiom request logs the worker already emits
+(`type="request"`, `request.path`, `request.method`, `response.status`) and
+computes the **5xx error rate** over the trailing hour per money path. 4xx
+(validation / auth) do **not** count against the budget.
+
+| SLI (path key) | Matches | Target | Min volume | Min errors to alert |
+|---|---|---|---|---|
+| `checkout` | `request.path` startswith `/api/payments` | 99% | 5 / h | 2 |
+| `signup` | `request.path` contains `register` | 99% | 5 / h | 2 |
+| `pitch_upload` | POST `request.path` startswith `/api/pitches` | 99% | 5 / h | 2 |
+
+A path is in **breach** when, in the trailing hour: `total ≥ minVolume` **and**
+`errors ≥ minErrors` **and** `errorRate > (1 − target)`. The min-volume /
+min-errors guards suppress noise from tiny samples and single blips (launch-stage
+traffic is low — better quiet than crying wolf).
+
+Targets / matchers are defined in one place — the `MONEY_PATH_SLOS` const in
+`src/worker-integrated.ts`. Adjust there.
+
+## What fires on a breach
+
+Each run emits a structured `category:"slo" action:"check_complete"` log with
+per-path `total`/`errors`/`error_rate`/`breached` (healthy runs are visibly
+healthy). On a breach it additionally:
+
+1. logs `category:"slo" action:"slo_breach"` at **error** level (captured by
+   Cloudflare Observability + Axiom), and
+2. sends a **Sentry** `captureMessage` at error level, tagged `slo.breach=<key>`.
+
+The check is pure-read and fully defensive: no `AXIOM_TOKEN` → skip; a failed or
+odd-shaped APL query for one path logs and continues, never paging falsely.
+
+## Owner action required (the "channel you actually read")
+
+The breach signal exists; routing it to a human is dashboard config (the Sentry
+MCP was removed — configure in the Sentry UI):
+
+- **Sentry alert rule**: route events with tag `slo.breach` (or error-level
+  `captureMessage` with "Money-path SLO breach") to Slack / email. Without this,
+  breaches sit in Sentry unseen.
+- Optionally, a Cloudflare/Axiom monitor on `category = "slo" AND action =
+  "slo_breach"` can route to the same Slack webhook the health check uses.
+
+## Verifying
+
+After deploy, the cron runs at the top of each hour. Confirm via Cloudflare
+Observability (or `wrangler tail`) for `category:"slo" action:"check_complete"` —
+expect a `results` array with one entry per path (`total`/`errors`/`breached`).
+A path with no traffic in the window reports `total:0 breached:false`. To
+exercise the breach path before real traffic exists, temporarily lower a target's
+`minVolume`/`minErrors` in `MONEY_PATH_SLOS`, redeploy, and confirm the Sentry
+event + `slo_breach` log appear, then revert.

--- a/frontend/e2e/smoke-regression.spec.ts
+++ b/frontend/e2e/smoke-regression.spec.ts
@@ -94,8 +94,9 @@ test.describe('smoke-regression: silent-failure guards', () => {
     await login(page, 'investor');
     await openPitch(page);
 
+    // Engagement actions now live in the shared InterestedCard ("Like this pitch" / "Liked").
     const liked = page.getByRole('button', { name: /^Liked$/ });
-    const like = page.getByRole('button', { name: /^Like$/ });
+    const like = page.getByRole('button', { name: /Like this pitch/i });
 
     if (await like.isVisible().catch(() => false)) await like.click();
     await expect(liked).toBeVisible();
@@ -113,8 +114,9 @@ test.describe('smoke-regression: silent-failure guards', () => {
     await login(page, 'investor');
     await openPitch(page);
 
-    const saved = page.getByRole('button', { name: /^Saved$/ });
-    const save = page.getByRole('button', { name: /^Save$/ });
+    // Engagement actions now live in the shared InterestedCard ("Save for later" / "Saved for later").
+    const saved = page.getByRole('button', { name: /^Saved for later$/ });
+    const save = page.getByRole('button', { name: /^Save for later$/ });
 
     if (await save.isVisible().catch(() => false)) await save.click();
     await expect(saved).toBeVisible();

--- a/frontend/src/features/billing/components/SubscriptionCard.tsx
+++ b/frontend/src/features/billing/components/SubscriptionCard.tsx
@@ -327,8 +327,8 @@ export default function SubscriptionCard({ subscription, onRefresh }: Subscripti
                   : isFree
                   ? 'Free Forever'
                   : isDowngrade
-                  ? `Downgrade to ${plan.name}`
-                  : `Upgrade to ${plan.name}`}
+                  ? 'Downgrade'
+                  : 'Upgrade'}
               </button>
             </div>
           );

--- a/frontend/src/features/pitches/components/InterestedCard.tsx
+++ b/frontend/src/features/pitches/components/InterestedCard.tsx
@@ -1,0 +1,209 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Heart, UserPlus, Bookmark } from 'lucide-react';
+import { API_URL } from '@/config';
+import { socialService } from '@features/browse/services/social.service';
+
+/**
+ * InterestedCard — the single, shared "Interested?" engagement box used on every
+ * pitch view (Public, Creator portal, Production portal, generic PitchDetail).
+ *
+ * It groups the three audience actions Karl asked for — "Like this pitch",
+ * "Follow this creator", "Save for later" — into one stylish, neat card so the
+ * controls are no longer scattered/inconsistent per portal.
+ *
+ * Self-contained: it owns its own like/save/follow state and calls the proven
+ * endpoints (POST/DELETE /api/pitches/:id/like + /save, socialService for follow).
+ * Anonymous clicks route to sign-in carrying the current path. Owners see nothing.
+ */
+export interface InterestedCardProps {
+  // Portals type pitch.id / creator id inconsistently (number vs string) — accept both.
+  pitchId: number | string;
+  creatorId?: number | string;
+  initialLiked?: boolean;
+  initialSaved?: boolean;
+  isAuthenticated: boolean;
+  isOwner?: boolean;
+  /** Path to return to after sign-in for anonymous users. Defaults to current location. */
+  fromPath?: string;
+  className?: string;
+}
+
+const InterestedCard: React.FC<InterestedCardProps> = ({
+  pitchId,
+  creatorId,
+  initialLiked = false,
+  initialSaved = false,
+  isAuthenticated,
+  isOwner = false,
+  fromPath,
+  className = '',
+}) => {
+  const navigate = useNavigate();
+  // socialService follow APIs expect a numeric id; coerce once.
+  const numericCreatorId =
+    creatorId != null && creatorId !== '' && !Number.isNaN(Number(creatorId))
+      ? Number(creatorId)
+      : undefined;
+  const [isLiked, setIsLiked] = useState(initialLiked);
+  const [isSaved, setIsSaved] = useState(initialSaved);
+  const [isFollowing, setIsFollowing] = useState(false);
+  const [busy, setBusy] = useState<'like' | 'save' | 'follow' | null>(null);
+
+  useEffect(() => { setIsLiked(initialLiked); }, [initialLiked]);
+  useEffect(() => { setIsSaved(initialSaved); }, [initialSaved]);
+
+  // Hydrate follow state on mount (FollowButton does the same).
+  useEffect(() => {
+    let cancelled = false;
+    if (isAuthenticated && numericCreatorId && !isOwner) {
+      socialService.checkFollowStatus(numericCreatorId, 'user')
+        .then((s) => { if (!cancelled) setIsFollowing(s); })
+        .catch(() => { /* non-fatal: default to not-following */ });
+    }
+    return () => { cancelled = true; };
+  }, [isAuthenticated, numericCreatorId, isOwner]);
+
+  const goToLogin = useCallback(() => {
+    const from = fromPath ?? (typeof window !== 'undefined' ? window.location.pathname : `/pitch/${pitchId}`);
+    void navigate('/login', { state: { from } });
+  }, [navigate, fromPath, pitchId]);
+
+  const toggleLike = useCallback(async () => {
+    if (!isAuthenticated) return goToLogin();
+    if (busy) return;
+    const next = !isLiked;
+    setIsLiked(next);
+    setBusy('like');
+    try {
+      const res = await fetch(`${API_URL}/api/pitches/${pitchId}/like`, {
+        method: next ? 'POST' : 'DELETE',
+        credentials: 'include',
+      });
+      if (!res.ok) throw new Error(`Like failed: ${res.status}`);
+    } catch (err) {
+      console.error('InterestedCard like error:', err);
+      setIsLiked(!next); // revert
+    } finally {
+      setBusy(null);
+    }
+  }, [isAuthenticated, busy, isLiked, pitchId, goToLogin]);
+
+  const toggleSave = useCallback(async () => {
+    if (!isAuthenticated) return goToLogin();
+    if (busy) return;
+    const next = !isSaved;
+    setIsSaved(next);
+    setBusy('save');
+    try {
+      const res = await fetch(`${API_URL}/api/pitches/${pitchId}/save`, {
+        method: next ? 'POST' : 'DELETE',
+        credentials: 'include',
+      });
+      if (!res.ok) throw new Error(`Save failed: ${res.status}`);
+    } catch (err) {
+      console.error('InterestedCard save error:', err);
+      setIsSaved(!next); // revert
+    } finally {
+      setBusy(null);
+    }
+  }, [isAuthenticated, busy, isSaved, pitchId, goToLogin]);
+
+  const toggleFollow = useCallback(async () => {
+    if (!numericCreatorId) return;
+    if (!isAuthenticated) return goToLogin();
+    if (busy) return;
+    const next = !isFollowing;
+    setIsFollowing(next);
+    setBusy('follow');
+    try {
+      if (next) await socialService.followUser(numericCreatorId);
+      else await socialService.unfollowUser(numericCreatorId);
+    } catch (err) {
+      console.error('InterestedCard follow error:', err);
+      setIsFollowing(!next); // revert
+    } finally {
+      setBusy(null);
+    }
+  }, [numericCreatorId, isAuthenticated, busy, isFollowing, goToLogin]);
+
+  // Owners don't engage with their own pitch.
+  if (isOwner) return null;
+
+  const showFollow = !!numericCreatorId;
+
+  return (
+    <div className={`bg-white rounded-xl shadow-sm p-6 ${className}`}>
+      <h3 className="text-lg font-semibold text-gray-900 mb-1">Interested?</h3>
+      <p className="text-sm text-gray-500 mb-4">
+        {isAuthenticated
+          ? 'Show your support and keep this pitch close.'
+          : 'Sign in to engage with this pitch and its creator.'}
+      </p>
+
+      <div className="space-y-2">
+        {/* Like this pitch */}
+        <button
+          type="button"
+          onClick={toggleLike}
+          aria-pressed={isLiked}
+          className={`w-full flex items-center gap-3 px-4 py-2.5 rounded-lg transition group ${
+            isLiked
+              ? 'bg-red-50 text-red-600 hover:bg-red-100'
+              : 'bg-gray-50 text-gray-700 hover:bg-red-50 hover:text-red-600'
+          }`}
+        >
+          <Heart className={`w-4 h-4 ${isLiked ? 'fill-current' : 'group-hover:fill-red-200'}`} />
+          <span className="flex-1 text-left text-sm font-medium">
+            {isLiked ? 'Liked' : 'Like this pitch'}
+          </span>
+          {!isAuthenticated && <span className="text-xs text-gray-400">Free</span>}
+        </button>
+
+        {/* Follow this creator */}
+        {showFollow && (
+          <button
+            type="button"
+            onClick={toggleFollow}
+            aria-pressed={isFollowing}
+            className={`w-full flex items-center gap-3 px-4 py-2.5 rounded-lg transition group ${
+              isFollowing
+                ? 'bg-purple-50 text-purple-600 hover:bg-purple-100'
+                : 'bg-gray-50 text-gray-700 hover:bg-purple-50 hover:text-purple-600'
+            }`}
+          >
+            <UserPlus className="w-4 h-4" />
+            <span className="flex-1 text-left text-sm font-medium">
+              {isFollowing ? 'Following creator' : 'Follow this creator'}
+            </span>
+            {!isAuthenticated && <span className="text-xs text-gray-400">Free</span>}
+          </button>
+        )}
+
+        {/* Save for later */}
+        <button
+          type="button"
+          onClick={toggleSave}
+          aria-pressed={isSaved}
+          className={`w-full flex items-center gap-3 px-4 py-2.5 rounded-lg transition group ${
+            isSaved
+              ? 'bg-blue-50 text-blue-600 hover:bg-blue-100'
+              : 'bg-gray-50 text-gray-700 hover:bg-blue-50 hover:text-blue-600'
+          }`}
+        >
+          <Bookmark className={`w-4 h-4 ${isSaved ? 'fill-current' : ''}`} />
+          <span className="flex-1 text-left text-sm font-medium">
+            {isSaved ? 'Saved for later' : 'Save for later'}
+          </span>
+          {!isAuthenticated && <span className="text-xs text-gray-400">Free</span>}
+        </button>
+      </div>
+
+      {!isAuthenticated && (
+        <p className="text-xs text-gray-400 mt-3 text-center">No credit card required</p>
+      )}
+    </div>
+  );
+};
+
+export default InterestedCard;

--- a/frontend/src/features/teams/components/CollaborationNdaModal.tsx
+++ b/frontend/src/features/teams/components/CollaborationNdaModal.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useState } from 'react';
+import { X, Shield, Loader, CheckCircle } from 'lucide-react';
+import apiClient from '../../../lib/api-client';
+import { toast } from 'react-hot-toast';
+
+interface CollaborationNdaModalProps {
+  teamId: number;
+  /** Company name — used for the disclosing-party autofill + copy. */
+  company: string;
+  /** Pre-fill the signer's legal name (e.g. the creator's account name). */
+  defaultName?: string;
+  onClose: () => void;
+  /** Fired after a successful sign so the caller can refresh access state. */
+  onSigned: () => void;
+}
+
+/**
+ * One-screen click-to-sign for the company **collaboration NDA** (B3 Phase 2).
+ * A creator who joined a production company via a code signs the Platform
+ * Standard NDA once per company before the shared workspace unlocks. Distinct
+ * from the credit-based, pitch-scoped access NDA. Renders the standard NDA text
+ * (company autofill) + agree checkbox + legal name/address, POSTs to
+ * `/api/teams/:id/collaboration-nda/sign`.
+ */
+export function CollaborationNdaModal({
+  teamId, company, defaultName = '', onClose, onSigned,
+}: CollaborationNdaModalProps) {
+  const [content, setContent] = useState('');
+  const [docName, setDocName] = useState('Pitchey Standard NDA');
+  const [loading, setLoading] = useState(true);
+  const [loadErr, setLoadErr] = useState<string | null>(null);
+
+  const [agreed, setAgreed] = useState(false);
+  const [name, setName] = useState(defaultName);
+  const [address, setAddress] = useState('');
+  const [signing, setSigning] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    const params = new URLSearchParams({
+      disclosingName: company,
+      projectName: `all ${company} projects`,
+    });
+    if (defaultName) params.set('recipientName', defaultName);
+    fetch(`${import.meta.env.VITE_API_URL}/api/ndas/standard?${params.toString()}`, {
+      credentials: 'include',
+    })
+      .then((r) => r.json())
+      .then((d) => {
+        if (!live) return;
+        if (d?.success && d.data) {
+          setContent(d.data.content || '');
+          if (d.data.name) setDocName(d.data.name);
+        } else {
+          setLoadErr('Unable to load the NDA. Please try again.');
+        }
+      })
+      .catch(() => live && setLoadErr('Unable to load the NDA. Please try again.'))
+      .finally(() => live && setLoading(false));
+    return () => { live = false; };
+  }, [company, defaultName]);
+
+  const canSign = agreed && name.trim().length > 0 && !signing;
+
+  const handleSign = async () => {
+    if (!canSign) return;
+    setSigning(true);
+    try {
+      const res: any = await apiClient.post(`/api/teams/${teamId}/collaboration-nda/sign`, {
+        agreed: true,
+        name: name.trim(),
+        address: address.trim() || undefined,
+      });
+      const ok = res?.success ?? res?.data?.success;
+      if (ok) {
+        toast.success(`Signed — you can now collaborate with ${company}.`);
+        onSigned();
+        onClose();
+      } else {
+        toast.error(res?.error?.message || res?.error || 'Failed to sign the NDA.');
+      }
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      toast.error(e.message);
+    } finally {
+      setSigning(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl bg-white shadow-xl">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4">
+          <div className="flex items-center gap-2.5">
+            <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-purple-50 text-purple-600 ring-1 ring-inset ring-purple-100">
+              <Shield className="h-5 w-5" />
+            </span>
+            <div>
+              <h2 className="text-base font-semibold text-gray-900">{docName}</h2>
+              <p className="text-xs text-gray-500">Collaboration NDA with {company}</p>
+            </div>
+          </div>
+          <button onClick={onClose} className="rounded-lg p-2 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600" aria-label="Close">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* NDA body */}
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+          {loading ? (
+            <div className="flex items-center justify-center py-16 text-gray-500">
+              <Loader className="mr-2 h-6 w-6 animate-spin" /> Loading…
+            </div>
+          ) : loadErr ? (
+            <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">{loadErr}</div>
+          ) : (
+            <article className="rounded-xl border border-gray-200 bg-gray-50 p-5">
+              <p className="mb-3 text-xs text-gray-500">
+                You're signing once to collaborate on all of {company}'s projects. Blank lines
+                (________________) are completed from the details you enter below.
+              </p>
+              <pre className="whitespace-pre-wrap font-sans text-sm leading-relaxed text-gray-800">{content}</pre>
+            </article>
+          )}
+        </div>
+
+        {/* Sign block */}
+        {!loading && !loadErr && (
+          <div className="border-t border-gray-200 px-6 py-4">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium text-gray-600">Full legal name <span className="text-red-500">*</span></span>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Jane Q. Creator"
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-purple-400 focus:outline-none focus:ring-1 focus:ring-purple-400"
+                />
+              </label>
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium text-gray-600">Address <span className="text-gray-400">(optional)</span></span>
+                <input
+                  type="text"
+                  value={address}
+                  onChange={(e) => setAddress(e.target.value)}
+                  placeholder="City, Country"
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-purple-400 focus:outline-none focus:ring-1 focus:ring-purple-400"
+                />
+              </label>
+            </div>
+            <label className="mt-3 flex items-start gap-2.5 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={agreed}
+                onChange={(e) => setAgreed(e.target.checked)}
+                className="mt-0.5 h-4 w-4 rounded border-gray-300 text-purple-600 focus:ring-purple-500"
+              />
+              <span>I have read and agree to be bound by this Non-Disclosure Agreement.</span>
+            </label>
+            <div className="mt-4 flex items-center justify-end gap-2">
+              <button onClick={onClose} className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100">
+                Cancel
+              </button>
+              <button
+                onClick={handleSign}
+                disabled={!canSign}
+                className="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-purple-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {signing ? <Loader className="h-4 w-4 animate-spin" /> : <CheckCircle className="h-4 w-4" />}
+                Sign &amp; Continue
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/teams/components/CompanyTeamCards.tsx
+++ b/frontend/src/features/teams/components/CompanyTeamCards.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Users, KeyRound, Copy, Check, RefreshCw } from 'lucide-react';
+import { Users, KeyRound, Copy, Check, RefreshCw, Shield, Clock, FileText } from 'lucide-react';
 
 const API = import.meta.env.VITE_API_URL || '';
 
@@ -87,13 +87,28 @@ export function JoinCompanyCard() {
  * Production-side: generate/rotate and share a join code so creators can join the
  * company team (B3). Resolves the company team via /api/teams, reads/sets the code.
  */
+interface SeatMember {
+  userId: number;
+  name: string;
+  email: string;
+  ndaStatus: 'signed' | 'pending';
+  signedAt: string | null;
+  documentUrl: string | null;
+}
+
 export function CompanyJoinCodeCard() {
   const [teamId, setTeamId] = useState<number | null>(null);
   const [code, setCode] = useState<string | null>(null);
   const [seats, setSeats] = useState<{ used: number; limit: number } | null>(null);
+  const [members, setMembers] = useState<SeatMember[]>([]);
   const [busy, setBusy] = useState(false);
   const [copied, setCopied] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+
+  const loadMembers = async (tid: number) => {
+    const res = await api(`/api/teams/${tid}/collaboration-nda/members`);
+    if (res.ok) setMembers(Array.isArray(res.body?.data?.members) ? res.body.data.members : []);
+  };
 
   useEffect(() => {
     (async () => {
@@ -108,6 +123,7 @@ export function CompanyJoinCodeCard() {
         setCode(codeRes.body?.data?.code ?? null);
         setSeats({ used: codeRes.body?.data?.seatsUsed ?? 0, limit: codeRes.body?.data?.seatLimit ?? 0 });
       }
+      await loadMembers(company.id);
     })();
   }, []);
 
@@ -162,6 +178,44 @@ export function CompanyJoinCodeCard() {
         </button>
       )}
       {err && <p className="mt-3 text-sm text-red-600">{err}</p>}
+
+      {members.length > 0 && (
+        <div className="mt-5 border-t border-gray-100 pt-4">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400">Members &amp; NDA status</p>
+          <ul className="space-y-1.5">
+            {members.map((m) => (
+              <li key={m.userId} className="flex items-center justify-between gap-2 rounded-lg px-1 py-1">
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-gray-800">{m.name}</p>
+                  <p className="truncate text-xs text-gray-400">{m.email}</p>
+                </div>
+                {m.ndaStatus === 'signed' ? (
+                  <div className="flex shrink-0 items-center gap-2">
+                    <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700 ring-1 ring-inset ring-emerald-200">
+                      <Shield className="h-3 w-3" /> Signed
+                    </span>
+                    {m.documentUrl && (
+                      <a
+                        href={`${API}${m.documentUrl}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-[11px] font-medium text-purple-600 hover:text-purple-800"
+                        title="View signed NDA"
+                      >
+                        <FileText className="h-3 w-3" /> NDA
+                      </a>
+                    )}
+                  </div>
+                ) : (
+                  <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700 ring-1 ring-inset ring-amber-200">
+                    <Clock className="h-3 w-3" /> Pending
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/features/teams/components/CreatorCollaborations.tsx
+++ b/frontend/src/features/teams/components/CreatorCollaborations.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Building2, FileText, ArrowRight } from 'lucide-react';
+import { Building2, FileText, ArrowRight, Shield, Lock } from 'lucide-react';
 import apiClient from '../../../lib/api-client';
+import { useBetterAuthStore } from '../../../store/betterAuthStore';
+import { CollaborationNdaModal } from './CollaborationNdaModal';
 
 interface CollabPitch {
   id: number;
@@ -16,6 +18,7 @@ interface Company {
   name: string;
   company: string;
   ownerId: number;
+  ndaSigned: boolean;
   pitches: CollabPitch[];
 }
 
@@ -28,22 +31,25 @@ interface Company {
 export function CreatorCollaborations() {
   const [companies, setCompanies] = useState<Company[]>([]);
   const [loaded, setLoaded] = useState(false);
+  const [signingCompany, setSigningCompany] = useState<Company | null>(null);
   const navigate = useNavigate();
+  const { user: authUser } = useBetterAuthStore();
+
+  const load = async () => {
+    try {
+      const res: any = await apiClient.get('/api/creator/companies');
+      const data = res?.data ?? res;
+      setCompanies(Array.isArray(data?.companies) ? data.companies : []);
+    } catch {
+      /* degrade quietly */
+    } finally {
+      setLoaded(true);
+    }
+  };
 
   useEffect(() => {
     let live = true;
-    (async () => {
-      try {
-        const res: any = await apiClient.get('/api/creator/companies');
-        if (!live) return;
-        const data = res?.data ?? res;
-        setCompanies(Array.isArray(data?.companies) ? data.companies : []);
-      } catch {
-        /* degrade quietly */
-      } finally {
-        if (live) setLoaded(true);
-      }
-    })();
+    (async () => { await load(); if (!live) setLoaded(false); })();
     return () => { live = false; };
   }, []);
 
@@ -65,10 +71,30 @@ export function CreatorCollaborations() {
         {companies.map((c) => (
           <div key={c.teamId}>
             <div className="mb-2 flex items-center justify-between">
-              <p className="text-sm font-semibold text-gray-800">{c.company}</p>
+              <div className="flex items-center gap-2">
+                <p className="text-sm font-semibold text-gray-800">{c.company}</p>
+                {!c.ndaSigned && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700 ring-1 ring-inset ring-amber-200">
+                    <Lock className="h-3 w-3" /> NDA required
+                  </span>
+                )}
+              </div>
               <span className="text-xs text-gray-400">{c.pitches.length} project{c.pitches.length === 1 ? '' : 's'}</span>
             </div>
-            {c.pitches.length === 0 ? (
+
+            {!c.ndaSigned ? (
+              <div className="flex flex-col items-start gap-2 rounded-xl border border-amber-200 bg-amber-50/60 px-3.5 py-3 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-xs leading-relaxed text-amber-800">
+                  Sign {c.company}'s NDA to open their projects and join the shared workspace.
+                </p>
+                <button
+                  onClick={() => setSigningCompany(c)}
+                  className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-purple-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-purple-700"
+                >
+                  <Shield className="h-3.5 w-3.5" /> Sign NDA to collaborate
+                </button>
+              </div>
+            ) : c.pitches.length === 0 ? (
               <p className="rounded-lg border border-dashed border-gray-200 bg-gray-50/60 px-3 py-3 text-xs text-gray-400">
                 No projects yet — they'll appear here when {c.company} adds pitches.
               </p>
@@ -99,6 +125,16 @@ export function CreatorCollaborations() {
           </div>
         ))}
       </div>
+
+      {signingCompany && (
+        <CollaborationNdaModal
+          teamId={signingCompany.teamId}
+          company={signingCompany.company}
+          defaultName={(authUser as any)?.name || (authUser as any)?.username || ''}
+          onClose={() => setSigningCompany(null)}
+          onSigned={load}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/features/teams/components/CreatorCollaborations.tsx
+++ b/frontend/src/features/teams/components/CreatorCollaborations.tsx
@@ -19,6 +19,7 @@ interface Company {
   company: string;
   ownerId: number;
   ndaSigned: boolean;
+  documentUrl: string | null;
   pitches: CollabPitch[];
 }
 
@@ -79,7 +80,20 @@ export function CreatorCollaborations() {
                   </span>
                 )}
               </div>
-              <span className="text-xs text-gray-400">{c.pitches.length} project{c.pitches.length === 1 ? '' : 's'}</span>
+              <div className="flex items-center gap-3">
+                {c.ndaSigned && c.documentUrl && (
+                  <a
+                    href={`${import.meta.env.VITE_API_URL || ''}${c.documentUrl}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-xs font-medium text-purple-600 hover:text-purple-800"
+                    title="View your signed NDA"
+                  >
+                    <FileText className="h-3.5 w-3.5" /> Signed NDA
+                  </a>
+                )}
+                <span className="text-xs text-gray-400">{c.pitches.length} project{c.pitches.length === 1 ? '' : 's'}</span>
+              </div>
             </div>
 
             {!c.ndaSigned ? (

--- a/frontend/src/features/teams/components/__tests__/CollaborationNdaModal.test.tsx
+++ b/frontend/src/features/teams/components/__tests__/CollaborationNdaModal.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import React from 'react'
+
+// ─── Hoisted mocks ──────────────────────────────────────────────────
+const mockPost = vi.fn()
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+vi.mock('../../../../lib/api-client', () => ({
+  default: { post: (...a: any[]) => mockPost(...a) },
+  apiClient: { post: (...a: any[]) => mockPost(...a) },
+}))
+
+vi.mock('react-hot-toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+import { CollaborationNdaModal } from '../CollaborationNdaModal'
+
+const ndaBody = { success: true, data: { name: 'Pitchey Standard NDA', content: 'NDA TERMS HERE' } }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFetch.mockResolvedValue({ json: () => Promise.resolve(ndaBody) } as any)
+  mockPost.mockResolvedValue({ success: true, data: { signed: true } })
+})
+
+describe('CollaborationNdaModal', () => {
+  it('renders the fetched NDA text with company autofill in the request', async () => {
+    render(
+      <CollaborationNdaModal teamId={2} company="Stellar Pictures" onClose={() => {}} onSigned={() => {}} />
+    )
+    await waitFor(() => expect(screen.getByText('NDA TERMS HERE')).toBeInTheDocument())
+    const url = mockFetch.mock.calls[0][0] as string
+    expect(url).toContain('disclosingName=Stellar+Pictures')
+    expect(url).toContain('projectName=all+Stellar+Pictures+projects')
+  })
+
+  it('keeps Sign disabled until the box is ticked and a name is entered', async () => {
+    render(
+      <CollaborationNdaModal teamId={2} company="Stellar Pictures" onClose={() => {}} onSigned={() => {}} />
+    )
+    await waitFor(() => screen.getByText('NDA TERMS HERE'))
+    const signBtn = screen.getByRole('button', { name: /Sign & Continue/i }) as HTMLButtonElement
+    expect(signBtn.disabled).toBe(true)
+
+    fireEvent.click(screen.getByRole('checkbox'))
+    expect(signBtn.disabled).toBe(true) // still needs a name
+
+    fireEvent.change(screen.getByPlaceholderText('Jane Q. Creator'), { target: { value: 'Alex Creator' } })
+    expect(signBtn.disabled).toBe(false)
+  })
+
+  it('POSTs the signature and fires onSigned', async () => {
+    const onSigned = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <CollaborationNdaModal teamId={2} company="Stellar Pictures" defaultName="Alex Creator" onClose={onClose} onSigned={onSigned} />
+    )
+    await waitFor(() => screen.getByText('NDA TERMS HERE'))
+    fireEvent.click(screen.getByRole('checkbox'))
+    fireEvent.click(screen.getByRole('button', { name: /Sign & Continue/i }))
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith(
+      '/api/teams/2/collaboration-nda/sign',
+      expect.objectContaining({ agreed: true, name: 'Alex Creator' }),
+    ))
+    await waitFor(() => expect(onSigned).toHaveBeenCalled())
+  })
+})

--- a/frontend/src/features/teams/components/__tests__/CompanyJoinCodeCard.test.tsx
+++ b/frontend/src/features/teams/components/__tests__/CompanyJoinCodeCard.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+import { CompanyJoinCodeCard } from '../CompanyTeamCards'
+
+// Route the local api() helper's fetch calls by URL.
+function routeFetch(url: string) {
+  const json = (body: any) => Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) } as any)
+  if (url.endsWith('/api/teams')) return json({ data: { teams: [{ id: 2, is_company_team: true }] } })
+  if (url.endsWith('/api/teams/2/code')) return json({ data: { code: 'ABCD2345', seatsUsed: 2, seatLimit: 3 } })
+  if (url.endsWith('/api/teams/2/collaboration-nda/members')) return json({ data: { members: [
+    { userId: 1025, name: 'Alex Creator', email: 'alex@demo.com', ndaStatus: 'signed', signedAt: '2026-06-05T13:18:28Z', documentUrl: '/api/teams/2/collaboration-nda/document?signerId=1025' },
+    { userId: 1099, name: 'Dana Writer', email: 'dana@demo.com', ndaStatus: 'pending', signedAt: null, documentUrl: null },
+  ] } })
+  return json({})
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFetch.mockImplementation((url: string) => routeFetch(String(url)))
+})
+
+describe('CompanyJoinCodeCard — per-seat NDA status', () => {
+  it('lists members with Signed / Pending status and a doc link for signed', async () => {
+    render(<CompanyJoinCodeCard />)
+
+    await waitFor(() => expect(screen.getByText('Alex Creator')).toBeInTheDocument())
+    expect(screen.getByText('Dana Writer')).toBeInTheDocument()
+    expect(screen.getByText('Signed')).toBeInTheDocument()
+    expect(screen.getByText('Pending')).toBeInTheDocument()
+
+    // Signed member exposes a "View NDA" link to the document endpoint.
+    const link = screen.getByTitle('View signed NDA') as HTMLAnchorElement
+    expect(link.getAttribute('href')).toContain('/api/teams/2/collaboration-nda/document?signerId=1025')
+  })
+})

--- a/frontend/src/pages/Homepage.tsx
+++ b/frontend/src/pages/Homepage.tsx
@@ -284,7 +284,7 @@ export default function Homepage() {
           rails below it intentionally read as the marquee turning the lights up.
           -mt-16 pulls the hero up behind the sticky nav so the nav's backdrop is the hero
           itself (not the light page background). */}
-      <section ref={heroRef} className="relative -mt-16 overflow-hidden bg-[#0a0a12] text-white">
+      <section ref={heroRef} className="relative -mt-16 overflow-hidden bg-gradient-to-b from-[#3a2f5c] via-[#2c2547] to-[#1f1934] text-white">
         {/* Spotlight glows */}
         <div aria-hidden className="absolute -top-48 left-1/2 -translate-x-1/2 w-[64rem] h-[44rem] rounded-full blur-[80px] bg-[radial-gradient(ellipse_at_center,rgba(132,45,168,0.45),transparent_62%)]" />
         <div aria-hidden className="absolute top-1/4 -right-24 w-[34rem] h-[34rem] rounded-full blur-[90px] bg-[radial-gradient(circle,rgba(245,158,11,0.20),transparent_60%)]" />
@@ -324,12 +324,15 @@ export default function Homepage() {
           <h1 className="font-display font-black tracking-tight leading-[0.92] text-5xl sm:text-7xl lg:text-8xl mb-6">
             Where stories
             <br />
-            <span className="italic font-semibold bg-gradient-to-r from-violet-300 via-fuchsia-300 to-purple-300 bg-clip-text text-transparent">
+            {/* inline-block + roomier leading + padding so the italic gradient "f"
+                ascender/overhang isn't clipped by WebKit bg-clip-text under the
+                tight 0.92 line-height (Karl: "the F in find is messy"). */}
+            <span className="inline-block italic font-semibold leading-[1.15] pb-1 pr-2 bg-gradient-to-r from-violet-300 via-fuchsia-300 to-purple-300 bg-clip-text text-transparent">
               find life
             </span>
           </h1>
 
-          <p className="max-w-2xl mx-auto text-lg sm:text-xl leading-relaxed text-white/60 mb-10">
+          <p className="max-w-2xl mx-auto text-lg sm:text-xl leading-relaxed text-white/80 mb-10">
             Share your vision, discover original stories, and connect directly with the producers
             and investors shaping the future of film, television, and new media.
           </p>

--- a/frontend/src/pages/PitchDetail.tsx
+++ b/frontend/src/pages/PitchDetail.tsx
@@ -13,6 +13,7 @@ import EnhancedNDARequest from '@features/ndas/components/NDA/EnhancedNDARequest
 import { ndaService } from '@features/ndas/services/nda.service';
 import FormatDisplay from '../components/FormatDisplay';
 import FollowButton from '@features/browse/components/FollowButton';
+import InterestedCard from '@features/pitches/components/InterestedCard';
 import SocialProofBadge from '@shared/components/SocialProofBadge';
 import { formatCurrency } from '@shared/utils/formatters';
 import FeedbackSection from '../components/feedback/FeedbackSection';
@@ -452,9 +453,7 @@ export default function PitchDetail() {
                       {pitch.creator?.name || pitch.creator?.username || 'Unknown Creator'}
                     </span>
                     <VerificationBadge tier={(pitch as any).creator_verification_tier || (pitch.creator as any)?.verificationTier} />
-                    {isAuthenticated && !isOwner && pitch.creator?.id && (
-                      <FollowButton creatorId={pitch.creator.id} variant="small" />
-                    )}
+                    {/* Follow lives in the unified InterestedCard below — no inline duplicate */}
                   </div>
                 ) : (
                   <div className="flex items-center gap-1.5">
@@ -462,9 +461,7 @@ export default function PitchDetail() {
                     <span className="text-gray-500 italic">Creator info hidden — NDA required</span>
                     {/* Following is a public action — allow it pre-NDA without
                         revealing the creator's name (button only needs the id). */}
-                    {isAuthenticated && !isOwner && pitch.creator?.id && (
-                      <FollowButton creatorId={pitch.creator.id} variant="small" />
-                    )}
+                    {/* Follow lives in the unified InterestedCard below — no inline duplicate */}
                   </div>
                 )}
                 <div className="flex items-center gap-1.5">
@@ -962,46 +959,30 @@ export default function PitchDetail() {
               />
             )}
 
-            {/* Engagement Actions */}
+            {/* Engagement Actions — unified "Interested?" box (shared across portals) */}
             {!isOwner && (
-              <div className="bg-white rounded-xl shadow-sm p-4 flex flex-col gap-2">
-                {/* Like — visible to all (anon click → sign-in) */}
-                <button
-                  onClick={handleLike}
-                  className={`w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg font-medium transition ${
-                    isLiked
-                      ? 'bg-red-50 text-red-600 hover:bg-red-100'
-                      : 'bg-gray-50 text-gray-600 hover:bg-gray-100'
-                  }`}
-                >
-                  <Heart className={`w-5 h-5 ${isLiked ? 'fill-current' : ''}`} />
-                  {isLiked ? 'Liked' : 'Like'}
-                </button>
-
-                {/* Save — auth-only */}
-                {isAuthenticated && (
-                  <button
-                    onClick={handleSave}
-                    className={`w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg font-medium transition ${
-                      isSaved
-                        ? 'bg-blue-50 text-blue-600 hover:bg-blue-100'
-                        : 'bg-gray-50 text-gray-600 hover:bg-gray-100'
-                    }`}
-                  >
-                    <Bookmark className={`w-5 h-5 ${isSaved ? 'fill-current' : ''}`} />
-                    {isSaved ? 'Saved' : 'Save'}
-                  </button>
-                )}
+              <>
+                <InterestedCard
+                  pitchId={pitch.id}
+                  creatorId={pitch.creator?.id}
+                  initialLiked={isLiked}
+                  initialSaved={isSaved}
+                  isAuthenticated={isAuthenticated}
+                  isOwner={isOwner}
+                  fromPath={`/pitch/${id}`}
+                />
 
                 {/* Share — visible to all */}
-                <button
-                  onClick={handleShare}
-                  className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg font-medium bg-gray-50 text-gray-600 hover:bg-gray-100 transition"
-                >
-                  <Share2 className="w-5 h-5" />
-                  {shareCopied ? 'Link copied!' : 'Share'}
-                </button>
-              </div>
+                <div className="bg-white rounded-xl shadow-sm p-4">
+                  <button
+                    onClick={handleShare}
+                    className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg font-medium bg-gray-50 text-gray-600 hover:bg-gray-100 transition"
+                  >
+                    <Share2 className="w-5 h-5" />
+                    {shareCopied ? 'Link copied!' : 'Share'}
+                  </button>
+                </div>
+              </>
             )}
 
             {/* Project Info */}

--- a/frontend/src/pages/PublicPitchView.tsx
+++ b/frontend/src/pages/PublicPitchView.tsx
@@ -9,6 +9,7 @@ import PortalTopNav from '@shared/components/layout/PortalTopNav';
 import { ndaService } from '@features/ndas/services/nda.service';
 import NDAWizard from '@features/ndas/components/NDAWizard';
 import PitchDocuments from '@features/pitches/components/PitchDocuments';
+import InterestedCard from '@features/pitches/components/InterestedCard';
 import FormatDisplay from '../components/FormatDisplay';
 import FeedbackSection from '../components/feedback/FeedbackSection';
 import { viewService } from '@features/analytics/services/view.service';
@@ -727,40 +728,17 @@ export default function PublicPitchView() {
               </div>
             </div>
 
-            {/* Engagement Actions — prompt signup for unauthenticated users */}
-            {!isAuthenticated && (
-              <div className="bg-white rounded-xl shadow-sm p-6">
-                <h3 className="text-lg font-semibold text-gray-900 mb-3">Interested?</h3>
-                <p className="text-sm text-gray-500 mb-4">Sign in to engage with this pitch and its creator. New here? You can create an account on the sign-in page.</p>
-                <div className="space-y-2">
-                  <button
-                    onClick={() => { void navigate('/login', { state: { from: `/pitch/${id}` } }); }}
-                    className="w-full flex items-center gap-3 px-4 py-2.5 bg-gray-50 hover:bg-red-50 text-gray-700 hover:text-red-600 rounded-lg transition group"
-                  >
-                    <Heart className="w-4 h-4 group-hover:fill-red-200" />
-                    <span className="flex-1 text-left text-sm font-medium">Like this pitch</span>
-                    <span className="text-xs text-gray-400">Free</span>
-                  </button>
-                  <button
-                    onClick={() => { void navigate('/login', { state: { from: `/pitch/${id}` } }); }}
-                    className="w-full flex items-center gap-3 px-4 py-2.5 bg-gray-50 hover:bg-purple-50 text-gray-700 hover:text-purple-600 rounded-lg transition group"
-                  >
-                    <UserPlus className="w-4 h-4" />
-                    <span className="flex-1 text-left text-sm font-medium">Follow this creator</span>
-                    <span className="text-xs text-gray-400">Free</span>
-                  </button>
-                  <button
-                    onClick={() => { void navigate('/login', { state: { from: `/pitch/${id}` } }); }}
-                    className="w-full flex items-center gap-3 px-4 py-2.5 bg-gray-50 hover:bg-blue-50 text-gray-700 hover:text-blue-600 rounded-lg transition group"
-                  >
-                    <Bookmark className="w-4 h-4" />
-                    <span className="flex-1 text-left text-sm font-medium">Save for later</span>
-                    <span className="text-xs text-gray-400">Free</span>
-                  </button>
-                </div>
-                <p className="text-xs text-gray-400 mt-3 text-center">No credit card required</p>
-              </div>
-            )}
+            {/* Engagement Actions — unified "Interested?" box (shared across portals).
+                Anonymous → sign-in prompts; authenticated → live like/follow/save. */}
+            <InterestedCard
+              pitchId={pitch.id}
+              creatorId={pitch.creator?.id}
+              initialLiked={(pitch as any).isLiked}
+              initialSaved={(pitch as any).isSaved}
+              isAuthenticated={isAuthenticated}
+              isOwner={isOwner}
+              fromPath={`/pitch/${id}`}
+            />
 
             {/* Actions */}
             <div className="bg-white rounded-xl shadow-sm p-6">

--- a/frontend/src/pages/__tests__/ProductionPitchView.test.tsx
+++ b/frontend/src/pages/__tests__/ProductionPitchView.test.tsx
@@ -228,8 +228,10 @@ describe('ProductionPitchView', () => {
     await waitFor(() => {
       expect(screen.getByText('Contact')).toBeInTheDocument()
     })
-    expect(screen.getByText('Shortlist')).toBeInTheDocument()
     expect(screen.getByText('Share')).toBeInTheDocument()
+    // Like + Save moved from the header into the unified InterestedCard (sidebar).
+    expect(screen.getByText('Save for later')).toBeInTheDocument()
+    expect(screen.getByText('Like this pitch')).toBeInTheDocument()
   })
 
   it('navigates when Contact button is clicked', async () => {

--- a/frontend/src/portals/creator/pages/CreatorPitchView.tsx
+++ b/frontend/src/portals/creator/pages/CreatorPitchView.tsx
@@ -12,6 +12,7 @@ import { useBetterAuthStore } from '@/store/betterAuthStore';
 import FormatDisplay from '@/components/FormatDisplay';
 import FeedbackDisplay from '@/components/feedback/FeedbackDisplay';
 import FollowButton from '@features/browse/components/FollowButton';
+import InterestedCard from '@features/pitches/components/InterestedCard';
 
 interface Pitch {
   id: string;
@@ -292,7 +293,7 @@ const CreatorPitchView: React.FC = () => {
                 because this portal view lacked it. */}
             {!isOwner && pitch.userId && (
               <div className="flex items-center gap-3">
-                <FollowButton creatorId={parseInt(pitch.userId)} />
+                {/* Follow now lives in the unified InterestedCard in the sidebar */}
                 <button
                   onClick={() => navigate(`/creator/messages?recipient=${pitch.userId}&pitch=${id}`)}
                   className="flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700"
@@ -593,6 +594,17 @@ const CreatorPitchView: React.FC = () => {
 
           {/* Right Column - Sidebar */}
           <div className="space-y-6">
+            {/* Unified "Interested?" box — like / follow creator / save (shared across portals) */}
+            {!isOwner && pitch.userId && (
+              <InterestedCard
+                pitchId={pitch.id}
+                creatorId={parseInt(pitch.userId)}
+                isAuthenticated={isAuthenticated}
+                isOwner={isOwner}
+                fromPath={`/creator/pitch/${id}`}
+              />
+            )}
+
             {/* Quick Stats */}
             <div className="bg-white rounded-xl shadow-lg p-6">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">Quick Stats</h3>

--- a/frontend/src/portals/creator/pages/CreatorSlates.tsx
+++ b/frontend/src/portals/creator/pages/CreatorSlates.tsx
@@ -207,7 +207,10 @@ export default function CreatorSlates() {
             {slates.length === 0 ? 'No slates yet' : 'No slates match your filters'}
           </p>
           {slates.length === 0 && (
-            <p className="text-gray-500 mt-1">Create a slate to curate and share collections of pitches</p>
+            <p className="text-gray-500 mt-1 max-w-md mx-auto">
+              A slate is a shareable, curated collection — bundle several of your pitches into one
+              link to send to investors, festivals, or collaborators. Create your first to get started.
+            </p>
           )}
         </div>
       ) : (

--- a/frontend/src/portals/production/components/ProductionSlateBoard.tsx
+++ b/frontend/src/portals/production/components/ProductionSlateBoard.tsx
@@ -120,7 +120,7 @@ export default function ProductionSlateBoard() {
           </span>
           <div>
             <h2 className="text-lg font-bold tracking-tight text-gray-900">Your Slate</h2>
-            <p className="text-xs text-gray-500">Owned & saved projects by readiness — derived from each project's workspace.</p>
+            <p className="text-xs text-gray-500">Your production pipeline — every project you own or saved, grouped by how close it is to being made. Move projects forward as you complete each one's workspace.</p>
           </div>
         </div>
         <button onClick={() => navigate('/production/browse')} className="hidden items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-700 sm:inline-flex">

--- a/frontend/src/portals/production/pages/ProductionPitchView.tsx
+++ b/frontend/src/portals/production/pages/ProductionPitchView.tsx
@@ -23,6 +23,7 @@ import { pitchService } from '@features/pitches/services/pitch.service';
 import PitchDocuments from '@features/pitches/components/PitchDocuments';
 import SocialProofBadge from '@shared/components/SocialProofBadge';
 import FeedbackSection from '@/components/feedback/FeedbackSection';
+import { CollaborationNdaModal } from '@features/teams/components/CollaborationNdaModal';
 
 interface Pitch {
   id: string;
@@ -54,6 +55,8 @@ interface Pitch {
   updatedAt: string;
   hasSignedNDA?: boolean;
   isCompanyMember?: boolean;
+  companyTeamId?: number | null;     // team to sign the collaboration NDA for
+  companyNdaSigned?: boolean;        // member has signed the company NDA (B3 Phase 2)
   requiresNDA?: boolean;           // pitch was created with NDA protection
   require_nda?: boolean;           // snake-case fallback
   creatorType?: string;            // owner's user_type — selects workspace mode
@@ -136,9 +139,17 @@ const ProductionPitchView: React.FC = () => {
   //  • creator-OWNED pitch → any production user edits their OWN private workspace.
   const ownerIsProduction =
     (pitch?.creatorType || pitch?.creator_type || pitch?.creator?.userType) === 'production';
+  // B3 Phase 2: a seated company member only collaborates once they've signed the
+  // company collaboration NDA. Pending members see a sign prompt, not the workspace.
+  const isCompanyMemberSigned = !!pitch?.isCompanyMember && !!pitch?.companyNdaSigned;
+  const isCompanyMemberPending = !!pitch?.isCompanyMember && !pitch?.companyNdaSigned;
   const canEditWorkspace = ownerIsProduction
-    ? (isOwner || !!pitch?.isCompanyMember)
+    ? (isOwner || isCompanyMemberSigned)
     : (authUser?.userType === 'production');
+  // Anyone who may see the workspace tab CONTENT (owner, NDA-signed producer, or
+  // a signed company member). Pending members are excluded — they get the prompt.
+  const canSeeWorkspace = isOwner || !!pitch?.hasSignedNDA || isCompanyMemberSigned;
+  const [signCompanyNda, setSignCompanyNda] = useState(false);
 
   // Whether this pitch was created WITH NDA protection. Pitches created without
   // one are openly accessible — so we don't offer "Request NDA Access" on them.
@@ -698,11 +709,11 @@ const ProductionPitchView: React.FC = () => {
               <div className="flex border-b">
                 {['overview', 'production', 'team', 'notes'].map((tab) => {
                   const ndaRequired = tab === 'team' || tab === 'notes';
-                  // Seated company members (B3) reach Team/Notes without an NDA —
-                  // matches the tab-content gate (isOwner || hasSignedNDA ||
-                  // isCompanyMember). Without isCompanyMember here the tab button
-                  // stayed locked for members even though the content would render.
-                  const locked = ndaRequired && !isOwner && !pitch?.hasSignedNDA && !pitch?.isCompanyMember;
+                  // Seated company members (B3) reach Team/Notes once they've
+                  // signed the company collaboration NDA — matches the tab-content
+                  // gate (canSeeWorkspace). Pending members stay locked and see the
+                  // sign prompt in the Access card.
+                  const locked = ndaRequired && !canSeeWorkspace;
                   return (
                     <button
                       key={tab}
@@ -963,7 +974,7 @@ const ProductionPitchView: React.FC = () => {
               </div>
             )}
 
-            {activeTab === 'team' && (isOwner || pitch?.hasSignedNDA || pitch?.isCompanyMember) && (
+            {activeTab === 'team' && canSeeWorkspace && (
               <div className="bg-white rounded-2xl shadow-sm ring-1 ring-gray-100 p-6 sm:p-8">
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex items-center gap-2.5">
@@ -1075,7 +1086,7 @@ const ProductionPitchView: React.FC = () => {
               </div>
             )}
 
-            {activeTab === 'notes' && (isOwner || pitch?.hasSignedNDA || pitch?.isCompanyMember) && (
+            {activeTab === 'notes' && canSeeWorkspace && (
               <div className="bg-white rounded-2xl shadow-sm ring-1 ring-gray-100 p-6 sm:p-8">
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex items-center gap-2.5">
@@ -1197,7 +1208,22 @@ const ProductionPitchView: React.FC = () => {
                     <Clock className="h-5 w-5 shrink-0 text-amber-600" />
                     <p className="text-sm font-medium leading-snug">NDA request pending — you'll get access once the creator approves it.</p>
                   </div>
-                ) : pitch?.isCompanyMember ? (
+                ) : isCompanyMemberPending ? (
+                  <div className="mt-3 rounded-lg bg-amber-50 px-3.5 py-3 text-amber-900">
+                    <div className="flex items-start gap-2.5">
+                      <Shield className="h-5 w-5 shrink-0 text-amber-600" />
+                      <p className="text-sm font-medium leading-snug">
+                        Sign the {pitch?.creator?.name || 'company'} NDA to start collaborating on this project.
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => setSignCompanyNda(true)}
+                      className="mt-3 flex w-full items-center justify-center gap-2 rounded-lg bg-purple-600 px-4 py-2.5 font-medium text-white shadow-sm transition hover:bg-purple-700"
+                    >
+                      <Shield className="h-4 w-4" /> Sign NDA to collaborate
+                    </button>
+                  </div>
+                ) : isCompanyMemberSigned ? (
                   <div className="mt-3 flex items-start gap-2.5 rounded-lg bg-indigo-50 px-3.5 py-3 text-indigo-800">
                     <Users className="h-5 w-5 shrink-0 text-indigo-600" />
                     <p className="text-sm font-medium leading-snug">You're collaborating on this project as a company member.</p>
@@ -1354,6 +1380,16 @@ const ProductionPitchView: React.FC = () => {
           </div>
         </div>
       </div>
+
+      {signCompanyNda && pitch?.companyTeamId && (
+        <CollaborationNdaModal
+          teamId={pitch.companyTeamId}
+          company={pitch?.creator?.name || 'the company'}
+          defaultName={(authUser as any)?.name || (authUser as any)?.username || ''}
+          onClose={() => setSignCompanyNda(false)}
+          onSigned={() => { setSignCompanyNda(false); fetchPitchData(); }}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/portals/production/pages/ProductionPitchView.tsx
+++ b/frontend/src/portals/production/pages/ProductionPitchView.tsx
@@ -19,6 +19,7 @@ import { toast } from 'react-hot-toast';
 import { ProductionService } from '../services/production.service';
 import type { ProductionNoteResponse, ProductionTeamMember } from '../services/production.service';
 import FollowButton from '@features/browse/components/FollowButton';
+import InterestedCard from '@features/pitches/components/InterestedCard';
 import { pitchService } from '@features/pitches/services/pitch.service';
 import PitchDocuments from '@features/pitches/components/PitchDocuments';
 import SocialProofBadge from '@shared/components/SocialProofBadge';
@@ -662,32 +663,7 @@ const ProductionPitchView: React.FC = () => {
         </div>
 
         <div className="flex items-center space-x-2 sm:space-x-3">
-          {!isOwner && (
-            <button
-              onClick={handleLike}
-              className={`flex items-center px-3 py-1.5 rounded-lg text-sm transition-colors ${
-                isLiked
-                  ? 'bg-red-50 text-red-600 hover:bg-red-100'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              }`}
-            >
-              <Heart className={`h-4 w-4 sm:mr-1.5 ${isLiked ? 'fill-current' : ''}`} />
-              <span className="hidden sm:inline">{isLiked ? 'Liked' : 'Like'}</span>
-            </button>
-          )}
-
-          <button
-            onClick={handleShortlistToggle}
-            className={`flex items-center px-3 py-1.5 rounded-lg text-sm transition-colors ${
-              isShortlisted
-                ? 'bg-yellow-100 text-yellow-700 hover:bg-yellow-200'
-                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-            }`}
-          >
-            {isShortlisted ? <BookmarkCheck className="h-4 w-4 sm:mr-1.5" /> : <Bookmark className="h-4 w-4 sm:mr-1.5" />}
-            <span className="hidden sm:inline">{isShortlisted ? 'Shortlisted' : 'Shortlist'}</span>
-          </button>
-
+          {/* Like + Save now live in the unified InterestedCard in the sidebar */}
           {!isOwner && (
             <button
               onClick={handleContactCreator}
@@ -1207,6 +1183,19 @@ const ProductionPitchView: React.FC = () => {
 
           {/* Right Column - Sidebar */}
           <div className="space-y-6">
+            {/* Unified "Interested?" box — like / follow creator / save (shared across portals) */}
+            {!isOwner && pitch && (
+              <InterestedCard
+                pitchId={pitch.id}
+                creatorId={pitch.userId ? parseInt(String(pitch.userId)) : undefined}
+                initialLiked={isLiked}
+                initialSaved={isShortlisted}
+                isAuthenticated={isAuthenticated}
+                isOwner={isOwner}
+                fromPath={`/production/pitch/${id}`}
+              />
+            )}
+
             {/* Access — the NDA is the single gate that unlocks the full script,
                 pitch deck, and all production materials (no separate "request script"). */}
             {!isOwner && (

--- a/frontend/src/portals/production/pages/ProductionPitchView.tsx
+++ b/frontend/src/portals/production/pages/ProductionPitchView.tsx
@@ -396,12 +396,31 @@ const ProductionPitchView: React.FC = () => {
     }
   };
 
-  const handleSharePitch = () => {
-    navigator.clipboard.writeText(window.location.href).then(() => {
+  const handleSharePitch = async () => {
+    if (!pitch) return;
+    // Share the PUBLIC pitch URL (/pitch/:id), NOT the gated /production/pitch/:id
+    // portal route. Only the public route has the social-unfurl Pages Function
+    // (functions/pitch/[id].ts) that injects Open Graph / Twitter Card tags + a
+    // preview image, so this is what renders a rich card in DMs / X / FB / iMessage.
+    const url = `${window.location.origin}/pitch/${pitch.id}`;
+    const title = pitch.title ? `${pitch.title} — Pitchey` : 'Pitchey';
+    const text = pitch.logline || 'Check out this pitch on Pitchey.';
+    // Native share sheet where supported (mobile + some desktop); clipboard fallback.
+    if (navigator.share) {
+      try {
+        await navigator.share({ title, text, url });
+        return;
+      } catch (err) {
+        // User dismissed the sheet → stop quietly. Other errors → clipboard fallback.
+        if (err instanceof Error && err.name === 'AbortError') return;
+      }
+    }
+    try {
+      await navigator.clipboard.writeText(url);
       toast.success('Link copied to clipboard');
-    }).catch(() => {
+    } catch {
       toast.error('Failed to copy link');
-    });
+    }
   };
 
   const handleAddNote = async () => {

--- a/src/handlers/creator-dashboard.ts
+++ b/src/handlers/creator-dashboard.ts
@@ -73,13 +73,23 @@ export async function creatorDashboardHandler(request: Request, env: Env): Promi
     
     // Fetch dashboard metrics with inline SQL for reliability
     // (query modules use WhereBuilder patterns incompatible with neon tagged templates)
-    const results = await Promise.allSettled([
-      sql`
+    // safeQuery: a query that explodes (schema drift, etc.) now reports to Sentry
+    // and is distinguishable from "returned empty" via .errored — instead of
+    // silently rendering as zero data. Fallbacks keep the page rendering.
+    const [
+      statsResult,
+      recentPitchesResult,
+      analyticsResult,
+      ndaResult,
+      investmentsResult,
+      notificationsResult,
+    ] = await Promise.all([
+      safeQuery<{ totalPitches: number; totalFollowers: number }>(() => sql`
         SELECT
           (SELECT COUNT(*)::int FROM pitches WHERE creator_id::text = ${userId} OR user_id::text = ${userId}) as "totalPitches",
           (SELECT COUNT(*)::int FROM follows WHERE following_id::text = ${userId}) as "totalFollowers"
-      `.catch((err: unknown) => { console.error('Dashboard stats query error:', err); return [{ totalPitches: 0, totalFollowers: 0 }]; }),
-      sql`
+      `, { fallback: [{ totalPitches: 0, totalFollowers: 0 }], context: 'creator-dashboard.stats' }),
+      safeQuery(() => sql`
         SELECT id, title, logline, genre, status,
                view_count as views, like_count as likes,
                title_image as thumbnail, created_at, updated_at,
@@ -90,37 +100,46 @@ export async function creatorDashboardHandler(request: Request, env: Env): Promi
         WHERE creator_id::text = ${userId} OR user_id::text = ${userId}
         ORDER BY updated_at DESC
         LIMIT 5
-      `.catch((err: unknown) => { console.error('Dashboard recent pitches query error:', err); return []; }),
-      sql`
+      `, { fallback: [], context: 'creator-dashboard.recent-pitches' }),
+      safeQuery<{ total_views: number; avg_engagement: number }>(() => sql`
         SELECT
           COALESCE(SUM(view_count), 0)::int as total_views,
           COALESCE(AVG(CASE WHEN view_count > 0 THEN (like_count::float / view_count * 100) ELSE 0 END), 0) as avg_engagement
         FROM pitches
         WHERE creator_id::text = ${userId} OR user_id::text = ${userId}
-      `.catch((err: unknown) => { console.error('Dashboard analytics query error:', err); return [{ total_views: 0, avg_engagement: 0 }]; }),
-      documentQueries.getUserNDARequests(sql as any, userId, 'received').catch((err: unknown) => { console.error('Dashboard NDA query error:', err); return []; }),
-      investmentQueries.getInvestorPortfolio(sql as any, userId, {}).catch((err: unknown) => { console.error('Dashboard investments query error:', err); return []; }),
-      notificationQueries.getUserNotifications(sql as any, userId, { limit: 5 }).catch((err: unknown) => { console.error('Dashboard notifications query error:', err); return []; })
+      `, { fallback: [{ total_views: 0, avg_engagement: 0 }], context: 'creator-dashboard.analytics' }),
+      safeQuery<documentQueries.NDARequest>(() => documentQueries.getUserNDARequests(sql as any, userId, 'received'), { fallback: [], context: 'creator-dashboard.ndas' }),
+      safeQuery<investmentQueries.Investment>(() => investmentQueries.getInvestorPortfolio(sql as any, userId, {}), { fallback: [], context: 'creator-dashboard.investments' }),
+      safeQuery<notificationQueries.Notification>(() => notificationQueries.getUserNotifications(sql as any, userId, { limit: 5 }), { fallback: [], context: 'creator-dashboard.notifications' }),
     ]);
 
-    const userStats = results[0].status === 'fulfilled' ? (results[0].value as any[])[0] || { totalPitches: 0, totalFollowers: 0 } : { totalPitches: 0, totalFollowers: 0 };
-    const recentPitches = results[1].status === 'fulfilled' ? results[1].value as any[] : [];
-    const analytics = results[2].status === 'fulfilled' ? (results[2].value as any[])[0] || { total_views: 0, avg_engagement: 0 } : { total_views: 0, avg_engagement: 0 };
-    const pendingNDAs = results[3].status === 'fulfilled' ? results[3].value as documentQueries.NDARequest[] : [];
-    const recentInvestments = results[4].status === 'fulfilled' ? results[4].value as investmentQueries.Investment[] : [];
-    const notifications = results[5].status === 'fulfilled' ? results[5].value as notificationQueries.Notification[] : [];
+    const userStats = statsResult.rows[0] || { totalPitches: 0, totalFollowers: 0 };
+    const recentPitches = recentPitchesResult.rows as any[];
+    const analytics = analyticsResult.rows[0] || { total_views: 0, avg_engagement: 0 };
+    const pendingNDAs = ndaResult.rows as documentQueries.NDARequest[];
+    const recentInvestments = investmentsResult.rows as investmentQueries.Investment[];
+    const notifications = notificationsResult.rows as notificationQueries.Notification[];
 
-    // Calculate revenue metrics with error handling
-    const revenueData = await getRevenueMetrics(sql, userId).catch((err: unknown) => { console.error('Dashboard revenue metrics error:', err); return {
-      totalRevenue: 0,
-      committedFunds: 0,
-      pipelineValue: 0,
-      activeInvestors: 0,
-      avgDealSize: 0
-    }; });
+    // Revenue metrics return an object — wrap in an array so safeQuery's
+    // error-reporting path (Sentry + .errored) covers it too.
+    const revenueResult = await safeQuery(() => getRevenueMetrics(sql, userId).then((r) => [r]), {
+      fallback: [{ totalRevenue: 0, committedFunds: 0, pipelineValue: 0, activeInvestors: 0, avgDealSize: 0 }],
+      context: 'creator-dashboard.revenue',
+    });
+    const revenueData = revenueResult.rows[0];
     
+    const viewTrendResult = await safeQuery(() => getViewTrend(sql, userId), { fallback: [], context: 'creator-dashboard.view-trend' });
+
+    // True when any query errored (vs. legitimately empty) — lets the frontend
+    // show "some data couldn't load" instead of a false zero state.
+    const degraded = [
+      statsResult, recentPitchesResult, analyticsResult, ndaResult,
+      investmentsResult, notificationsResult, revenueResult, viewTrendResult,
+    ].some((r) => r.errored);
+
     return new Response(JSON.stringify({
       success: true,
+      degraded,
       data: {
         overview: {
           totalPitches: userStats.totalPitches || 0,
@@ -139,7 +158,7 @@ export async function creatorDashboardHandler(request: Request, env: Env): Promi
           notifications: notifications
         },
         analytics: {
-          viewTrend: await getViewTrend(sql, userId).catch((err: unknown) => { console.error('Dashboard view trend error:', err); return []; }),
+          viewTrend: viewTrendResult.rows,
           engagementRate: analytics.avg_engagement || 0,
           topPerformingPitch: recentPitches.length > 0 ? recentPitches[0] : null
         }

--- a/src/handlers/follows-enhanced.ts
+++ b/src/handlers/follows-enhanced.ts
@@ -1,11 +1,22 @@
 import type { Env } from '../worker-integrated';
 import postgres from 'postgres';
 import { z } from 'zod';
-import { getAuthUser } from '../utils/auth';
 import { corsHeaders, getCorsHeaders } from '../utils/response';
 import { getDb } from '../db/connection';
 import type { Env as DbEnv } from '../db/connection';
-import { getUserId } from '../utils/auth-extract';
+import { getUserId, getAuthenticatedUser } from '../utils/auth-extract';
+
+// Authenticate via auth-extract (getAuthenticatedUser) — the same reliable path
+// like/save use. The previous getAuthUser (utils/auth → verifyAuth) 401'd on a KV
+// cache miss because its DB fallback diverged from auth-extract's, making follow
+// intermittently fail for users whose session wasn't warm in KV. verifyAuth's
+// DB-fallback fragility is broader (other handlers use it) and wants a separate audit.
+async function resolveFollowUser(request: Request, env: Env) {
+  const auth = await getAuthenticatedUser(request, env);
+  if (!auth.authenticated || !auth.user) return null;
+  // Normalize id to number so downstream int-column SQL comparisons stay valid.
+  return { ...auth.user, id: toIntId(auth.user.id) };
+}
 import { sendNewFollowerEmail } from '../services/email/index';
 import * as Sentry from '@sentry/cloudflare';
 
@@ -41,7 +52,7 @@ function toIntId(id: string | number | null | undefined): number {
  */
 export async function followActionHandler(request: Request, env: Env): Promise<Response> {
   try {
-    const user = await getAuthUser(request, env);
+    const user = await resolveFollowUser(request, env);
     if (!user) {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), {
         status: 401,
@@ -218,7 +229,7 @@ export async function getFollowListHandler(request: Request, env: Env): Promise<
     const params = Object.fromEntries(url.searchParams);
     const query = FollowListSchema.parse(params);
     
-    const currentUser = await getAuthUser(request, env);
+    const currentUser = await resolveFollowUser(request, env);
     const rawTargetId = query.userId || (currentUser?.id != null ? String(currentUser.id) : null);
 
     if (!rawTargetId) {
@@ -327,7 +338,7 @@ export async function getFollowStatsHandler(request: Request, env: Env): Promise
     const userId = url.searchParams.get('userId');
     const username = url.searchParams.get('username');
 
-    const currentUser = await getAuthUser(request, env);
+    const currentUser = await resolveFollowUser(request, env);
     const sql = postgres(env.DATABASE_URL);
 
     // Resolve target: explicit userId > username lookup > current user.
@@ -444,7 +455,7 @@ export async function getFollowStatsHandler(request: Request, env: Env): Promise
  */
 export async function getFollowSuggestionsHandler(request: Request, env: Env): Promise<Response> {
   try {
-    const user = await getAuthUser(request, env);
+    const user = await resolveFollowUser(request, env);
     if (!user) {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), {
         status: 401,
@@ -618,7 +629,7 @@ export async function mutualFollowersHandler(request: Request, env: DbEnv): Prom
  */
 export async function checkPitchFollowStatusHandler(request: Request, env: Env): Promise<Response> {
   try {
-    const user = await getAuthUser(request, env);
+    const user = await resolveFollowUser(request, env);
     if (!user) {
       return new Response(JSON.stringify({ success: true, data: { isFollowing: false, followerCount: 0 } }), {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' }

--- a/src/handlers/investor-dashboard.ts
+++ b/src/handlers/investor-dashboard.ts
@@ -5,6 +5,7 @@
 import { getDb } from '../db/connection';
 import type { Env } from '../db/connection';
 import { requireRole } from '../utils/auth-extract';
+import { safeQuery } from '../db/safe-query';
 
 export async function investorDashboardHandler(request: Request, env: Env): Promise<Response> {
   // Require investor role
@@ -74,27 +75,33 @@ export async function investorDashboardHandler(request: Request, env: Env): Prom
       return [{ active_ndas: 0 }];
     })();
 
-    // Simple queries for free tier
-    const [investmentStats, ndaStats, savedStats] = await Promise.all([
-      sql`
+    // Simple queries for free tier. safeQuery so a schema-drift error reports to
+    // Sentry and flips `degraded` instead of silently zeroing the portfolio.
+    const [investmentResult, ndaStats, savedResult] = await Promise.all([
+      safeQuery<{ total_investments: number; portfolio_value: number; avg_investment: number }>(() => sql`
         SELECT
           COUNT(DISTINCT i.id) as total_investments,
           COALESCE(SUM(i.amount), 0) as portfolio_value,
           COALESCE(AVG(i.amount), 0) as avg_investment
         FROM investments i
         WHERE i.investor_id = ${userId}
-      `.catch((err: unknown) => { console.error('Investor dashboard investments query error:', err); return [{ total_investments: 0, portfolio_value: 0, avg_investment: 0 }]; }),
+      `, { fallback: [{ total_investments: 0, portfolio_value: 0, avg_investment: 0 }], context: 'investor-dashboard.investments' }),
       ndaStatsP,
-      sql`
+      safeQuery<{ saved_count: number }>(() => sql`
         SELECT
           COUNT(*) as saved_count
         FROM saved_pitches
         WHERE user_id = ${userId}
-      `.catch((err: unknown) => { console.error('Investor dashboard saved_pitches query error:', err); return [{ saved_count: 0 }]; })
+      `, { fallback: [{ saved_count: 0 }], context: 'investor-dashboard.saved-pitches' })
     ]);
-    
+
+    const investmentStats = investmentResult.rows;
+    const savedStats = savedResult.rows;
+    const degraded = investmentResult.errored || savedResult.errored;
+
     return new Response(JSON.stringify({
       success: true,
+      degraded,
       data: {
         totalInvestments: Number(investmentStats[0]?.total_investments) || 0,
         portfolioValue: Number(investmentStats[0]?.portfolio_value) || 0,

--- a/src/handlers/investor-dashboard.ts
+++ b/src/handlers/investor-dashboard.ts
@@ -54,24 +54,39 @@ export async function investorDashboardHandler(request: Request, env: Env): Prom
     // Get user ID from auth
     const userId = authenticatedUserId ? Number(authenticatedUserId) : 2;
     
+    // The `ndas` signer column drifts across envs (signer_id is canonical;
+    // requester_id is legacy — see CLAUDE.md "NDA signer drift"). Try the
+    // canonical column first, fall back to the legacy one, default to 0. Wrapped
+    // so a column/table mismatch can't reject the whole Promise.all and zero out
+    // the entire dashboard (which it was doing — every investor saw all zeros).
+    // Lazy thunks — only run the fallback query if the primary column is absent
+    // (building a sql`` template eagerly kicks off the request, so a non-thunk
+    // array would fire both and leave an unhandled rejection on the unused one).
+    const ndaStatsP = (async () => {
+      const variants = [
+        () => sql`SELECT COUNT(*) FILTER (WHERE status = 'active' OR status = 'signed') AS active_ndas FROM ndas WHERE signer_id = ${userId}`,
+        () => sql`SELECT COUNT(*) FILTER (WHERE status = 'active' OR status = 'signed') AS active_ndas FROM ndas WHERE requester_id = ${userId}`,
+      ];
+      for (const run of variants) {
+        try { return await run(); } catch { /* try the next column variant */ }
+      }
+      console.error('Investor dashboard nda query: no usable signer column on `ndas`');
+      return [{ active_ndas: 0 }];
+    })();
+
     // Simple queries for free tier
     const [investmentStats, ndaStats, savedStats] = await Promise.all([
       sql`
-        SELECT 
+        SELECT
           COUNT(DISTINCT i.id) as total_investments,
           COALESCE(SUM(i.amount), 0) as portfolio_value,
           COALESCE(AVG(i.amount), 0) as avg_investment
         FROM investments i
         WHERE i.investor_id = ${userId}
-      `,
+      `.catch((err: unknown) => { console.error('Investor dashboard investments query error:', err); return [{ total_investments: 0, portfolio_value: 0, avg_investment: 0 }]; }),
+      ndaStatsP,
       sql`
-        SELECT 
-          COUNT(*) FILTER (WHERE status = 'active' OR status = 'signed') as active_ndas
-        FROM ndas
-        WHERE requester_id = ${userId}
-      `,
-      sql`
-        SELECT 
+        SELECT
           COUNT(*) as saved_count
         FROM saved_pitches
         WHERE user_id = ${userId}

--- a/src/handlers/production-pitch-data.ts
+++ b/src/handlers/production-pitch-data.ts
@@ -51,6 +51,21 @@ interface WorkspaceCtx {
   canView: boolean;
 }
 
+/** Has this creator signed the company's (collaboration) NDA? Keyed on the pitch
+ *  owner — one signature per company covers all its projects (B3 per-company
+ *  scope). Pre-migration (table absent) → false, i.e. the secure default of
+ *  blocking workspace access until signed. See collaboration-nda-scope.md. */
+async function hasSignedCompanyNda(sql: any, signerId: number, ownerId: number): Promise<boolean> {
+  try {
+    const r = await sql`
+      SELECT 1 FROM company_nda_signatures s
+      JOIN teams t ON t.id = s.team_id
+      WHERE t.owner_id = ${ownerId} AND s.signer_id = ${signerId} AND s.status = 'signed'
+      LIMIT 1`;
+    return r.length > 0;
+  } catch { return false; }
+}
+
 /** Defensive "has this user signed/been-granted an NDA on this pitch" — tolerant
  *  of the signer_id / requester_id / pitch_access schema drift (see CLAUDE.md). */
 async function hasSignedNda(sql: any, userId: number, pitchId: number): Promise<boolean> {
@@ -93,12 +108,20 @@ async function resolveWorkspace(sql: any, actingUserId: number, pitchId: number)
         WHERE t.owner_id = ${ownerId} AND tm.role IN ('owner','editor','member')`;
       teamUserIds = [ownerId, ...members.map((m: any) => Number(m.user_id))];
     } catch { /* team_members drift — owner-only */ }
+    const isOwner = actingUserId === ownerId;
     const isTeam = teamUserIds.includes(actingUserId);
-    let canView = isTeam;
+    // Collaboration-NDA gate (B3 Phase 2): a seated member (a creator who joined
+    // via a code) must sign the company NDA before the shared workspace unlocks.
+    // The owner is exempt; NDA-signed external producers keep their read-only view.
+    let memberAccess = isOwner;
+    if (!isOwner && isTeam) {
+      memberAccess = await hasSignedCompanyNda(sql, actingUserId, ownerId);
+    }
+    let canView = memberAccess;
     if (!canView && myType === 'production') {
       canView = await hasSignedNda(sql, actingUserId, pitchId); // NDA producer → read-only
     }
-    return { ownerId, isProductionPitch, workspaceUserId: ownerId, teamUserIds, canEdit: isTeam, canView };
+    return { ownerId, isProductionPitch, workspaceUserId: ownerId, teamUserIds, canEdit: memberAccess, canView };
   }
 
   // Creator-owned pitch — private per-producer workspace.

--- a/src/handlers/production-sidebar.ts
+++ b/src/handlers/production-sidebar.ts
@@ -68,21 +68,24 @@ export async function productionStatsHandler(
   }
 
   try {
-    // Check if production_pipeline table exists
-    const tableCheck = await sql`
+    // Check if production_pipeline table exists. report:false — a missing table
+    // is an expected branch here, not a Sentry-worthy error.
+    const tableCheckResult = await safeQuery<{ exists: boolean }>(() => sql`
       SELECT EXISTS (
         SELECT FROM information_schema.tables
         WHERE table_schema = 'public' AND table_name = 'production_pipeline'
       ) AS exists
-    `.catch((err: unknown) => { console.error('Production table check error:', err); return [{ exists: false }]; });
+    `, { fallback: [{ exists: false }], context: 'production-sidebar.stats.table-check', report: false });
+    const tableExists = !!tableCheckResult.rows[0]?.exists;
+    let degraded = tableCheckResult.errored;
 
     let totalProjects = 0;
     let activeProjects = 0;
     let completedProjects = 0;
     let totalBudgetAllocated = 0;
 
-    if (tableCheck[0]?.exists) {
-      const projectStats = await sql`
+    if (tableExists) {
+      const projectStats = await safeQuery<{ total_projects: number; active_projects: number; completed_projects: number; total_budget_allocated: number }>(() => sql`
         SELECT
           COUNT(*)::int AS total_projects,
           COUNT(*) FILTER (WHERE status = 'active')::int AS active_projects,
@@ -90,13 +93,14 @@ export async function productionStatsHandler(
           COALESCE(SUM(budget_allocated), 0) AS total_budget_allocated
         FROM production_pipeline
         WHERE production_company_id::text = ${String(userId)}
-      `.catch((err: unknown) => { console.error('Production project stats error:', err); return []; });
+      `, { fallback: [], context: 'production-sidebar.stats.project-stats' });
+      degraded = degraded || projectStats.errored;
 
-      if (projectStats.length > 0) {
-        totalProjects = Number(projectStats[0].total_projects) || 0;
-        activeProjects = Number(projectStats[0].active_projects) || 0;
-        completedProjects = Number(projectStats[0].completed_projects) || 0;
-        totalBudgetAllocated = Number(projectStats[0].total_budget_allocated) || 0;
+      if (projectStats.rows.length > 0) {
+        totalProjects = Number(projectStats.rows[0].total_projects) || 0;
+        activeProjects = Number(projectStats.rows[0].active_projects) || 0;
+        completedProjects = Number(projectStats.rows[0].completed_projects) || 0;
+        totalBudgetAllocated = Number(projectStats.rows[0].total_budget_allocated) || 0;
       }
     }
 
@@ -104,8 +108,8 @@ export async function productionStatsHandler(
     let totalRevenue = 0;
     let monthlyRevenue = 0;
 
-    if (tableCheck[0]?.exists) {
-      const revenueStats = await sql`
+    if (tableExists) {
+      const revenueStats = await safeQuery<{ total_revenue: number; monthly_revenue: number }>(() => sql`
         SELECT
           COALESCE(SUM(i.amount), 0) AS total_revenue,
           COALESCE(SUM(
@@ -115,28 +119,31 @@ export async function productionStatsHandler(
         JOIN production_pipeline pp ON i.pitch_id = pp.pitch_id
         WHERE pp.production_company_id::text = ${String(userId)}
           AND i.status IN ('active', 'funded', 'committed', 'completed')
-      `.catch((err: unknown) => { console.error('Production revenue stats error:', err); return []; });
+      `, { fallback: [], context: 'production-sidebar.stats.revenue' });
+      degraded = degraded || revenueStats.errored;
 
-      if (revenueStats.length > 0) {
-        totalRevenue = Number(revenueStats[0].total_revenue) || 0;
-        monthlyRevenue = Number(revenueStats[0].monthly_revenue) || 0;
+      if (revenueStats.rows.length > 0) {
+        totalRevenue = Number(revenueStats.rows[0].total_revenue) || 0;
+        monthlyRevenue = Number(revenueStats.rows[0].monthly_revenue) || 0;
       }
     }
 
     // Count published pitches as "submissions" visible to this production user
-    const submissionStats = await sql`
+    const submissionStats = await safeQuery<{ total_submissions: number; pending_submissions: number }>(() => sql`
       SELECT
         COUNT(*)::int AS total_submissions,
         COUNT(*) FILTER (WHERE status = 'pending' OR status = 'submitted')::int AS pending_submissions
       FROM pitches
       WHERE status IN ('published', 'pending', 'submitted')
-    `.catch((err: unknown) => { console.error('Production submission stats error:', err); return [{ total_submissions: 0, pending_submissions: 0 }]; });
+    `, { fallback: [{ total_submissions: 0, pending_submissions: 0 }], context: 'production-sidebar.stats.submissions' });
+    degraded = degraded || submissionStats.errored;
 
-    const totalSubmissions = Number(submissionStats[0]?.total_submissions) || 0;
-    const pendingSubmissions = Number(submissionStats[0]?.pending_submissions) || 0;
+    const totalSubmissions = Number(submissionStats.rows[0]?.total_submissions) || 0;
+    const pendingSubmissions = Number(submissionStats.rows[0]?.pending_submissions) || 0;
 
     return jsonResponse({
       success: true,
+      degraded,
       data: {
         totalProjects,
         activeProjects,

--- a/src/handlers/teams.ts
+++ b/src/handlers/teams.ts
@@ -1177,6 +1177,7 @@ export async function getCreatorCollaborationsHandler(request: Request, env: Env
       } catch { /* pre-migration */ }
       companies.push({
         teamId: t.team_id, name: t.team_name, company: t.company, ownerId: t.owner_id, ndaSigned,
+        documentUrl: ndaSigned ? `/api/teams/${t.team_id}/collaboration-nda/document` : null,
         pitches: pitches.map((p: any) => ({ id: p.id, title: p.title, poster: p.poster, genre: p.genre, format: p.format, status: p.status })),
       });
     }
@@ -1276,6 +1277,7 @@ export async function getCompanyNdaStatusHandler(request: Request, env: Env): Pr
       signed: !!sig,
       signedAt: sig?.signed_at ?? null,
       ndaVersion: sig?.nda_version ?? COLLAB_NDA_VERSION,
+      documentUrl: sig ? `/api/teams/${teamId}/collaboration-nda/document` : null,
     } });
   } catch {
     return json({ success: true, data: { signed: false } });
@@ -1316,14 +1318,194 @@ export async function signCompanyNdaHandler(request: Request, env: Env): Promise
     const ua = request.headers.get('User-Agent') || null;
     const sigData = JSON.stringify({ agreed: true });
 
+    // document_url is the canonical download path for the signed record. The HTML
+    // record is generated on demand (deterministic from this immutable row), so we
+    // just persist the path — no R2 write / backfill needed.
+    const docUrl = `/api/teams/${teamId}/collaboration-nda/document`;
     const [row] = await sql`
       INSERT INTO company_nda_signatures
-        (team_id, signer_id, nda_version, signed_name, signed_address, ip_address, user_agent, signature_data)
-      VALUES (${teamId}, ${auth.user.id}, ${COLLAB_NDA_VERSION}, ${signedName}, ${body.address || null}, ${ip}, ${ua}, ${sigData}::jsonb)
-      ON CONFLICT (team_id, signer_id) DO UPDATE SET status = 'signed'
+        (team_id, signer_id, nda_version, signed_name, signed_address, ip_address, user_agent, signature_data, document_url)
+      VALUES (${teamId}, ${auth.user.id}, ${COLLAB_NDA_VERSION}, ${signedName}, ${body.address || null}, ${ip}, ${ua}, ${sigData}::jsonb, ${docUrl})
+      ON CONFLICT (team_id, signer_id) DO UPDATE SET status = 'signed', document_url = ${docUrl}
       RETURNING signed_at`;
 
-    return json({ success: true, data: { signed: true, signedAt: row?.signed_at } });
+    return json({ success: true, data: { signed: true, signedAt: row?.signed_at, documentUrl: docUrl } });
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    return json({ success: false, error: e.message }, 500);
+  }
+}
+
+/**
+ * GET /api/teams/:id/collaboration-nda/members
+ * Producer-facing per-seat NDA status for the join-code card: each seated member
+ * (creators who joined via a code) + whether they've signed the company NDA.
+ * Owner (production) only.
+ */
+export async function getCompanyNdaMembersHandler(request: Request, env: Env): Promise<Response> {
+  const corsHeaders = getCorsHeaders(request.headers.get('Origin'));
+  const json = (b: unknown, s = 200) => new Response(JSON.stringify(b), { status: s, headers: { 'Content-Type': 'application/json', ...corsHeaders } });
+  try {
+    const auth = await verifyAuth(request, env);
+    if (!auth.success || !auth.user) return json({ success: false, error: 'Unauthorized' }, 401);
+    const sql = getDb(env) as any;
+    if (!sql) return json({ success: true, data: { members: [] } });
+
+    const parts = new URL(request.url).pathname.split('/');
+    const teamId = parseInt(parts[3] || '0', 10);
+    if (!teamId) return json({ success: false, error: 'Invalid team ID' }, 400);
+
+    const [team] = await sql`SELECT id, owner_id FROM teams WHERE id = ${teamId}`;
+    if (!team) return json({ success: false, error: 'Team not found' }, 404);
+    if (String(team.owner_id) !== String(auth.user.id)) {
+      return json({ success: false, error: 'Only the team owner can view NDA status' }, 403);
+    }
+
+    // Seated members (role 'member' = joined creators) LEFT JOIN their signature.
+    const rows = await sql`
+      SELECT u.id AS user_id,
+             COALESCE(u.name, u.username, u.email) AS name,
+             u.email,
+             tm.joined_at,
+             s.status AS nda_status, s.signed_at, s.signed_name
+      FROM team_members tm
+      JOIN users u ON u.id = tm.user_id
+      LEFT JOIN company_nda_signatures s
+        ON s.team_id = tm.team_id AND s.signer_id = tm.user_id AND s.status = 'signed'
+      WHERE tm.team_id = ${teamId} AND tm.role = 'member'
+      ORDER BY tm.joined_at ASC NULLS LAST`;
+
+    const members = rows.map((r: any) => ({
+      userId: r.user_id,
+      name: r.name,
+      email: r.email,
+      joinedAt: r.joined_at,
+      ndaStatus: r.nda_status === 'signed' ? 'signed' : 'pending',
+      signedAt: r.signed_at ?? null,
+      documentUrl: r.nda_status === 'signed'
+        ? `/api/teams/${teamId}/collaboration-nda/document?signerId=${r.user_id}`
+        : null,
+    }));
+    return json({ success: true, data: { members } });
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    return json({ success: false, error: e.message }, 500);
+  }
+}
+
+/** Fill {{placeholder}} tokens from ctx; unmatched → a blank line (mirrors the
+ *  worker's renderNdaTemplate so the record reads like the signed text). */
+function fillNdaTemplate(content: string, ctx: Record<string, string | undefined>): string {
+  const blank = '________________';
+  return (content || '').replace(/\{\{(\w+)\}\}/g, (_m, key) => {
+    const v = ctx[key];
+    return v && String(v).trim() ? String(v) : blank;
+  });
+}
+
+const esc = (s: unknown): string =>
+  String(s ?? '').replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] as string));
+
+/**
+ * GET /api/teams/:id/collaboration-nda/document[?signerId=]
+ * Returns a self-contained HTML record of a signed collaboration NDA (the standard
+ * NDA text + an execution/signature block). Printable to PDF by the browser.
+ * Access: the signer themselves (own record) or the team owner (any member's).
+ * Generated on demand from the immutable signature row — no storage/backfill.
+ */
+export async function getCompanyNdaDocumentHandler(request: Request, env: Env): Promise<Response> {
+  const corsHeaders = getCorsHeaders(request.headers.get('Origin'));
+  const json = (b: unknown, s = 200) => new Response(JSON.stringify(b), { status: s, headers: { 'Content-Type': 'application/json', ...corsHeaders } });
+  try {
+    const auth = await verifyAuth(request, env);
+    if (!auth.success || !auth.user) return json({ success: false, error: 'Unauthorized' }, 401);
+    const sql = getDb(env) as any;
+    if (!sql) return json({ success: false, error: 'Database unavailable' }, 503);
+
+    const url = new URL(request.url);
+    const parts = url.pathname.split('/');
+    const teamId = parseInt(parts[3] || '0', 10);
+    if (!teamId) return json({ success: false, error: 'Invalid team ID' }, 400);
+    const signerId = parseInt(url.searchParams.get('signerId') || String(auth.user.id), 10);
+
+    const [team] = await sql`
+      SELECT t.id, t.name AS team_name, t.owner_id,
+             COALESCE(NULLIF(u.company_name, ''), u.name, u.username, u.email) AS company,
+             COALESCE(NULLIF(u.company_address, ''), NULLIF(u.location, '')) AS company_address
+      FROM teams t JOIN users u ON u.id = t.owner_id WHERE t.id = ${teamId}`;
+    if (!team) return json({ success: false, error: 'Team not found' }, 404);
+
+    // Access: the signer themselves, or the team owner.
+    const isOwner = String(team.owner_id) === String(auth.user.id);
+    const isSelf = String(signerId) === String(auth.user.id);
+    if (!isOwner && !isSelf) return json({ success: false, error: 'Not authorized to view this document' }, 403);
+
+    const [sig] = await sql`
+      SELECT signed_name, signed_address, signed_at, nda_version, ip_address, status
+      FROM company_nda_signatures
+      WHERE team_id = ${teamId} AND signer_id = ${signerId} AND status = 'signed' LIMIT 1`;
+    if (!sig) return json({ success: false, error: 'No signed NDA on record' }, 404);
+
+    // Standard NDA text (default template), rendered with company/creator context.
+    let bodyText = '';
+    let tplName = 'Pitchey Standard NDA';
+    try {
+      const [tpl] = await sql`SELECT name, template_content FROM nda_templates WHERE is_default = true ORDER BY id ASC LIMIT 1`;
+      tplName = tpl?.name || tplName;
+      bodyText = fillNdaTemplate(tpl?.template_content || '', {
+        date: new Date(sig.signed_at).toISOString().slice(0, 10),
+        recipient_name: sig.signed_name,
+        recipient_address: sig.signed_address || undefined,
+        disclosing_party_name: team.company,
+        disclosing_party_address: team.company_address || undefined,
+        project_name: `all ${team.company} projects`,
+      });
+    } catch { /* template table drift → render the certificate without the body */ }
+
+    const signedAtFmt = new Date(sig.signed_at).toLocaleString('en-US', {
+      year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit', timeZoneName: 'short',
+    });
+
+    const html = `<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>${esc(tplName)} — ${esc(team.company)}</title>
+<style>
+  body { font-family: Georgia, 'Times New Roman', serif; color: #1f2937; max-width: 760px; margin: 2rem auto; padding: 0 1.5rem; line-height: 1.6; }
+  h1 { font-size: 1.4rem; border-bottom: 2px solid #6d28d9; padding-bottom: .5rem; }
+  .meta { font-size: .85rem; color: #6b7280; margin-bottom: 1.5rem; }
+  pre { white-space: pre-wrap; font-family: inherit; font-size: .95rem; }
+  .cert { margin-top: 2rem; border: 1px solid #e5e7eb; border-radius: 10px; padding: 1.25rem 1.5rem; background: #faf5ff; page-break-inside: avoid; }
+  .cert h2 { font-size: 1rem; margin: 0 0 .75rem; color: #6d28d9; }
+  .cert dl { display: grid; grid-template-columns: 11rem 1fr; gap: .35rem .75rem; font-size: .9rem; margin: 0; }
+  .cert dt { color: #6b7280; }
+  .cert dd { margin: 0; font-weight: 600; }
+  @media print { body { margin: 0; } .noprint { display: none; } }
+</style></head>
+<body>
+  <h1>${esc(tplName)}</h1>
+  <p class="meta">Collaboration agreement between <strong>${esc(team.company)}</strong> (Disclosing Party) and <strong>${esc(sig.signed_name)}</strong> (Recipient), covering all of ${esc(team.company)}'s projects.</p>
+  <pre>${esc(bodyText)}</pre>
+  <section class="cert">
+    <h2>Certificate of Electronic Execution</h2>
+    <dl>
+      <dt>Recipient (signed)</dt><dd>${esc(sig.signed_name)}</dd>
+      ${sig.signed_address ? `<dt>Address</dt><dd>${esc(sig.signed_address)}</dd>` : ''}
+      <dt>Disclosing Party</dt><dd>${esc(team.company)}</dd>
+      <dt>Signed at</dt><dd>${esc(signedAtFmt)}</dd>
+      <dt>Agreement version</dt><dd>${esc(sig.nda_version)}</dd>
+      ${sig.ip_address ? `<dt>IP address</dt><dd>${esc(sig.ip_address)}</dd>` : ''}
+      <dt>Method</dt><dd>Click-to-sign (electronic acceptance)</dd>
+    </dl>
+  </section>
+  <p class="meta noprint" style="margin-top:1.5rem">Tip: use your browser's Print → Save as PDF to keep a copy.</p>
+</body></html>`;
+
+    return new Response(html, {
+      status: 200,
+      headers: { 'Content-Type': 'text/html; charset=utf-8', ...corsHeaders },
+    });
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
     return json({ success: false, error: e.message }, 500);

--- a/src/services/stripe.service.ts
+++ b/src/services/stripe.service.ts
@@ -127,6 +127,19 @@ export class StripeService {
     return this.request('GET', endpoint);
   }
 
+  // ── Reconciliation ──
+
+  // Page subscriptions by status so a daily cron can cross-check Stripe's truth
+  // against the local subscription_history table (catches dropped invoice.paid /
+  // subscription.* webhooks). `metadata.userId`/`metadata.tier` are stamped on
+  // the subscription at checkout creation, so the id + metadata are enough to
+  // detect "paid in Stripe, no active local row".
+  async listSubscriptions(status: string = 'active', startingAfter?: string): Promise<{ data: any[]; has_more: boolean }> {
+    let endpoint = `/subscriptions?status=${encodeURIComponent(status)}&limit=100`;
+    if (startingAfter) endpoint += `&starting_after=${encodeURIComponent(startingAfter)}`;
+    return this.request('GET', endpoint);
+  }
+
   // ── Payment Methods ──
 
   async createSetupIntent(customerId: string): Promise<{ client_secret: string }> {

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -21493,7 +21493,8 @@ const websocketSafeHandler = {
         case "0 * * * *": // Hourly
           await Promise.all([
             sendDigestEmails(env, ctx),
-            aggregateMetrics(env, ctx)
+            aggregateMetrics(env, ctx),
+            checkMoneyPathSLOs(env, ctx)
           ]);
           break;
 
@@ -21687,6 +21688,100 @@ async function reconcileStripeSubscriptions(env: any, _ctx: ExecutionContext): P
     }));
     try { Sentry.captureException(e, { tags: { cron: 'stripe_reconcile' } }); } catch { /* noop */ }
   }
+}
+
+// ── Money-path SLOs ──────────────────────────────────────────────────────
+// The research bar: don't just monitor availability (is the DB up?) — monitor
+// RELIABILITY on the paths that make money. These are SLIs over the trailing
+// window: server-error rate (5xx) on signup, checkout, and pitch creation.
+// 4xx are client errors (validation/auth) and do NOT count against the budget.
+// Source: the Axiom request logs the worker already emits (type="request",
+// request.path, request.method, response.status). No new bindings.
+const MONEY_PATH_SLOS: Array<{
+  key: string;
+  predicate: string;   // APL predicate over the request-log fields
+  target: number;      // success-rate target (e.g. 0.99 = 99%)
+  minVolume: number;   // skip the check below this request count (sample too small)
+  minErrors: number;   // require at least this many 5xx to alert (blip suppression)
+}> = [
+  { key: 'checkout',     predicate: `['request.path'] startswith "/api/payments"`, target: 0.99, minVolume: 5, minErrors: 2 },
+  { key: 'signup',       predicate: `['request.path'] contains "register"`,        target: 0.99, minVolume: 5, minErrors: 2 },
+  { key: 'pitch_upload', predicate: `['request.method'] == "POST" and ['request.path'] startswith "/api/pitches"`, target: 0.99, minVolume: 5, minErrors: 2 },
+];
+
+// Hourly money-path SLO check. Queries Axiom for the trailing hour, computes the
+// 5xx error rate per money path, and reports a breach to Sentry (error level) +
+// a structured `slo_breach` log so the existing alerting path surfaces it. Pure
+// read; defensive — a missing token or a failed/odd-shaped query logs and skips,
+// never pages falsely.
+async function checkMoneyPathSLOs(env: any, _ctx: ExecutionContext): Promise<void> {
+  const token = env.AXIOM_TOKEN;
+  const dataset = env.AXIOM_DATASET || 'pitchey-logs';
+  if (!token) {
+    console.warn(JSON.stringify({ level: 'warn', category: 'slo', action: 'skipped', reason: 'no_axiom_token' }));
+    return;
+  }
+  const startedAt = Date.now();
+  const endTime = new Date().toISOString();
+  const startTime = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+  let axiom: any;
+  try {
+    const { AxiomClient } = await import('./lib/observability');
+    axiom = new AxiomClient(token, dataset);
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error(JSON.stringify({ level: 'error', category: 'slo', action: 'init_failed', error: e.message }));
+    return;
+  }
+
+  const summary: Array<Record<string, unknown>> = [];
+  for (const slo of MONEY_PATH_SLOS) {
+    try {
+      const apl = `['${dataset}'] | where ['type'] == "request" and (${slo.predicate}) | summarize total = count(), errors = countif(['response.status'] >= 500)`;
+      const res = await axiom.query(apl, startTime, endTime);
+      // Aggregation result: tables[0].fields names the columns, columns[i][0] holds the value.
+      const table = res?.tables?.[0];
+      const fields: string[] = (table?.fields || []).map((f: any) => f?.name);
+      const cols: any[] = table?.columns || [];
+      const valueOf = (name: string): number => {
+        const i = fields.indexOf(name);
+        return i >= 0 ? Number(cols[i]?.[0] ?? 0) : 0;
+      };
+      const total = valueOf('total');
+      const errors = valueOf('errors');
+      const errorRate = total > 0 ? errors / total : 0;
+      const breached = total >= slo.minVolume && errors >= slo.minErrors && errorRate > (1 - slo.target);
+
+      summary.push({ key: slo.key, total, errors, error_rate: Number(errorRate.toFixed(4)), breached });
+
+      if (breached) {
+        const msg = `Money-path SLO breach: ${slo.key} — ${errors}/${total} 5xx (${(errorRate * 100).toFixed(1)}%) over 1h, target ${(slo.target * 100).toFixed(1)}%`;
+        console.error(JSON.stringify({
+          level: 'error', category: 'slo', action: 'slo_breach',
+          path_key: slo.key, total, errors, error_rate: errorRate, target: slo.target,
+        }));
+        try {
+          Sentry.captureMessage(msg, {
+            level: 'error',
+            tags: { 'slo.breach': slo.key },
+            extra: { total, errors, error_rate: errorRate, target: slo.target, window: '1h' },
+          });
+        } catch { /* Sentry hub not initialized */ }
+      }
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      // Query failure is non-fatal — don't let one path's APL error abort the rest.
+      console.error(JSON.stringify({ level: 'error', category: 'slo', action: 'query_failed', path_key: slo.key, error: e.message }));
+    }
+  }
+
+  const breaches = summary.filter((s) => s.breached).length;
+  console.log(JSON.stringify({
+    level: breaches > 0 ? 'warn' : 'info',
+    category: 'slo', action: 'check_complete',
+    breaches, results: summary, duration_ms: Date.now() - startedAt,
+  }));
 }
 
 async function monitorJobQueues(env: any, ctx: ExecutionContext): Promise<void> {

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -4725,13 +4725,21 @@ class RouteRegistry {
 
       // Check Stripe API reachability (non-blocking)
       let stripeStatus = 'not configured';
-      if (this.env.STRIPE_SECRET_KEY) {
-        try {
-          const stripeResp = await fetch('https://api.stripe.com/v1/balance', {
-            headers: { Authorization: `Bearer ${this.env.STRIPE_SECRET_KEY}` }
-          });
-          stripeStatus = stripeResp.ok ? 'connected' : 'auth_error';
-        } catch { stripeStatus = 'unreachable'; }
+      const stripeKey = this.env.STRIPE_SECRET_KEY;
+      if (stripeKey) {
+        if (this.env.ENVIRONMENT === 'production' && !stripeKey.startsWith('sk_live_')) {
+          // A test-mode key in production means real charges never land in the
+          // live balance — the classic silent go-live misconfig. Surface as a
+          // non-healthy status so the per-service CI health gate fires.
+          stripeStatus = 'test_key_in_prod';
+        } else {
+          try {
+            const stripeResp = await fetch('https://api.stripe.com/v1/balance', {
+              headers: { Authorization: `Bearer ${stripeKey}` }
+            });
+            stripeStatus = stripeResp.ok ? 'connected' : 'auth_error';
+          } catch { stripeStatus = 'unreachable'; }
+        }
       }
 
       // Check Resend API reachability (non-blocking)
@@ -4745,7 +4753,8 @@ class RouteRegistry {
         } catch { resendStatus = 'unreachable'; }
       }
 
-      const allConnected = dbStatus === 'connected' && redisStatus !== 'error' && stripeStatus !== 'unreachable';
+      const allConnected = dbStatus === 'connected' && redisStatus !== 'error'
+        && stripeStatus !== 'unreachable' && stripeStatus !== 'test_key_in_prod';
 
       return builder.success({
         status: allConnected ? 'ok' : 'degraded',
@@ -10646,6 +10655,22 @@ pitchey_analytics_datapoints_per_minute 1250
       return new ApiResponseBuilder(request).error(ErrorCode.INTERNAL_ERROR, 'Stripe webhook not configured');
     }
 
+    // Go-live guard: a test-mode secret deployed to production means live events
+    // will fail signature verification (test secret can't sign live deliveries)
+    // and real payments are silently dropped. Log loudly + report so the misconfig
+    // is caught immediately rather than via a customer "I paid but no access" email.
+    if ((this.env as any).ENVIRONMENT === 'production' && !stripeKey.startsWith('sk_live_')) {
+      console.error(JSON.stringify({
+        level: 'error',
+        category: 'stripe_webhook',
+        action: 'test_key_in_production',
+        message: 'STRIPE_SECRET_KEY is not a live key (sk_live_*) in a production environment',
+      }));
+      try {
+        Sentry.captureMessage('Stripe test key deployed to production', { level: 'error' });
+      } catch { /* Sentry hub not initialized */ }
+    }
+
     const signature = request.headers.get('stripe-signature');
     if (!signature) {
       return new ApiResponseBuilder(request).error(ErrorCode.BAD_REQUEST, 'Missing stripe-signature header');
@@ -10907,37 +10932,96 @@ pitchey_analytics_datapoints_per_minute 1250
         case 'customer.subscription.deleted': {
           const sub = event.data.object;
           const subId = sub.id;
-          await sql`
+          const canceled = await sql`
             UPDATE subscription_history SET status = 'canceled'
             WHERE stripe_subscription_id = ${subId} AND status IN ('active', 'cancelling')
+            RETURNING id
           `;
-          console.log(JSON.stringify({
-            level: 'info',
-            category: 'stripe_webhook',
-            event_id: event.id,
-            event_type: event.type,
-            stripe_subscription_id: subId,
-            action: 'subscription_canceled',
-          }));
+          if (canceled.length > 0) {
+            console.log(JSON.stringify({
+              level: 'info',
+              category: 'stripe_webhook',
+              event_id: event.id,
+              event_type: event.type,
+              stripe_subscription_id: subId,
+              action: 'subscription_canceled',
+            }));
+          } else {
+            // 0 rows matched. Disambiguate: a row that exists but is already
+            // terminal is a benign re-delivery (stay quiet — avoid alert
+            // fatigue); NO row at all means the .deleted arrived before the
+            // creating event (Stripe does not guarantee ordering) and the
+            // cancellation would have been silently lost. Surface the latter —
+            // the reconciliation cron (1C) is the eventual backstop.
+            const existing = await sql`
+              SELECT 1 FROM subscription_history WHERE stripe_subscription_id = ${subId} LIMIT 1
+            `;
+            const outOfOrder = existing.length === 0;
+            console.warn(JSON.stringify({
+              level: 'warn',
+              category: 'stripe_webhook',
+              event_id: event.id,
+              event_type: event.type,
+              stripe_subscription_id: subId,
+              action: outOfOrder ? 'subscription_deleted_unmapped' : 'subscription_deleted_noop_already_terminal',
+            }));
+            if (outOfOrder) {
+              try {
+                Sentry.captureException(new Error(`subscription.deleted matched no local row: ${subId}`), {
+                  tags: { 'stripe.webhook': 'subscription_deleted_unmapped' },
+                  extra: { stripe_subscription_id: subId, customer: sub.customer ?? null, event_id: event.id },
+                });
+              } catch { /* Sentry hub not initialized */ }
+            }
+          }
           break;
         }
 
         case 'customer.subscription.updated': {
           const sub = event.data.object;
           const subId = sub.id;
+          let stateTouched = 0;
           if (sub.cancel_at_period_end) {
-            await sql`
+            const flagged = await sql`
               UPDATE subscription_history SET status = 'cancelling'
               WHERE stripe_subscription_id = ${subId} AND status = 'active'
+              RETURNING id
             `;
+            stateTouched += flagged.length;
           }
           // Update period end (API drift: also check items.data[0]).
           const updPeriodEnd = sub?.current_period_end ?? sub?.items?.data?.[0]?.current_period_end ?? null;
           if (updPeriodEnd) {
-            await sql`
+            const dated = await sql`
               UPDATE subscription_history SET period_end = ${new Date(updPeriodEnd * 1000).toISOString()}
               WHERE stripe_subscription_id = ${subId}
+              RETURNING id
             `;
+            stateTouched += dated.length;
+          }
+          // A meaningful update (cancellation flag or period end) that matched no
+          // local row and where no row exists at all = out-of-order arrival; the
+          // state change was silently lost. Flag it so drift is visible.
+          if (stateTouched === 0 && (sub.cancel_at_period_end || updPeriodEnd)) {
+            const existing = await sql`
+              SELECT 1 FROM subscription_history WHERE stripe_subscription_id = ${subId} LIMIT 1
+            `;
+            if (existing.length === 0) {
+              console.warn(JSON.stringify({
+                level: 'warn',
+                category: 'stripe_webhook',
+                event_id: event.id,
+                event_type: event.type,
+                stripe_subscription_id: subId,
+                action: 'subscription_updated_unmapped',
+              }));
+              try {
+                Sentry.captureException(new Error(`subscription.updated matched no local row: ${subId}`), {
+                  tags: { 'stripe.webhook': 'subscription_updated_unmapped' },
+                  extra: { stripe_subscription_id: subId, customer: sub.customer ?? null, event_id: event.id },
+                });
+              } catch { /* Sentry hub not initialized */ }
+            }
           }
           break;
         }
@@ -21426,6 +21510,10 @@ const websocketSafeHandler = {
           await cleanupDatabase(env, ctx);
           break;
 
+        case "0 3 * * *": // Daily 3 AM
+          await reconcileStripeSubscriptions(env, ctx);
+          break;
+
         case "*/15 * * * *": // Every 15 minutes
           await updateTrendingAlgorithm(env, ctx);
           break;
@@ -21486,6 +21574,118 @@ async function keepDatabaseWarm(env: any, _ctx: ExecutionContext): Promise<void>
     // Non-fatal: the retry-wrapped getDb already handles cold-start drops; a
     // failure here just means the warm-ping missed, the next real request retries.
     console.warn(JSON.stringify({ level: 'warn', category: 'keep_warm', action: 'db_ping', outcome: 'failed', error: e.message }));
+  }
+}
+
+// Daily Stripe<->DB subscription reconciliation. The webhook path always returns
+// 200 — even on a swallowed processing error — and Stripe can drop a delivery, so
+// a paying customer can end up with no active local subscription row and nobody
+// notices. This is the backstop: page Stripe's active subscriptions, diff against
+// the local subscription_history active set, and report drift to Sentry. LOG ONLY,
+// no mutation — visibility first (the money-path-safety plan). Remediation (re-grant
+// access / reverse stale access) is deliberate follow-up, not an automated cron.
+async function reconcileStripeSubscriptions(env: any, _ctx: ExecutionContext): Promise<void> {
+  const startedAt = Date.now();
+  const stripeKey = env.STRIPE_SECRET_KEY;
+  if (!stripeKey) {
+    console.warn(JSON.stringify({ level: 'warn', category: 'stripe_reconcile', action: 'skipped', reason: 'no_stripe_key' }));
+    return;
+  }
+  try {
+    const { getDb } = await import('./db');
+    const sql = getDb(env);
+    if (!sql) {
+      console.error(JSON.stringify({ level: 'error', category: 'stripe_reconcile', action: 'skipped', reason: 'no_db' }));
+      return;
+    }
+    const { StripeService } = await import('./services/stripe.service');
+    const stripe = new StripeService(stripeKey);
+
+    // Local active subscription ids.
+    const localRows = await sql`
+      SELECT stripe_subscription_id FROM subscription_history
+      WHERE status = 'active' AND stripe_subscription_id IS NOT NULL
+    ` as { stripe_subscription_id: string }[];
+    const localActive = new Set(localRows.map((r) => r.stripe_subscription_id));
+
+    // Stripe active subscription ids (paged, capped to bound a runaway scan).
+    const stripeActive = new Map<string, any>(); // id -> sub (metadata used on drift)
+    let startingAfter: string | undefined;
+    let pages = 0;
+    const MAX_PAGES = 20; // 100/page → up to 2000 active subs; flagged if hit
+    let capped = false;
+    do {
+      const page = await stripe.listSubscriptions('active', startingAfter);
+      for (const sub of (page.data || [])) stripeActive.set(sub.id, sub);
+      pages++;
+      startingAfter = (page.has_more && page.data?.length)
+        ? page.data[page.data.length - 1].id
+        : undefined;
+      if (pages >= MAX_PAGES && startingAfter) { capped = true; break; }
+    } while (startingAfter);
+
+    // Stripe→DB: paid in Stripe, no active local row (the existential case —
+    // "I paid but I'm still locked out").
+    const paidNoAccess: string[] = [];
+    for (const [id, sub] of stripeActive) {
+      if (!localActive.has(id)) {
+        paidNoAccess.push(id);
+        try {
+          Sentry.captureException(new Error(`Stripe active subscription has no active local row: ${id}`), {
+            tags: { 'stripe.reconcile.drift': 'paid_no_access' },
+            extra: {
+              stripe_subscription_id: id,
+              customer: sub.customer ?? null,
+              user_id: sub.metadata?.userId ?? null,
+              tier: sub.metadata?.tier ?? null,
+            },
+          });
+        } catch { /* Sentry hub not initialized */ }
+      }
+    }
+
+    // DB→Stripe: local active but Stripe doesn't list it active (missed
+    // cancellation / revenue leak). Skipped when capped — the Stripe set is then
+    // incomplete and every unseen id would be a false positive.
+    const accessNoActiveSub: string[] = [];
+    if (!capped) {
+      for (const id of localActive) {
+        if (!stripeActive.has(id)) {
+          accessNoActiveSub.push(id);
+          try {
+            Sentry.captureException(new Error(`Local active subscription not active in Stripe: ${id}`), {
+              tags: { 'stripe.reconcile.drift': 'access_no_active_sub' },
+              extra: { stripe_subscription_id: id },
+            });
+          } catch { /* Sentry hub not initialized */ }
+        }
+      }
+    }
+
+    const driftCount = paidNoAccess.length + accessNoActiveSub.length;
+    console.log(JSON.stringify({
+      level: driftCount > 0 ? 'warn' : 'info',
+      category: 'stripe_reconcile',
+      action: 'reconcile_complete',
+      stripe_active: stripeActive.size,
+      local_active: localActive.size,
+      paid_no_access: paidNoAccess.length,
+      access_no_active_sub: accessNoActiveSub.length,
+      drift_count: driftCount,
+      paged: pages,
+      capped,
+      duration_ms: Date.now() - startedAt,
+    }));
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error(JSON.stringify({
+      level: 'error',
+      category: 'stripe_reconcile',
+      action: 'failed',
+      error: e.message,
+      duration_ms: Date.now() - startedAt,
+    }));
+    try { Sentry.captureException(e, { tags: { cron: 'stripe_reconcile' } }); } catch { /* noop */ }
   }
 }
 

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -5990,6 +5990,8 @@ pitchey_analytics_datapoints_per_minute 1250
       let viewerUserType: string | null = null;
       let hasNDAAccess = false;
       let isCompanyMember = false;
+      let companyTeamId: number | null = null;
+      let companyNdaSigned = false;
       try {
         const authResult = await this.validateAuth(request);
         if (authResult.valid && authResult.user) {
@@ -6050,12 +6052,26 @@ pitchey_analytics_datapoints_per_minute 1250
           // by this pitch's owner gets Team/Notes access without a per-pitch NDA.
           try {
             const memberRows = await sql`
-              SELECT 1 FROM team_members tm
+              SELECT tm.team_id FROM team_members tm
               JOIN teams t ON t.id = tm.team_id
               WHERE t.owner_id = ${pitch.user_id} AND tm.user_id = ${authUserId} AND tm.role = 'member'
               LIMIT 1
             `;
             isCompanyMember = memberRows.length > 0;
+            if (isCompanyMember) {
+              companyTeamId = Number(memberRows[0].team_id);
+              // B3 Phase 2: has this member signed the company collaboration NDA?
+              // Drives the sign-vs-edit state in the workspace UI. Pre-migration
+              // (table absent) → false (member sees the sign prompt).
+              try {
+                const sigRows = await sql`
+                  SELECT 1 FROM company_nda_signatures
+                  WHERE team_id = ${companyTeamId} AND signer_id = ${authUserId} AND status = 'signed'
+                  LIMIT 1
+                `;
+                companyNdaSigned = sigRows.length > 0;
+              } catch { /* company_nda_signatures may not exist pre-migration */ }
+            }
           } catch { /* teams tables may not exist in all envs */ }
         }
       } catch {
@@ -6149,6 +6165,8 @@ pitchey_analytics_datapoints_per_minute 1250
         hasSignedNDA: hasNDAAccess,
         hasNDA: hasNDAAccess,
         isCompanyMember,
+        companyTeamId,
+        companyNdaSigned,
         hasProtectedContent,
         view_count: parseInt(String(pitch.view_count || '0')),
         investment_count: investmentCount,

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -3105,6 +3105,15 @@ class RouteRegistry {
       const { signCompanyNdaHandler } = await import('./handlers/teams');
       return signCompanyNdaHandler(req, this.env);
     });
+    // Producer per-seat NDA status (owner-only) + downloadable signed record (signer or owner).
+    this.register('GET', '/api/teams/:id/collaboration-nda/members', async (req) => {
+      const { getCompanyNdaMembersHandler } = await import('./handlers/teams');
+      return getCompanyNdaMembersHandler(req, this.env);
+    });
+    this.register('GET', '/api/teams/:id/collaboration-nda/document', async (req) => {
+      const { getCompanyNdaDocumentHandler } = await import('./handlers/teams');
+      return getCompanyNdaDocumentHandler(req, this.env);
+    });
 
     // Project Collaborators — aggregate team view + invitation management + scoped project access
     this.register('GET', '/api/production/team/collaborators', async (req) => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -150,6 +150,7 @@ crons = [
   "0 * * * *",      # Hourly: Send digest emails and metrics aggregation
   "0 0 * * *",      # Daily: Export audit logs and archive jobs
   "0 2 * * 1",      # Weekly: Database cleanup (Mondays at 2 AM)
+  "0 3 * * *",      # Daily 3 AM: Stripe<->DB subscription reconciliation (drift detection)
   "*/15 * * * *"    # Every 15 min: Update trending algorithm
 ]
 


### PR DESCRIPTION
Completes the Collaboration NDA (B3) feature — creators sign the Platform Standard NDA once per production company before the shared workspace unlocks. Builds on Phase 1 (already in `main`: migration 099 + sign/status endpoints). Both phases are deployed live (worker `8928fd41`, frontend entry `index-CxUcduDj.js`) and smoke-tested.

Scope doc: `docs/sessions/2026-06-05-collaboration-nda-scope.md`.

## Phase 2 — sign UI + workspace gate
- **`resolveWorkspace` gate** (`production-pitch-data.ts`): a seated company member now needs `hasSignedCompanyNda(signer, owner)` before `canView`/`canEdit` on a production-owned pitch. Owner exempt; external NDA-signed producers' read-only view unaffected. Pre-migration (table absent) → blocked (secure default, D1).
- **`getPitch`** returns `companyTeamId` + `companyNdaSigned` so the UI splits signed vs pending members.
- **`CollaborationNdaModal`** (new) — click-to-sign: renders the standard NDA with company autofill, agree-checkbox + legal name/address, POSTs to `/api/teams/:id/collaboration-nda/sign`.
- **`CreatorCollaborations`** — unsigned companies show "Sign NDA to collaborate"; signed open normally.
- **`ProductionPitchView`** — pending member sees the sign prompt + locked Team/Notes tabs; signed member edits.

## Phase 3 — producer visibility + signed record
- **`GET /api/teams/:id/collaboration-nda/members`** (owner-only) — each seated member + signed/pending status + per-member document link. Rendered as a "Members & NDA status" list on `CompanyJoinCodeCard`.
- **`GET /api/teams/:id/collaboration-nda/document[?signerId=]`** — self-contained **HTML record** (standard NDA text + an Execution Certificate) generated on demand from the immutable signature row. Access: the signer or the team owner. Printable to PDF via the browser.
  - *Not a server-rendered PDF:* Cloudflare Workers have no PDF renderer and no browser binding (the existing `nda-pdf.service` is a stub). The HTML record is the no-new-infra deliverable; true PDF (Browser Rendering API / pdf-lib) is a deferred follow-up.
- `document_url` persisted on sign; status + creator-companies endpoints expose it; `CreatorCollaborations` shows a "Signed NDA" link on signed companies.

## Verification
- tsc (frontend) + esbuild (worker) clean; frontend build OK.
- Tests: 4 new teams-component tests; 28 existing ProductionPitchView/CreatorCollaborations tests still pass.
- Live smoke (demo accounts): signed member edits workspace (201) / non-collaborator denied (403); members endpoint owner-only (403 for non-owner); document endpoint serves HTML for signer + owner, 403 for third party.

## Not included (Phase 4, deliberately deferred)
Wet-ink upload fallback (D6), version-bump re-sign (D4), explicit producer counter-sign (D5) — all speculative pre-launch; no current need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)