### PR TITLE
Fix collaboration shared-notes read + getPitch collab coercion

### DIFF
--- a/src/handlers/production-pitch-data.ts
+++ b/src/handlers/production-pitch-data.ts
@@ -174,21 +174,16 @@ export async function getProductionNotes(request: Request, env: Env): Promise<Re
     const ws = await resolveWorkspace(sql, Number(userId), pitchId);
     if (!ws || !ws.canView) return jsonResponse({ success: true, data: { notes: [] } }, origin);
 
-    // Production pitch → the team's shared notes (scoped to team authors so
-    // external producers' private notes never leak). Creator pitch → my own.
-    const notesResult = ws.isProductionPitch
-      ? await safeQuery(() => sql`
-          SELECT id, content, category, author, shared, user_id, created_at, updated_at
-          FROM production_notes
-          WHERE pitch_id = ${pitchId} AND user_id = ANY(${ws.teamUserIds})
-          ORDER BY created_at ASC
-        `, { fallback: [], context: 'production-pitch-data.notes.list' })
-      : await safeQuery(() => sql`
-          SELECT id, content, category, author, shared, user_id, created_at, updated_at
-          FROM production_notes
-          WHERE pitch_id = ${pitchId} AND user_id = ${Number(userId)}
-          ORDER BY created_at ASC
-        `, { fallback: [], context: 'production-pitch-data.notes.list' });
+    // Notes are read across the workspace's authors (`teamUserIds`): a private
+    // creator-evaluation workspace = [me]; a production team = owner+members; a
+    // producer↔creator collaboration = [producer, creator]. Writes keep their own
+    // author user_id, so authorship is preserved while everyone sees the shared set.
+    const notesResult = await safeQuery(() => sql`
+      SELECT id, content, category, author, shared, user_id, created_at, updated_at
+      FROM production_notes
+      WHERE pitch_id = ${pitchId} AND user_id = ANY(${ws.teamUserIds})
+      ORDER BY created_at ASC
+    `, { fallback: [], context: 'production-pitch-data.notes.list' });
 
     return jsonResponse({ success: true, data: { notes: notesResult.rows } }, origin);
   } catch (err) {

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -6097,6 +6097,7 @@ pitchey_analytics_datapoints_per_minute 1250
           // user's pending/active collaboration on this pitch so both portals can
           // render the propose / waiting / co-developing states.
           try {
+            const meId = Number(authUserId); // collaborations.*_id are INTEGER
             const collabRows = await sql`
               SELECT c.id, c.status, c.role, c.requester_id, c.collaborator_id,
                      ru.username AS requester_name, ru.company_name AS requester_company,
@@ -6105,7 +6106,7 @@ pitchey_analytics_datapoints_per_minute 1250
               JOIN users ru ON ru.id = c.requester_id
               JOIN users cu ON cu.id = c.collaborator_id
               WHERE c.pitch_id = ${pitchId}
-                AND (c.requester_id = ${authUserId} OR c.collaborator_id = ${authUserId})
+                AND (c.requester_id = ${meId} OR c.collaborator_id = ${meId})
                 AND c.status IN ('pending', 'accepted')
               ORDER BY (c.status = 'accepted') DESC, c.updated_at DESC
               LIMIT 1


### PR DESCRIPTION
Round-trip fixes for the collaboration bridge: notes now read across teamUserIds (so both producer & creator see the shared set), and the getPitch collaboration query coerces authUserId to Number (INTEGER columns). 🤖 Generated with [Claude Code](https://claude.com/claude-code)