### PR TITLE
Collaboration bridge — Phase 1 (propose + shared workspace, producer side)

### DIFF
--- a/frontend/src/portals/production/components/ProductionSlateBoard.tsx
+++ b/frontend/src/portals/production/components/ProductionSlateBoard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { LayoutGrid, CheckCircle, Users, FileText, ShieldCheck, ArrowRight } from 'lucide-react';
+import { LayoutGrid, CheckCircle, Users, FileText, ShieldCheck, ArrowRight, Handshake } from 'lucide-react';
 import apiClient from '../../../lib/api-client';
 
 interface SlateItem {
@@ -18,6 +18,7 @@ interface SlateItem {
   rolesFilled: number;
   notesCount: number;
   hasNda: boolean;
+  collaboration?: 'none' | 'pending' | 'accepted';
 }
 
 // The funnel a producer actually runs their slate on. Stages are derived from
@@ -80,6 +81,8 @@ function SlateCard({ item, onOpen }: { item: SlateItem; onOpen: () => void }) {
         )}
         {item.hasNda && <Badge tone="blue"><ShieldCheck className="h-3 w-3" /> NDA</Badge>}
         {item.notesCount > 0 && <Badge tone="slate"><FileText className="h-3 w-3" /> {item.notesCount}</Badge>}
+        {item.collaboration === 'accepted' && <Badge tone="emerald"><Handshake className="h-3 w-3" /> Collaborating</Badge>}
+        {item.collaboration === 'pending' && <Badge tone="indigo"><Handshake className="h-3 w-3" /> Proposed</Badge>}
       </div>
     </button>
   );

--- a/frontend/src/portals/production/pages/ProductionPitchView.tsx
+++ b/frontend/src/portals/production/pages/ProductionPitchView.tsx
@@ -58,6 +58,13 @@ interface Pitch {
   isCompanyMember?: boolean;
   companyTeamId?: number | null;     // team to sign the collaboration NDA for
   companyNdaSigned?: boolean;        // member has signed the company NDA (B3 Phase 2)
+  collaboration?: {                  // pitch-scoped producer↔creator collaboration
+    id: number;
+    status: string;                  // 'pending' | 'accepted'
+    role: string | null;
+    withUserId: number;
+    withName: string | null;
+  } | null;
   requiresNDA?: boolean;           // pitch was created with NDA protection
   require_nda?: boolean;           // snake-case fallback
   creatorType?: string;            // owner's user_type — selects workspace mode
@@ -167,14 +174,24 @@ const ProductionPitchView: React.FC = () => {
   // reads as if you own or are managing the creator's pitch.
   const evaluationMode = !ownerIsProduction;
   const evalCreatorName = pitch?.creatorName || pitch?.creatorCompany || 'the creator';
-  // Access chip — in evaluation mode we lead with an unmissable "not your pitch"
-  // badge so the editable workspace can't be mistaken for owning the project.
+  // Pitch-scoped collaboration state (producer↔creator).
+  const collab = pitch?.collaboration ?? null;
+  const isCollaborating = collab?.status === 'accepted';
+  const collabPending = collab?.status === 'pending';
+  // Access chip — in evaluation mode we lead with an unmissable status badge.
+  // Once the creator accepts, it flips from "not your pitch" to "Collaborating".
   const accessChip = (
     <div className="flex flex-wrap items-center justify-end gap-2">
       {evaluationMode && (
-        <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-50 px-2.5 py-1 text-xs font-semibold text-amber-700 ring-1 ring-inset ring-amber-200">
-          <Eye className="h-3.5 w-3.5" /> Evaluating · not your pitch
-        </span>
+        isCollaborating ? (
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-semibold text-emerald-700 ring-1 ring-inset ring-emerald-200">
+            <Users className="h-3.5 w-3.5" /> Collaborating with {evalCreatorName}
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-50 px-2.5 py-1 text-xs font-semibold text-amber-700 ring-1 ring-inset ring-amber-200">
+            <Eye className="h-3.5 w-3.5" /> Evaluating · not your pitch
+          </span>
+        )
       )}
       {canEditWorkspace ? (
         <span className="inline-flex items-center gap-1.5 rounded-full bg-indigo-50 px-2.5 py-1 text-xs font-semibold text-indigo-700 ring-1 ring-inset ring-indigo-200">
@@ -189,6 +206,8 @@ const ProductionPitchView: React.FC = () => {
   );
   const workspaceScopeNote = ownerIsProduction
     ? (canEditWorkspace ? 'Shared workspace — visible to your whole company team.' : 'Read-only access granted by your signed NDA.')
+    : isCollaborating
+    ? `Shared with ${evalCreatorName} — you're co-developing this pitch together. Both of you can edit the Team Plan and Notes.`
     : `You're planning ${evalCreatorName}'s pitch as a possible production — it isn't your project. Private to your company: ${evalCreatorName} can’t see any of this.`;
   // In evaluation mode (a creator-owned pitch you didn't create), the private
   // Team/Notes workspace stays HIDDEN until you opt in by saving the pitch to
@@ -402,6 +421,32 @@ const ProductionPitchView: React.FC = () => {
 
   const handleContactCreator = () => {
     navigate(`/production/messages?recipient=${pitch?.userId}&pitch=${id}`);
+  };
+
+  // Propose a pitch-scoped collaboration to the creator. On accept (their side)
+  // the producer's private Team Plan + Notes become the shared workspace.
+  const [proposingCollab, setProposingCollab] = useState(false);
+  const handleProposeCollaboration = async () => {
+    if (!pitch?.userId || proposingCollab) return;
+    setProposingCollab(true);
+    try {
+      const res = await apiClient.post('/api/collaborations', {
+        collaboratorId: parseInt(String(pitch.userId), 10),
+        pitchId: parseInt(String(pitch.id), 10),
+        role: 'co_development',
+      });
+      if (res.success) {
+        toast.success(`Collaboration proposed to ${pitch.creatorName || 'the creator'}.`);
+        await fetchPitchData(); // refresh → pitch.collaboration becomes 'pending'
+      } else {
+        toast.error(res.error?.message || 'Could not propose collaboration.');
+      }
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      toast.error(e.message);
+    } finally {
+      setProposingCollab(false);
+    }
   };
 
   // Like — production cos can like a pitch they're evaluating (mirrors PitchDetail).
@@ -906,6 +951,47 @@ const ProductionPitchView: React.FC = () => {
                 <p className="text-sm text-gray-500 bg-indigo-50/50 ring-1 ring-inset ring-indigo-100 rounded-lg px-4 py-3">
                   💡 Save this pitch to open a private <span className="font-medium text-gray-700">Team&nbsp;Plan</span> &amp; <span className="font-medium text-gray-700">Notes</span> workspace — your space to plan it as a production. The creator never sees it.
                 </p>
+              )}
+
+              {/* Collaboration bridge — once you've opted in (saved) and built a
+                  plan, propose co-developing the pitch with its creator. On accept,
+                  your private Team Plan + Notes become the shared workspace. */}
+              {evaluationMode && workspaceUnlocked && (
+                isCollaborating ? (
+                  <div className="flex items-start gap-3 rounded-xl bg-emerald-50 ring-1 ring-inset ring-emerald-200 px-4 py-3.5">
+                    <Users className="h-5 w-5 shrink-0 text-emerald-600" />
+                    <div className="text-sm">
+                      <p className="font-semibold text-emerald-800">Collaborating with {pitch?.creatorName || 'the creator'}</p>
+                      <p className="mt-0.5 text-emerald-700">Your Team Plan &amp; Notes are now shared — you're both co-developing this pitch.</p>
+                    </div>
+                  </div>
+                ) : collabPending ? (
+                  <div className="flex items-start gap-3 rounded-xl bg-indigo-50 ring-1 ring-inset ring-indigo-200 px-4 py-3.5">
+                    <Clock className="h-5 w-5 shrink-0 text-indigo-500" />
+                    <div className="text-sm">
+                      <p className="font-semibold text-indigo-800">Collaboration proposed</p>
+                      <p className="mt-0.5 text-indigo-700">Waiting for {pitch?.creatorName || 'the creator'} to accept. Once they do, your plan becomes a shared workspace.</p>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="rounded-xl bg-white ring-1 ring-inset ring-gray-200 px-4 py-3.5 shadow-sm">
+                    <div className="flex items-start gap-3">
+                      <Users className="h-5 w-5 shrink-0 text-indigo-500" />
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-semibold text-gray-900">Ready to develop this together?</p>
+                        <p className="mt-0.5 text-sm text-gray-500">Propose a collaboration to {pitch?.creatorName || 'the creator'}. If they accept, your Team Plan &amp; Notes become a shared workspace you co-develop.</p>
+                        <button
+                          onClick={handleProposeCollaboration}
+                          disabled={proposingCollab}
+                          className="mt-3 inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-3.5 py-2 text-sm font-medium text-white transition hover:bg-indigo-700 disabled:opacity-50"
+                        >
+                          <Users className="h-4 w-4" />
+                          {proposingCollab ? 'Proposing…' : 'Propose collaboration'}
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                )
               )}
 
               {/* Feedback & rating — production cos can rate + leave structured

--- a/src/handlers/collaborations-real.ts
+++ b/src/handlers/collaborations-real.ts
@@ -146,6 +146,50 @@ export async function createCollaborationHandler(request: Request, env: Env): Pr
       }, 409, origin);
     }
 
+    // Notify the creator (best-effort — never block the proposal). The creator's
+    // accept surface (Phase 2) reads the collaborations table directly, so a
+    // missing notification/email is cosmetic, not load-bearing.
+    try {
+      let producerName = 'A production company';
+      let pitchTitle = 'your pitch';
+      let creatorEmail: string | null = null;
+      try {
+        const [info] = await sql`
+          SELECT u.username AS producer_name, u.company_name AS producer_company,
+                 cu.email AS creator_email,
+                 (SELECT title FROM pitches WHERE id = ${pitchId || null}) AS pitch_title
+          FROM users u, users cu
+          WHERE u.id = ${userId} AND cu.id = ${collaboratorId}`;
+        if (info) {
+          producerName = info.producer_company || info.producer_name || producerName;
+          pitchTitle = info.pitch_title || pitchTitle;
+          creatorEmail = info.creator_email || null;
+        }
+      } catch { /* lookup drift — use defaults */ }
+
+      const title = 'New collaboration request';
+      const msg = `${producerName} wants to collaborate with you on "${pitchTitle}".`;
+      try {
+        await sql`INSERT INTO notifications (user_id, type, title, message)
+                  VALUES (${collaboratorId}, 'collaboration_invite', ${title}, ${msg})`;
+      } catch (e) { console.warn('collab notify insert failed (non-fatal):', e); }
+
+      const resendKey = (env as any).RESEND_API_KEY as string | undefined;
+      if (creatorEmail && resendKey) {
+        try {
+          const { sendCollaboratorInviteEmail } = await import('../services/email/index');
+          const base = (env as any).FRONTEND_URL || 'https://pitchey-5o8.pages.dev';
+          await sendCollaboratorInviteEmail(creatorEmail, {
+            inviterName: producerName,
+            companyName: producerName,
+            role: role || 'co_development',
+            projectTitle: pitchTitle,
+            acceptUrl: `${base}/creator/collaborations`,
+          }, resendKey);
+        } catch (e) { console.warn('collab invite email failed (non-fatal):', e); }
+      }
+    } catch (e) { console.warn('collab notify block failed (non-fatal):', e); }
+
     return jsonResponse({
       success: true,
       data: result[0],
@@ -248,6 +292,23 @@ export async function updateCollaborationHandler(request: Request, env: Env): Pr
       }, 403, origin);
     }
 
+    // One ACTIVE collaboration per pitch (MVP): block accepting a second while
+    // another is already accepted on the same pitch. Close the first to switch.
+    if (status === 'accepted' && collaboration.pitch_id) {
+      try {
+        const [other] = await sql`
+          SELECT id FROM collaborations
+          WHERE pitch_id = ${collaboration.pitch_id} AND status = 'accepted' AND id <> ${collaborationId}
+          LIMIT 1`;
+        if (other) {
+          return jsonResponse({
+            success: false,
+            error: 'This pitch already has an active collaboration. Close it before accepting another.'
+          }, 409, origin);
+        }
+      } catch { /* collaborations drift — allow */ }
+    }
+
     // Perform the update
     const updated = status === 'closed'
       ? await sql`
@@ -265,6 +326,21 @@ export async function updateCollaborationHandler(request: Request, env: Env): Pr
 
     if (!updated || updated.length === 0) {
       return jsonResponse({ success: false, error: 'Failed to update collaboration' }, 500, origin);
+    }
+
+    // Notify the producer (requester) when the creator accepts (best-effort).
+    if (status === 'accepted') {
+      try {
+        const [info] = await sql`
+          SELECT cu.username AS creator_name,
+                 (SELECT title FROM pitches WHERE id = ${collaboration.pitch_id || null}) AS pitch_title
+          FROM users cu WHERE cu.id = ${userId}`;
+        const cname = info?.creator_name || 'The creator';
+        const ptitle = info?.pitch_title || 'your pitch';
+        await sql`INSERT INTO notifications (user_id, type, title, message)
+          VALUES (${collaboration.requester_id}, 'collaboration_accepted', 'Collaboration accepted',
+                  ${`${cname} accepted your collaboration on "${ptitle}".`})`;
+      } catch (e) { console.warn('collab accept notify failed (non-fatal):', e); }
     }
 
     return jsonResponse({

--- a/src/handlers/production-pitch-data.ts
+++ b/src/handlers/production-pitch-data.ts
@@ -100,6 +100,29 @@ async function resolveWorkspace(sql: any, actingUserId: number, pitchId: number)
   let myType: string | undefined;
   try { const [me] = await sql`SELECT user_type FROM users WHERE id = ${actingUserId}`; myType = me?.user_type; } catch { /* default below */ }
 
+  // Pitch-scoped collaboration: an ACCEPTED collaborations row between a producer
+  // (requester) and the creator (collaborator) turns this creator-owned pitch into
+  // a SHARED workspace. Both sides resolve to the producer's existing evaluation
+  // rows (workspaceUserId = requester) so the producer's plan carries straight over
+  // and both co-edit. Runs before the private-per-producer fallback below.
+  if (!isProductionPitch) {
+    try {
+      const [collab] = await sql`
+        SELECT requester_id, collaborator_id FROM collaborations
+        WHERE pitch_id = ${pitchId} AND status = 'accepted'
+          AND (requester_id = ${actingUserId} OR collaborator_id = ${actingUserId})
+        ORDER BY updated_at DESC LIMIT 1`;
+      if (collab) {
+        const producerId = Number(collab.requester_id);
+        const creatorId = Number(collab.collaborator_id);
+        return {
+          ownerId, isProductionPitch: false, workspaceUserId: producerId,
+          teamUserIds: [producerId, creatorId], canEdit: true, canView: true,
+        };
+      }
+    } catch { /* collaborations table drift — fall through to private workspace */ }
+  }
+
   if (isProductionPitch) {
     let teamUserIds = [ownerId];
     try {
@@ -545,7 +568,7 @@ function buildSlateItem(r: any): {
   poster: string | null; source: string; stage: SlateStage;
   completeness: { score: number; total: number };
   checklistPct: number; rolesConfirmed: number; rolesTotal: number; rolesFilled: number;
-  notesCount: number; hasNda: boolean;
+  notesCount: number; hasNda: boolean; collaboration: 'none' | 'pending' | 'accepted';
 } {
   // Mirror the Feasibility tab's 9-field completeness (ProductionPitchView.calculateCompleteness).
   const team = Array.isArray(r.team) ? r.team : [];
@@ -574,6 +597,8 @@ function buildSlateItem(r: any): {
 
   const notesCount = Number(r.notes_count) || 0;
   const hasNda = r.has_nda === true;
+  const collaboration: 'none' | 'pending' | 'accepted' =
+    r.collab_status === 'accepted' ? 'accepted' : r.collab_status === 'pending' ? 'pending' : 'none';
 
   // Derived stage — default thresholds (tunable). Pure function of the signals.
   let stage: SlateStage = 'evaluating';
@@ -586,7 +611,7 @@ function buildSlateItem(r: any): {
     poster: r.poster ?? null, source: r.source, stage,
     completeness: { score: completenessScore, total: present.length },
     checklistPct, rolesConfirmed, rolesTotal, rolesFilled,
-    notesCount, hasNda,
+    notesCount, hasNda, collaboration,
   };
 }
 
@@ -638,7 +663,11 @@ export async function getProductionSlate(request: Request, env: Env): Promise<Re
       )
       SELECT sp.*, c.checklist, t.team,
         COALESCE((SELECT COUNT(*)::int FROM production_notes n WHERE n.pitch_id = sp.id AND n.user_id = ${me}), 0) AS notes_count,
-        EXISTS (SELECT 1 FROM ndas nd WHERE nd.pitch_id = sp.id AND nd.signer_id = ${me} AND (nd.status = 'approved' OR nd.status = 'signed')) AS has_nda
+        EXISTS (SELECT 1 FROM ndas nd WHERE nd.pitch_id = sp.id AND nd.signer_id = ${me} AND (nd.status = 'approved' OR nd.status = 'signed')) AS has_nda,
+        (SELECT co.status FROM collaborations co
+           WHERE co.pitch_id = sp.id AND co.requester_id = ${me}
+             AND co.status IN ('pending','accepted')
+           ORDER BY (co.status = 'accepted') DESC LIMIT 1) AS collab_status
       FROM slate_pitches sp
       LEFT JOIN production_checklists c ON c.user_id = ${me} AND c.pitch_id = sp.id
       LEFT JOIN production_team_assignments t ON t.user_id = ${me} AND t.pitch_id = sp.id

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -6010,6 +6010,7 @@ pitchey_analytics_datapoints_per_minute 1250
       let isCompanyMember = false;
       let companyTeamId: number | null = null;
       let companyNdaSigned = false;
+      let collaboration: { id: number; status: string; role: string | null; withUserId: number; withName: string | null } | null = null;
       try {
         const authResult = await this.validateAuth(request);
         if (authResult.valid && authResult.user) {
@@ -6091,6 +6092,38 @@ pitchey_analytics_datapoints_per_minute 1250
               } catch { /* company_nda_signatures may not exist pre-migration */ }
             }
           } catch { /* teams tables may not exist in all envs */ }
+
+          // Pitch-scoped collaboration (producer ↔ creator). Surface the acting
+          // user's pending/active collaboration on this pitch so both portals can
+          // render the propose / waiting / co-developing states.
+          try {
+            const collabRows = await sql`
+              SELECT c.id, c.status, c.role, c.requester_id, c.collaborator_id,
+                     ru.username AS requester_name, ru.company_name AS requester_company,
+                     cu.username AS collaborator_name
+              FROM collaborations c
+              JOIN users ru ON ru.id = c.requester_id
+              JOIN users cu ON cu.id = c.collaborator_id
+              WHERE c.pitch_id = ${pitchId}
+                AND (c.requester_id = ${authUserId} OR c.collaborator_id = ${authUserId})
+                AND c.status IN ('pending', 'accepted')
+              ORDER BY (c.status = 'accepted') DESC, c.updated_at DESC
+              LIMIT 1
+            `;
+            if (collabRows.length > 0) {
+              const c = collabRows[0];
+              const iAmRequester = Number(c.requester_id) === Number(authUserId);
+              collaboration = {
+                id: Number(c.id),
+                status: String(c.status),
+                role: c.role ?? null,
+                withUserId: iAmRequester ? Number(c.collaborator_id) : Number(c.requester_id),
+                withName: iAmRequester
+                  ? (c.collaborator_name ?? null)
+                  : (c.requester_company || c.requester_name || null),
+              };
+            }
+          } catch { /* collaborations table may not exist in all envs */ }
         }
       } catch {
         // Auth check is optional for public pitch viewing
@@ -6185,6 +6218,7 @@ pitchey_analytics_datapoints_per_minute 1250
         isCompanyMember,
         companyTeamId,
         companyNdaSigned,
+        collaboration,
         hasProtectedContent,
         view_count: parseInt(String(pitch.view_count || '0')),
         investment_count: investmentCount,


### PR DESCRIPTION
Phase 1 of the "Ready → Start collaboration" bridge. Turns a producer's saved-pitch evaluation into a real producer↔creator collaboration, reusing the live `collaborations` table + `collaborations-real.ts` handlers.

**Backend**
- `resolveWorkspace`: an **accepted** collaboration on a creator-owned pitch makes the workspace **shared** — both sides resolve to the producer's existing evaluation rows (`workspaceUserId = requester`, `teamUserIds = [P,C]`, co-edit). The plan carries over automatically. Existing workspace endpoints gate only on `resolveWorkspace`, so the creator can use them once granted.
- `createCollaborationHandler`: notifies the creator (in-app + best-effort email). `updateCollaborationHandler`: one active collaboration per pitch + notifies producer on accept.
- `getPitch`: new `pitch.collaboration {id,status,role,withUserId,withName}`.
- `/api/production/slate`: per-item `collaboration` status.

**Producer frontend**
- `ProductionPitchView`: "Propose collaboration" CTA + state framing (propose → proposed/waiting → "Collaborating with {creator}" badge + shared scope note).
- `ProductionSlateBoard`: Collaborating/Proposed badge on cards.

**Deferred to Phase 2**: creator accept UI + creator-side shared-workspace view.

Tests: tsc clean; full frontend suite 3435 passing; worker dry-run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)