### PR TITLE
Reframe producer Team/Notes as private evaluation space on creator-owned pitches

### DIFF
--- a/frontend/src/pages/__tests__/ProductionPitchView.test.tsx
+++ b/frontend/src/pages/__tests__/ProductionPitchView.test.tsx
@@ -304,8 +304,10 @@ describe('ProductionPitchView', () => {
       expect(screen.getByText('overview')).toBeInTheDocument()
     })
     expect(screen.getByText('Feasibility')).toBeInTheDocument()
-    expect(screen.getByText(/^team/)).toBeInTheDocument()
-    expect(screen.getByText(/^notes/)).toBeInTheDocument()
+    // Creator-owned pitch viewed by a producer = evaluation mode: the Team/Notes
+    // tabs are relabelled as the producer's own private space.
+    expect(screen.getByText(/My Team Plan/i)).toBeInTheDocument()
+    expect(screen.getByText(/My Notes/i)).toBeInTheDocument()
   })
 
   it('shows NDA credit cost when NDA not signed', async () => {

--- a/frontend/src/portals/production/pages/ProductionPitchView.tsx
+++ b/frontend/src/portals/production/pages/ProductionPitchView.tsx
@@ -170,9 +170,14 @@ const ProductionPitchView: React.FC = () => {
       <Eye className="h-3.5 w-3.5" /> View only
     </span>
   );
+  // Evaluation mode = a producer looking at someone else's (creator-owned) pitch.
+  // The Team/Notes here are a PRIVATE scratchpad scoped to this company — NOT the
+  // creator's project workspace. We keep that logic but relabel so it never reads
+  // as if you're managing the creator's pitch.
+  const evaluationMode = !ownerIsProduction;
   const workspaceScopeNote = ownerIsProduction
     ? (canEditWorkspace ? 'Shared workspace — visible to your whole company team.' : 'Read-only access granted by your signed NDA.')
-    : 'Private workspace — only you can see these notes.';
+    : 'Private to your company — the creator can’t see any of this. Use it to plan as if you were producing this pitch.';
   const teamStatusMeta: Record<string, { label: string; cls: string }> = {
     confirmed:   { label: 'Confirmed',   cls: 'bg-emerald-100 text-emerald-700 ring-emerald-200' },
     considering: { label: 'Considering', cls: 'bg-amber-100 text-amber-700 ring-amber-200' },
@@ -723,7 +728,13 @@ const ProductionPitchView: React.FC = () => {
                       }`}
                       title={locked ? 'NDA required to view' : undefined}
                     >
-                      {tab === 'production' ? 'Feasibility' : tab}
+                      {tab === 'production'
+                        ? 'Feasibility'
+                        : tab === 'team'
+                        ? (evaluationMode ? 'My Team Plan' : 'Team')
+                        : tab === 'notes'
+                        ? (evaluationMode ? 'My Notes' : 'Notes')
+                        : tab}
                       {locked && ' 🔒'}
                     </button>
                   );
@@ -990,7 +1001,7 @@ const ProductionPitchView: React.FC = () => {
                     <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 ring-1 ring-inset ring-indigo-100">
                       <Users className="h-5 w-5" />
                     </span>
-                    <h2 className="text-xl font-bold tracking-tight text-gray-900">Team Assembly</h2>
+                    <h2 className="text-xl font-bold tracking-tight text-gray-900">{evaluationMode ? 'Your Team Plan' : 'Team Assembly'}</h2>
                   </div>
                   {accessChip}
                 </div>
@@ -1102,7 +1113,7 @@ const ProductionPitchView: React.FC = () => {
                     <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 ring-1 ring-inset ring-indigo-100">
                       <FileText className="h-5 w-5" />
                     </span>
-                    <h2 className="text-xl font-bold tracking-tight text-gray-900">Production Notes</h2>
+                    <h2 className="text-xl font-bold tracking-tight text-gray-900">{evaluationMode ? 'Your Private Notes' : 'Production Notes'}</h2>
                   </div>
                   {accessChip}
                 </div>


### PR DESCRIPTION
Karl was confused that an editable "Team Assembly" / "Production Notes" showed on a creator-owned pitch (At Ever Las) he was only evaluating — it read like he was managing the creator's project.

The per-producer-private **logic was already correct** (workspace data is scoped to `user_id = <viewing producer>`, never the creator's). The problem was purely UI: the same project-style labels were used whether the pitch is production-owned (shared team) or creator-owned (private scratchpad).

**Option 2 (chosen): keep the logic, reframe the labels** in evaluation mode (`!ownerIsProduction`):
- Tabs: Team → "My Team Plan", Notes → "My Notes"
- Headings: "Team Assembly" → "Your Team Plan", "Production Notes" → "Your Private Notes"
- Scope note: "Private to your company — the creator can't see any of this. Use it to plan as if you were producing this pitch."

Production-owned pitches are unchanged (shared "Team Assembly"/"Production Notes").

Tests: tsc clean; ProductionPitchView suite green (updated the tab-label assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)