### PR TITLE
Hide producer Team/Notes until opt-in on pitches you didn't create

### DIFF
--- a/frontend/src/features/pitches/components/InterestedCard.tsx
+++ b/frontend/src/features/pitches/components/InterestedCard.tsx
@@ -26,6 +26,8 @@ export interface InterestedCardProps {
   isOwner?: boolean;
   /** Path to return to after sign-in for anonymous users. Defaults to current location. */
   fromPath?: string;
+  /** Fired after a successful save/unsave so a parent can react (e.g. unlock a workspace). */
+  onSavedChange?: (saved: boolean) => void;
   className?: string;
 }
 
@@ -37,6 +39,7 @@ const InterestedCard: React.FC<InterestedCardProps> = ({
   isAuthenticated,
   isOwner = false,
   fromPath,
+  onSavedChange,
   className = '',
 }) => {
   const navigate = useNavigate();
@@ -101,13 +104,14 @@ const InterestedCard: React.FC<InterestedCardProps> = ({
         credentials: 'include',
       });
       if (!res.ok) throw new Error(`Save failed: ${res.status}`);
+      onSavedChange?.(next);
     } catch (err) {
       console.error('InterestedCard save error:', err);
       setIsSaved(!next); // revert
     } finally {
       setBusy(null);
     }
-  }, [isAuthenticated, busy, isSaved, pitchId, goToLogin]);
+  }, [isAuthenticated, busy, isSaved, pitchId, goToLogin, onSavedChange]);
 
   const toggleFollow = useCallback(async () => {
     if (!numericCreatorId) return;

--- a/frontend/src/pages/__tests__/ProductionPitchView.test.tsx
+++ b/frontend/src/pages/__tests__/ProductionPitchView.test.tsx
@@ -291,7 +291,10 @@ describe('ProductionPitchView', () => {
 
   // ─── Tabs ────────────────────────────────────────────────────────
 
-  it('renders all five tabs', async () => {
+  it('hides the private Team/Notes workspace on an unsaved creator-owned pitch', async () => {
+    // Evaluation mode: a producer viewing a pitch they didn't create. The private
+    // workspace stays hidden until they opt in by saving the pitch — only Overview
+    // + Feasibility show, plus the opt-in hint.
     mockPitchGetPublicById.mockResolvedValue(mockPitch)
 
     render(
@@ -304,10 +307,9 @@ describe('ProductionPitchView', () => {
       expect(screen.getByText('overview')).toBeInTheDocument()
     })
     expect(screen.getByText('Feasibility')).toBeInTheDocument()
-    // Creator-owned pitch viewed by a producer = evaluation mode: the Team/Notes
-    // tabs are relabelled as the producer's own private space.
-    expect(screen.getByText(/My Team Plan/i)).toBeInTheDocument()
-    expect(screen.getByText(/My Notes/i)).toBeInTheDocument()
+    expect(screen.queryByText(/My Team Plan/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/My Notes/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/Save this pitch to open a private/i)).toBeInTheDocument()
   })
 
   it('shows NDA credit cost when NDA not signed', async () => {

--- a/frontend/src/portals/production/pages/ProductionPitchView.tsx
+++ b/frontend/src/portals/production/pages/ProductionPitchView.tsx
@@ -178,6 +178,10 @@ const ProductionPitchView: React.FC = () => {
   const workspaceScopeNote = ownerIsProduction
     ? (canEditWorkspace ? 'Shared workspace — visible to your whole company team.' : 'Read-only access granted by your signed NDA.')
     : 'Private to your company — the creator can’t see any of this. Use it to plan as if you were producing this pitch.';
+  // In evaluation mode (a creator-owned pitch you didn't create), the private
+  // Team/Notes workspace stays HIDDEN until you opt in by saving the pitch to
+  // your slate. Your own production pitches always have it.
+  const workspaceUnlocked = !evaluationMode || isShortlisted;
   const teamStatusMeta: Record<string, { label: string; cls: string }> = {
     confirmed:   { label: 'Confirmed',   cls: 'bg-emerald-100 text-emerald-700 ring-emerald-200' },
     considering: { label: 'Considering', cls: 'bg-amber-100 text-amber-700 ring-amber-200' },
@@ -189,6 +193,14 @@ const ProductionPitchView: React.FC = () => {
   const [autoFillLoading, setAutoFillLoading] = useState(false);
   const [ndaRequested, setNdaRequested] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // If the workspace gets locked again (e.g. you un-save an evaluation pitch)
+  // while you're on a hidden tab, fall back to Overview so nothing strands.
+  useEffect(() => {
+    if (!workspaceUnlocked && (activeTab === 'team' || activeTab === 'notes')) {
+      setActiveTab('overview');
+    }
+  }, [workspaceUnlocked, activeTab]);
 
   useEffect(() => {
     if (id) {
@@ -707,7 +719,7 @@ const ProductionPitchView: React.FC = () => {
             {/* Tabs */}
             <div className="bg-white rounded-xl shadow-sm border border-gray-100 mb-6">
               <div className="flex border-b">
-                {['overview', 'production', 'team', 'notes'].map((tab) => {
+                {(workspaceUnlocked ? ['overview', 'production', 'team', 'notes'] : ['overview', 'production']).map((tab) => {
                   const ndaRequired = tab === 'team' || tab === 'notes';
                   // Seated company members (B3) reach Team/Notes once they've
                   // signed the company collaboration NDA — matches the tab-content
@@ -870,7 +882,18 @@ const ProductionPitchView: React.FC = () => {
                   isAuthenticated={isAuthenticated}
                   isOwner={isOwner}
                   fromPath={`/production/pitch/${id}`}
+                  // Saving an evaluation pitch is the opt-in that unlocks the
+                  // private Team/Notes workspace (kept in sync without a reload).
+                  onSavedChange={evaluationMode ? setIsShortlisted : undefined}
                 />
+              )}
+
+              {/* Opt-in hint — only when this is someone else's pitch you haven't
+                  saved yet: saving opens a private planning workspace. */}
+              {evaluationMode && !isShortlisted && (
+                <p className="text-sm text-gray-500 bg-indigo-50/50 ring-1 ring-inset ring-indigo-100 rounded-lg px-4 py-3">
+                  💡 Save this pitch to open a private <span className="font-medium text-gray-700">Team&nbsp;Plan</span> &amp; <span className="font-medium text-gray-700">Notes</span> workspace — your space to plan it as a production. The creator never sees it.
+                </p>
               )}
 
               {/* Feedback & rating — production cos can rate + leave structured
@@ -994,7 +1017,7 @@ const ProductionPitchView: React.FC = () => {
               </div>
             )}
 
-            {activeTab === 'team' && canSeeWorkspace && (
+            {activeTab === 'team' && canSeeWorkspace && workspaceUnlocked && (
               <div className="bg-white rounded-2xl shadow-sm ring-1 ring-gray-100 p-6 sm:p-8">
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex items-center gap-2.5">
@@ -1106,7 +1129,7 @@ const ProductionPitchView: React.FC = () => {
               </div>
             )}
 
-            {activeTab === 'notes' && canSeeWorkspace && (
+            {activeTab === 'notes' && canSeeWorkspace && workspaceUnlocked && (
               <div className="bg-white rounded-2xl shadow-sm ring-1 ring-gray-100 p-6 sm:p-8">
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex items-center gap-2.5">


### PR DESCRIPTION
Follow-up to the workspace reframe. Karl: a production company shouldn't have a Team/Notes workspace on a pitch they didn't create.

**Behaviour now (evaluation mode = creator-owned pitch a producer is viewing):**
- Team/Notes tabs are **hidden by default** — only Overview + Feasibility show.
- An opt-in hint appears: "💡 Save this pitch to open a private Team Plan & Notes workspace…".
- **Saving the pitch (shortlist) unlocks it** — "My Team Plan" + "My Notes" appear, in-session (via a new `onSavedChange` callback on InterestedCard) and re-hydrated on reload from saved status.
- Un-saving hides them again; if you were on a hidden tab it falls back to Overview.
- Production-owned pitches are unchanged (workspace always available).

The per-producer-private data scoping is unchanged.

Tests: tsc clean; ProductionPitchView suite green (rewrote the tab test to assert the gated default + opt-in hint); PitchDetail/PublicPitchView green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)