### PR TITLE
fix(cron): resolve ./db dynamic import + Axiom APL 422 in scheduled jobs

### DIFF
--- a/src/lib/observability.ts
+++ b/src/lib/observability.ts
@@ -162,7 +162,9 @@ export class AxiomClient {
     });
 
     if (!response.ok) {
-      const detail = await response.text().catch(() => '');
+      // Best-effort: include the response body in the error for debuggability.
+      let detail = '';
+      try { detail = await response.text(); } catch { /* body not readable */ }
       throw new Error(`Axiom query failed: ${response.status}${detail ? ` — ${detail.slice(0, 200)}` : ''}`);
     }
 

--- a/src/lib/observability.ts
+++ b/src/lib/observability.ts
@@ -150,7 +150,9 @@ export class AxiomClient {
     if (startTime) body.startTime = startTime;
     if (endTime) body.endTime = endTime;
 
-    const response = await fetch('https://api.axiom.co/v1/datasets/_apl', {
+    // `format=tabular` is required to get the { tables: [{ fields, columns }] }
+    // response shape callers parse; without it the API 422s / returns legacy shape.
+    const response = await fetch('https://api.axiom.co/v1/datasets/_apl?format=tabular', {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${this.token}`,
@@ -160,7 +162,8 @@ export class AxiomClient {
     });
 
     if (!response.ok) {
-      throw new Error(`Axiom query failed: ${response.status}`);
+      const detail = await response.text().catch(() => '');
+      throw new Error(`Axiom query failed: ${response.status}${detail ? ` — ${detail.slice(0, 200)}` : ''}`);
     }
 
     return response.json();

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -21605,7 +21605,7 @@ async function checkContainerHealth(env: any, ctx: ExecutionContext): Promise<vo
 async function keepDatabaseWarm(env: any, _ctx: ExecutionContext): Promise<void> {
   if (env.KEEP_WARM_DB !== 'true') return; // default off — see #65 quota note above
   try {
-    const { getDb } = await import('./db');
+    const { getDb } = await import('./db/connection');
     const sql = getDb(env);
     if (!sql) return;
     await sql`SELECT 1`;
@@ -21633,7 +21633,7 @@ async function reconcileStripeSubscriptions(env: any, _ctx: ExecutionContext): P
     return;
   }
   try {
-    const { getDb } = await import('./db');
+    const { getDb } = await import('./db/connection');
     const sql = getDb(env);
     if (!sql) {
       console.error(JSON.stringify({ level: 'error', category: 'stripe_reconcile', action: 'skipped', reason: 'no_db' }));
@@ -21891,7 +21891,7 @@ async function updateTrendingAlgorithm(env: any, _ctx: ExecutionContext): Promis
   // produced.
   const startedAt = Date.now();
   try {
-    const { getDb } = await import('./db');
+    const { getDb } = await import('./db/connection');
     const sql = getDb(env);
     if (!sql) {
       console.log(JSON.stringify({
@@ -21958,7 +21958,7 @@ async function topUpDemoAccountCredits(env: any, ctx: ExecutionContext): Promise
   const BASELINE = 500;
 
   try {
-    const { getDb } = await import('./db');
+    const { getDb } = await import('./db/connection');
     const sql = getDb(env);
     if (!sql) {
       console.log(JSON.stringify({
@@ -22022,7 +22022,7 @@ async function topUpDemoAccountCredits(env: any, ctx: ExecutionContext): Promise
 async function sweepExpiredSubscriptionGrants(env: any, ctx: ExecutionContext): Promise<void> {
   const startedAt = Date.now();
   try {
-    const { getDb } = await import('./db');
+    const { getDb } = await import('./db/connection');
     const sql = getDb(env);
     if (!sql) {
       console.log(JSON.stringify({


### PR DESCRIPTION
## What

Two production bugs found while verifying the money-path-safety crons against live Worker Observability.

### 1. `No such module "db"` — all five `./db` dynamic imports (pre-existing)
`worker-integrated.ts` had five scheduled-job functions doing `await import('./db')`, but there is **no `src/db/index.ts` barrel** — `getDb` lives in `src/db/connection.ts`, and every static importer in the repo uses `'../db/connection'`. At runtime the bundled worker threw `No such module "db".`, so each cron failed at `duration_ms: 0` before doing any work.

Confirmed live (Worker Observability, last 24h):
- **`heat_score`** (`updateTrendingAlgorithm`, `*/15`) — failing every 15 min → **heat scores frozen** since the import landed (2026-05-04)
- **`stripe_reconcile`** (`0 3 * * *`) — money-path reconciliation never ran (failed at 03:00:09 today)
- **demo-credit top-up** + **subscription-expiry sweep** (daily)
- **`keepDatabaseWarm`** — latent (gated off; would throw the moment `KEEP_WARM_DB=true`)

**Fix:** point all five at `'./db/connection'`.

### 2. `Axiom query failed: 422` — money-path SLO check
`checkMoneyPathSLOs` (`0 * * * *`) logged `query_failed` with HTTP 422 every hour. `AxiomClient.query` POSTed to `/v1/datasets/_apl` **without** `?format=tabular`, which the API requires to return the `{ tables: [{ fields, columns }] }` shape the caller parses.

**Fix:** add `?format=tabular`; also surface the response body in the thrown error for future debugging.

## Verification
- Local `wrangler deploy --dry-run` clean.
- Deployed to `pitchey-api-prod` (version `b940ade5`) ahead of this PR (prod was actively broken).
- Post-deploy: confirm `heat_score` logs `recalculate_cron` success (not `No such module`) on the next `*/15` fire, and `slo` logs `check_complete` (not `query_failed`) on the next hourly fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)