### PR TITLE
Move Interested box above the feedback (Karl, production portal)

### DIFF
--- a/frontend/src/pages/PitchDetail.tsx
+++ b/frontend/src/pages/PitchDetail.tsx
@@ -926,6 +926,20 @@ export default function PitchDetail() {
               );
             })()}
 
+            {/* Engagement Actions — unified "Interested?" box, placed ABOVE the
+                feedback so the like/follow/save controls are seen first. */}
+            {!isOwner && (
+              <InterestedCard
+                pitchId={pitch.id}
+                creatorId={pitch.creator?.id}
+                initialLiked={isLiked}
+                initialSaved={isSaved}
+                isAuthenticated={isAuthenticated}
+                isOwner={isOwner}
+                fromPath={`/pitch/${id}`}
+              />
+            )}
+
             {/* Feedback & Ratings — visible to all viewers (anon included).
                 Quick-rate (1-5 stars) is open to anyone except the owner;
                 structured feedback form is auth-gated inside the component
@@ -959,30 +973,17 @@ export default function PitchDetail() {
               />
             )}
 
-            {/* Engagement Actions — unified "Interested?" box (shared across portals) */}
+            {/* Share — visible to all (the Interested box moved above the feedback) */}
             {!isOwner && (
-              <>
-                <InterestedCard
-                  pitchId={pitch.id}
-                  creatorId={pitch.creator?.id}
-                  initialLiked={isLiked}
-                  initialSaved={isSaved}
-                  isAuthenticated={isAuthenticated}
-                  isOwner={isOwner}
-                  fromPath={`/pitch/${id}`}
-                />
-
-                {/* Share — visible to all */}
-                <div className="bg-white rounded-xl shadow-sm p-4">
-                  <button
-                    onClick={handleShare}
-                    className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg font-medium bg-gray-50 text-gray-600 hover:bg-gray-100 transition"
-                  >
-                    <Share2 className="w-5 h-5" />
-                    {shareCopied ? 'Link copied!' : 'Share'}
-                  </button>
-                </div>
-              </>
+              <div className="bg-white rounded-xl shadow-sm p-4">
+                <button
+                  onClick={handleShare}
+                  className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg font-medium bg-gray-50 text-gray-600 hover:bg-gray-100 transition"
+                >
+                  <Share2 className="w-5 h-5" />
+                  {shareCopied ? 'Link copied!' : 'Share'}
+                </button>
+              </div>
             )}
 
             {/* Project Info */}

--- a/frontend/src/pages/PublicPitchView.tsx
+++ b/frontend/src/pages/PublicPitchView.tsx
@@ -568,6 +568,20 @@ export default function PublicPitchView() {
                 "Rate this Pitch" widget is available to all viewers. This is
                 what makes the feedback feature visible on the guest/public view
                 instead of disappearing for users served PublicPitchView. */}
+            {/* Engagement Actions — unified "Interested?" box, placed ABOVE the
+                feedback so the like/follow/save controls are seen first. */}
+            {pitch && !isOwner && (
+              <InterestedCard
+                pitchId={pitch.id}
+                creatorId={pitch.creator?.id}
+                initialLiked={(pitch as any).isLiked}
+                initialSaved={(pitch as any).isSaved}
+                isAuthenticated={isAuthenticated}
+                isOwner={isOwner}
+                fromPath={`/pitch/${id}`}
+              />
+            )}
+
             {pitch && (
               <div className="bg-white rounded-xl shadow-sm p-6">
                 <FeedbackSection
@@ -728,17 +742,7 @@ export default function PublicPitchView() {
               </div>
             </div>
 
-            {/* Engagement Actions — unified "Interested?" box (shared across portals).
-                Anonymous → sign-in prompts; authenticated → live like/follow/save. */}
-            <InterestedCard
-              pitchId={pitch.id}
-              creatorId={pitch.creator?.id}
-              initialLiked={(pitch as any).isLiked}
-              initialSaved={(pitch as any).isSaved}
-              isAuthenticated={isAuthenticated}
-              isOwner={isOwner}
-              fromPath={`/pitch/${id}`}
-            />
+            {/* Interested box moved above the feedback in the main column. */}
 
             {/* Actions */}
             <div className="bg-white rounded-xl shadow-sm p-6">

--- a/frontend/src/portals/production/pages/ProductionPitchView.tsx
+++ b/frontend/src/portals/production/pages/ProductionPitchView.tsx
@@ -848,6 +848,20 @@ const ProductionPitchView: React.FC = () => {
                 </div>
               </div>
 
+              {/* Engagement Actions — unified "Interested?" box, placed ABOVE the
+                  feedback so the like/follow/save controls are seen first. */}
+              {!isOwner && (
+                <InterestedCard
+                  pitchId={pitch.id}
+                  creatorId={pitch.userId ? parseInt(String(pitch.userId)) : undefined}
+                  initialLiked={isLiked}
+                  initialSaved={isShortlisted}
+                  isAuthenticated={isAuthenticated}
+                  isOwner={isOwner}
+                  fromPath={`/production/pitch/${id}`}
+                />
+              )}
+
               {/* Feedback & rating — production cos can rate + leave structured
                   feedback, same as other viewers on PitchDetail. */}
               <FeedbackSection
@@ -1183,18 +1197,7 @@ const ProductionPitchView: React.FC = () => {
 
           {/* Right Column - Sidebar */}
           <div className="space-y-6">
-            {/* Unified "Interested?" box — like / follow creator / save (shared across portals) */}
-            {!isOwner && pitch && (
-              <InterestedCard
-                pitchId={pitch.id}
-                creatorId={pitch.userId ? parseInt(String(pitch.userId)) : undefined}
-                initialLiked={isLiked}
-                initialSaved={isShortlisted}
-                isAuthenticated={isAuthenticated}
-                isOwner={isOwner}
-                fromPath={`/production/pitch/${id}`}
-              />
-            )}
+            {/* Interested box moved above the feedback in the main column. */}
 
             {/* Access — the NDA is the single gate that unlocks the full script,
                 pitch deck, and all production materials (no separate "request script"). */}


### PR DESCRIPTION
Karl (on the production portal viewing a pitch) asked for the shared like/follow/save "Interested?" box to sit **above** the feedback. Moved `InterestedCard` from the right sidebar into the main content column, directly above `FeedbackSection`, on:
- `PitchDetail.tsx`
- `ProductionPitchView.tsx` (the page Karl was on)
- `PublicPitchView.tsx`

`CreatorPitchView` unchanged — it only shows feedback to the owner, who never sees the card.

Verified: `tsc` clean; PitchDetail/Production/Public suites green (69 tests). Button labels unchanged, so the smoke-regression like/save selectors still match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)