### PR TITLE
fix(pitch): PitchEdit crash + double-upload + deck/lookbook label + drop Total Invested (Karl round)

### DIFF
--- a/docs/decisions/2026-06-09-team-assembly-scope.md
+++ b/docs/decisions/2026-06-09-team-assembly-scope.md
@@ -1,0 +1,89 @@
+# Decision: scope of "Team Assembly" — 2026-06-09
+
+**Status:** Proposed (decision doc, no code)
+**Owner:** product
+**Trigger:** stakeholder reaction that Team Assembly "is trying to be something else" —
+drifting into a production-management workflow rather than a pitch marketplace.
+
+---
+
+## 1. What Team Assembly does today
+
+It's a tab inside the **production pitch-view workspace**
+(`frontend/src/portals/production/pages/ProductionPitchView.tsx:1118`), gated behind
+`canSeeWorkspace && workspaceUnlocked` (so it only appears for a producer who owns or has
+unlocked the workspace on a pitch). Titled **"Team Assembly"** (or **"Your Team Plan"** in
+evaluation mode). It has two distinct blocks:
+
+1. **Collaborators** — auto-populated chips: the company owner + any creators who redeemed
+   a company **join code** ([[project_company_team_join_codes]]). Nobody types these in;
+   they come from real seat membership.
+2. **Creative roster** — manual slots for **Director, Producer, Cinematographer (DP),
+   Production Designer, Editor, Composer** (and Line Producer). Each is "add a name",
+   with a `pending → confirmed` status, editable only when `canEditWorkspace`.
+
+So one block is **real, wired data** (seat membership from join codes) and the other is a
+**free-text planning surface** (type in who you want in each chair). The roster doesn't
+invite anyone, doesn't attach to the pitch's public record, and doesn't drive any
+downstream behaviour — it's a notepad with role labels.
+
+## 2. The tension
+
+Pitchey's current job is a **pitch marketplace**: creators publish pitches, investors and
+producers discover and engage them. The creative roster is the first feature that points
+at a *different* product — **assembling and tracking a production crew**. That's a
+legitimate future direction, but mid-build it muddies the value proposition:
+
+- It reads as "project-management for getting a film made," which raises expectations
+  (invite the DP? track availability? contracts?) the product doesn't meet.
+- It's half-wired: the Collaborators block is real; the roster is a static form. Users
+  can't tell which parts "do something."
+- It competes for attention with the pitch itself — the thing the marketplace is actually
+  about.
+
+## 3. Options
+
+### A) Cut it for now (hide the roster)
+Hide the "Creative roster" block (keep the auto-populated Collaborators, which *is* real
+and tied to join codes). Revisit post-launch.
+- **Pros:** removes the confusing half-feature immediately; zero data model change; keeps
+  the genuinely-wired collaborators view; smallest surface to support at launch.
+- **Cons:** loses a (rough) signal some producers may have liked; throws away the UI work
+  rather than repurposing it.
+
+### B) Minimise to pitch metadata (recommended)
+Reframe the roster from "assemble a crew" to **"attach key creative names to this pitch"** —
+i.e. optional metadata on the pitch (e.g. "Attached: Director — Jane Doe"), shown on the
+pitch record, with **no** workflow framing (no statuses, no invites, no workspace).
+- **Pros:** keeps the one genuinely pitch-relevant idea (a pitch is more fundable with
+  names attached) while dropping the production-management drift; turns a notepad into
+  real, displayable pitch data; small, contained scope.
+- **Cons:** needs a small data model addition (attached-creatives on the pitch) and a
+  display surface; requires deciding visibility (public vs NDA-gated) — a modest, but
+  non-zero, build.
+
+### C) Keep building toward a production workflow
+Commit to crew assembly as a real feature: invitations, availability, confirmation states,
+maybe contracts.
+- **Pros:** if this is the real long-term bet, sunk-cost now compounds later.
+- **Cons:** **explicitly out of scope for the current launch.** It's a second product
+  (production management) bolted onto a marketplace, with a large surface (invites,
+  notifications, calendars, legal) and the exact "trying to be something else" risk the
+  stakeholder named. High cost, unvalidated demand.
+
+## 4. Recommendation
+
+**Lean B, fall back to A.** The stakeholder signal is that the feature is *premature and
+confusing*, not that the underlying idea is wrong — so the move is to **keep the
+pitch-relevant kernel and shed the workflow framing**, not to keep building the workflow
+(C). If B's small metadata build can't be fit before launch, do **A** now (hide the roster,
+keep the real Collaborators block) and reconsider B/C post-launch with actual demand
+signal. Do **not** ship C for launch.
+
+Concretely, "minimise" (B) means:
+- Replace the roster's `pending/confirmed` status chips and per-role workspace editing with
+  a flat, optional **"Attached creatives"** list on the pitch (role → name), editable by
+  the pitch owner.
+- Surface it read-only on the pitch view as metadata (decide public vs NDA-gated).
+- Drop the "Team Assembly / Team Plan" workflow language entirely; keep the auto-populated
+  Collaborators block as-is (it's real and already correct).

--- a/docs/sessions/2026-06-09-karl-testing-round.md
+++ b/docs/sessions/2026-06-09-karl-testing-round.md
@@ -1,0 +1,132 @@
+# Karl testing round — 2026-06-09
+
+Karl tested on `https://pitchey-5o8.pages.dev`. The test notes flagged this as "the
+Issue #18 orphan, NOT production" — **that's wrong**. `pitchey-5o8.pages.dev` *is* the
+live production frontend (the `-5o8` suffix is permanent; the real orphan
+`pitchey.pages.dev` was deleted 2026-04-21 and now NXDOMAINs — see
+`project_pages_subdomain_model`). So every bug below is current, not a stale-preview
+artifact.
+
+## Shipped (PR #227, deployed — bundle `index-BxgIrNe0.js`)
+
+| # | Fix | File(s) |
+|---|-----|---------|
+| P1 | PitchEdit white-screen crash on `.size` of undefined | `DocumentUpload.tsx`, `PitchEdit.tsx` |
+| P2 | Document upload required two attempts | `DocumentUpload.tsx` |
+| P3 | Deck/lookbook uploader label (synonym surfaced) | `DocumentUpload.tsx` |
+| P5 | Removed "Total Invested" marketplace stat | `MarketplaceEnhanced.tsx` |
+
+**P1** — `uploadStatistics` did `d.file.size`, but documents rehydrated on the **edit**
+flow have no `File` (persisted as `{ url, title, … }`, `file: undefined`). The interface
+lied (`file: File` required). Made `file` optional + added `size?`, null-guarded every
+`.file.*` access (reduce, list render, download, dedupe, progress math). The useMemo was
+the white-screen; the list render would have been the *next* crash.
+
+**P2** — click re-entry, not a state race. The hidden `<input>` sits inside the dropzone
+`<div>` whose `onClick` calls `fileInputRef.click()`. A programmatic `input.click()`
+dispatches a click **on the input that bubbles back to the div's onClick → `.click()`
+again** → picker opens twice, first selection swallowed. Fixed with `stopPropagation` on
+the input + the "Choose Files" button.
+
+---
+
+## Report-only (need a decision before code)
+
+### P3 — lookbook vs pitch deck is a *data-model* split, not a label bug
+
+"Lookbook" and "pitch deck" are industry-synonymous, but the codebase models them as
+**two distinct things in two ways at once**:
+
+1. **Two document types** — `DOCUMENT_TYPES` in `DocumentUpload.tsx` has both
+   `pitch_deck` and `lookbook`. NDA exemption is keyed on the type
+   (`requiresNda: type !== 'lookbook'` in `CreatePitch.tsx:437`, `PitchEdit.tsx:446`) —
+   lookbooks skip the NDA gate, pitch decks don't.
+2. **Two top-level URL fields** — `pitch.pitchDeck` (`pitch_deck_url`) and
+   `pitch.lookbookUrl` (`api.ts:74,158`). The creator view (`CreatorPitchView.tsx:774`)
+   renders the "Pitch Deck" link from `pitch.pitchDeck` — a field that an **uploaded
+   document does not populate at all**. So even uploading a real pitch-deck *document*
+   won't light up the pitch-deck slot that reads the URL field.
+3. **Separate UI tiles** — `ProductionDashboard.tsx` has both a Lookbook tile (1108) and
+   a Pitch Deck tile (1151), each matching only its own `type`.
+
+**Where the "no pitch deck" signal comes from:** any check of the form
+`mediaFiles.find(m => m.type === 'pitch_deck')` (e.g. `ProductionDashboard.tsx:1153`) goes
+grey when only a `lookbook` was uploaded. The creator-facing `pitch.pitchDeck` link is a
+separate disconnect (URL field vs. uploaded document).
+
+**Shipped now:** the uploader option is relabelled `Pitch Deck / Lookbook` to surface the
+synonym (zero-risk string change).
+
+**Decision needed (do NOT migrate blind):**
+- **Option A (recommended):** treat `lookbook` as an alias of `pitch_deck` at the
+  *presence-check* layer — any `m.type === 'pitch_deck' || m.type === 'lookbook'`
+  satisfies "has a pitch deck". Keep both as upload sub-labels. No schema change. Decide
+  whether the merged concept is NDA-gated (today lookbook = exempt, deck = gated).
+- **Option B:** collapse to one type. Requires backfilling existing `lookbook` rows,
+  picking one NDA rule, and reconciling the parallel `pitch_deck_url`/`lookbook_url`
+  columns. A real migration — out of scope for a label fix.
+
+### P4 — budget is a free-text TEXT field, not a number
+
+The prompt assumed `budget` is numeric (USD, $1B cap, thousands separators). It isn't:
+
+- DB column `pitches.estimated_budget` is **TEXT** (free-form).
+- The input is a `text` field (`CreatePitch.tsx:1220`) with placeholder
+  *"Set your budget — e.g. $2.5M, £400K, or a range you're comfortable sharing"* — i.e.
+  ranges and non-USD currencies are **by design**.
+- Frontend schema: `EstimatedBudgetSchema = optional string, maxLength 100`
+  (`schemas/pitch.schema.ts:219`). Backend treats it as `estimatedBudget?: string`
+  (`worker-integrated.ts:5546`) with no numeric validation.
+
+So the requested rework (numeric USD, $1B cap, separators, backend range Zod) is a
+**breaking data-model change**, not a UI tweak:
+
+- **Option A — keep free-text, tighten UX (low risk):** keep TEXT, add a `$`/`USD` hint +
+  helper text, and a soft client-side warning for implausible inputs. No data migration;
+  ranges/currencies still allowed. Doesn't give a hard server cap.
+- **Option B — structured numeric (what the prompt describes; higher cost):** add a new
+  `estimated_budget_usd BIGINT` column, migrate/parse existing free-text where possible
+  (lossy — "£400K", "$2.5M", "1-2M range" don't all parse), make the input numeric with
+  `$`/separators/`≤ $1,000,000,000`, and add the Zod `int().min(0).max(1_000_000_000)`
+  bound server-side. Keep the free-text column for legacy display or drop it after backfill.
+
+**Recommendation:** confirm the product intent first. If budgets must stay expressible as
+ranges/other currencies, do A. If a single comparable USD figure is the goal (enables real
+"Avg Budget" math — note `MarketplaceEnhanced` already `Number()`-coerces the text today,
+so non-numeric budgets silently count as 0), do B as its own migration.
+
+### P6 — pitch → marketplace latency: it's the publish gate, not the cache
+
+- The marketplace (`MarketplaceEnhanced.tsx:354`) fetches **`/api/search`**, which (after
+  a duplicate registration — `search` at 2466 is dead, overwritten by) resolves to
+  **`searchPitches`** (`worker-integrated.ts:8812`). That handler filters
+  `status = 'published'`, orders by `created_at DESC`, and is **not cached**.
+- `createPitch` inserts new pitches as **`status = 'draft'`** (`:5634`). Drafts never
+  appear in search. A pitch only lands on the marketplace once **explicitly published**
+  via `POST /api/pitches/:id/publish` (`:2577`), which also calls `invalidateBrowseCache()`.
+- Because the search path is uncached, a *published* pitch shows on the very next
+  marketplace load — there is **no cache lag on the marketplace itself**.
+
+**So "takes a while to appear" is almost certainly one of:**
+1. The pitch was still a **draft** — publishing is a separate, possibly non-obvious step.
+   (Most likely. Fix: clarify the publish CTA, or auto-publish on create where intended.)
+2. Karl was looking at a **browse-cached surface** (homepage trending/new widgets fed by
+   `/api/pitches/browse`, 3-min Redis TTL `browse:pitches:*`). Publish invalidates that
+   cache, but `invalidateBrowseCache()` (`:12106`) only enumerates tabs
+   `trending/new/popular/default` × pages 1–3 × `l10/l20` — **any other key
+   (other tab, page ≥ 4, other limit) stays stale up to 3 min.**
+
+**Recommended fixes (pick per the actual repro):**
+- Make the **publish step explicit/obvious** post-create (or auto-publish if that's the
+  intended UX) — addresses cause 1.
+- If browse-surface staleness is the repro: switch `invalidateBrowseCache()` to a
+  key-prefix sweep (Upstash `SCAN`/prefix) instead of the hard-coded permutation list, or
+  drop the browse TTL to ~30s. Cheap, removes the silent-miss gap.
+- Clean up the **duplicate `/api/search` registration** (dead `search` at 2466).
+
+---
+
+## Not bugs
+
+- **P7 — Team Assembly:** product-scope decision, see
+  `docs/decisions/2026-06-09-team-assembly-scope.md`.

--- a/frontend/src/features/uploads/components/DocumentUpload/DocumentUpload.tsx
+++ b/frontend/src/features/uploads/components/DocumentUpload/DocumentUpload.tsx
@@ -26,7 +26,14 @@ import { uploadService } from '../../services/upload.service';
 export interface DocumentFile {
   id: string;
   type: 'script' | 'treatment' | 'pitch_deck' | 'nda' | 'supporting_materials' | 'lookbook' | 'budget';
-  file: File;
+  // Present for freshly-selected files (browser File objects). ABSENT for
+  // already-persisted documents rehydrated on the edit flow — those come from
+  // the DB as { url, title, ... } with no File. Anything reading `file.size` /
+  // `file.name` MUST null-guard (see uploadStatistics + the list render).
+  file?: File;
+  // Byte size for persisted docs where the File isn't available (the backend
+  // may send it); used as the fallback for the size readout. Unknown is fine.
+  size?: number;
   title: string;
   description?: string;
   uploadProgress?: number;
@@ -71,8 +78,8 @@ interface DocumentUploadProps {
 const DOCUMENT_TYPES = [
   { value: 'script', label: 'Script', icon: FileText, color: 'blue' },
   { value: 'treatment', label: 'Treatment', icon: FileText, color: 'green' },
-  { value: 'pitch_deck', label: 'Pitch Deck', icon: FileIcon, color: 'purple' },
-  { value: 'lookbook', label: 'Visual Lookbook', icon: ImageIcon, color: 'pink' },
+  { value: 'pitch_deck', label: 'Pitch Deck / Lookbook', icon: FileIcon, color: 'purple' },
+  { value: 'lookbook', label: 'Lookbook (Visual Pitch Deck)', icon: ImageIcon, color: 'pink' },
   { value: 'budget', label: 'Budget Breakdown', icon: FileText, color: 'yellow' },
   { value: 'nda', label: 'NDA Document', icon: Shield, color: 'red' },
   { value: 'supporting_materials', label: 'Supporting Materials', icon: FileIcon, color: 'gray' }
@@ -153,10 +160,13 @@ export default function DocumentUpload({
     const uploading = documents.filter(d => d.uploadStatus === 'uploading').length;
     const failed = documents.filter(d => d.uploadStatus === 'error').length;
     const pending = documents.filter(d => d.uploadStatus === 'idle').length;
-    const totalSize = documents.reduce((sum, d) => sum + d.file.size, 0);
+    // Persisted docs (edit flow) have no `file`; fall back to a known byte size
+    // or 0. Reading `d.file.size` directly here was the PitchEdit white-screen.
+    const sizeOf = (d: DocumentFile) => d.file?.size ?? d.size ?? 0;
+    const totalSize = documents.reduce((sum, d) => sum + sizeOf(d), 0);
     const uploadedSize = documents
       .filter(d => d.uploadStatus === 'completed')
-      .reduce((sum, d) => sum + d.file.size, 0);
+      .reduce((sum, d) => sum + sizeOf(d), 0);
     
     return {
       total,
@@ -193,10 +203,10 @@ export default function DocumentUpload({
     }
 
     // Check for duplicate files
-    const duplicate = documents.find(d => 
-      d.file.name === file.name && 
-      d.file.size === file.size && 
-      d.file.lastModified === file.lastModified
+    const duplicate = documents.find(d =>
+      d.file?.name === file.name &&
+      d.file?.size === file.size &&
+      d.file?.lastModified === file.lastModified
     );
     if (duplicate) {
       return {
@@ -334,6 +344,11 @@ export default function DocumentUpload({
 
   // Upload document to server with enhanced features
   const uploadDocument = useCallback(async (document: DocumentFile) => {
+    // Persisted docs (edit flow) carry no File and are already 'completed' —
+    // they must never be re-uploaded. Bail defensively; also narrows the
+    // optional `file` for the size math below.
+    const file = document.file;
+    if (!file) return;
     const controller = new AbortController();
     abortControllers.current.set(document.id, controller);
     
@@ -353,7 +368,7 @@ export default function DocumentUpload({
     
     try {
       const result = await uploadService.uploadDocument(
-        document.file,
+        file,
         document.type,
         {
           pitchId,
@@ -367,8 +382,8 @@ export default function DocumentUpload({
               const progressDiff = progress.percentage - stats.lastProgress;
               
               if (timeDiff > 0 && progressDiff > 0) {
-                const speed = (progressDiff / 100 * document.file.size) / timeDiff; // bytes per second
-                const remainingBytes = document.file.size * (1 - progress.percentage / 100);
+                const speed = (progressDiff / 100 * file.size) / timeDiff; // bytes per second
+                const remainingBytes = file.size * (1 - progress.percentage / 100);
                 const estimatedTimeRemaining = remainingBytes / speed; // seconds
                 
                 updateDocument(document.id, { 
@@ -664,6 +679,11 @@ export default function DocumentUpload({
           multiple
           accept={allowedTypes.join(',')}
           onChange={handleFileSelect}
+          // The programmatic fileInputRef.click() dispatches a click ON this
+          // input, which would bubble up to the wrapper div's onClick and call
+          // .click() AGAIN — opening the picker twice so the first selection is
+          // swallowed (Karl's "had to upload twice"). Stop it bubbling.
+          onClick={(e) => e.stopPropagation()}
           className="hidden"
           disabled={disabled}
         />
@@ -700,7 +720,9 @@ export default function DocumentUpload({
           {!disabled && (
             <button
               type="button"
-              onClick={() => fileInputRef.current?.click()}
+              // stopPropagation so this doesn't ALSO fire the wrapper div's
+              // onClick (which opens the picker) → single picker per click.
+              onClick={(e) => { e.stopPropagation(); fileInputRef.current?.click(); }}
               className="inline-flex items-center gap-2 px-6 py-3 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2"
             >
               <Plus className="w-4 h-4" />
@@ -903,8 +925,12 @@ export default function DocumentUpload({
                       {/* File Info */}
                       <div className="space-y-2">
                         <div className="flex items-center justify-between text-sm text-gray-500">
-                          <span className="truncate">{document.file.name}</span>
-                          <span>{formatFileSize(document.file.size)}</span>
+                          {/* Persisted docs (edit flow) have no File — fall back
+                              to the stored title and hide the size if unknown. */}
+                          <span className="truncate">{document.file?.name ?? document.title}</span>
+                          {(document.file?.size ?? document.size) != null && (
+                            <span>{formatFileSize((document.file?.size ?? document.size) as number)}</span>
+                          )}
                         </div>
                         
                         {/* Upload Status Details */}
@@ -968,7 +994,7 @@ export default function DocumentUpload({
                           onClick={() => {
                             const link = window.document.createElement('a');
                             link.href = document.url!;
-                            link.download = document.file.name;
+                            link.download = document.file?.name ?? document.title;
                             link.click();
                           }}
                           className="p-2 text-gray-500 hover:text-green-600 transition-colors rounded"

--- a/frontend/src/pages/MarketplaceEnhanced.tsx
+++ b/frontend/src/pages/MarketplaceEnhanced.tsx
@@ -197,7 +197,6 @@ export default function MarketplaceEnhanced() {
   // Statistics
   const [stats, setStats] = useState({
     totalPitches: 0,
-    totalInvestment: 0,
     avgBudget: 0,
     activeCreators: 0
   });
@@ -410,17 +409,12 @@ export default function MarketplaceEnhanced() {
       console.warn('calculateStats received non-array data:', pitchData);
       setStats({
         totalPitches: 0,
-        totalInvestment: 0,
         avgBudget: 0,
         activeCreators: 0
       });
       return;
     }
-    
-    const totalInvestment = pitchData.reduce((sum, p) => {
-      const pp = p as unknown as Record<string, unknown>;
-      return sum + (Number(pp.totalInvestment) || Number(pp.total_investment) || 0);
-    }, 0);
+
     // Use estimatedBudget (camelCase from interface) with fallbacks for API snake_case
     const avgBudget = pitchData.reduce((sum, p) => {
       const pp = p as unknown as Record<string, unknown>;
@@ -434,7 +428,6 @@ export default function MarketplaceEnhanced() {
     
     setStats({
       totalPitches: pitchData.length,
-      totalInvestment,
       avgBudget,
       activeCreators
     });
@@ -818,8 +811,8 @@ export default function MarketplaceEnhanced() {
               <p className="text-sm sm:text-base text-purple-200/80">Discover and back the next big story.</p>
             </div>
 
-            {/* Quick stats — 2x2 on mobile, 4 across on tablet+ */}
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 sm:gap-3 w-full md:w-auto">
+            {/* Quick stats — 3 across (Total Invested removed per Karl feedback) */}
+            <div className="grid grid-cols-3 gap-2 sm:gap-3 w-full md:w-auto">
               <div className="rounded-xl border border-white/10 bg-white/[0.06] backdrop-blur px-4 py-3">
                 <div className="text-xl sm:text-2xl font-bold tabular-nums">{filteredPitches.length}</div>
                 <div className="text-[10px] sm:text-xs uppercase tracking-wider text-purple-200/70">Active Pitches</div>
@@ -827,12 +820,6 @@ export default function MarketplaceEnhanced() {
               <div className="rounded-xl border border-white/10 bg-white/[0.06] backdrop-blur px-4 py-3">
                 <div className="text-xl sm:text-2xl font-bold tabular-nums">{stats.activeCreators}</div>
                 <div className="text-[10px] sm:text-xs uppercase tracking-wider text-purple-200/70">Creators</div>
-              </div>
-              <div className="rounded-xl border border-white/10 bg-white/[0.06] backdrop-blur px-4 py-3">
-                <div className="text-xl sm:text-2xl font-bold tabular-nums">
-                  {stats.totalInvestment > 0 ? formatBudgetCompact(stats.totalInvestment) : '$0'}
-                </div>
-                <div className="text-[10px] sm:text-xs uppercase tracking-wider text-purple-200/70">Total Invested</div>
               </div>
               <div className="rounded-xl border border-white/10 bg-white/[0.06] backdrop-blur px-4 py-3">
                 <div className="text-xl sm:text-2xl font-bold tabular-nums">

--- a/frontend/src/pages/PitchEdit.tsx
+++ b/frontend/src/pages/PitchEdit.tsx
@@ -236,9 +236,11 @@ export default function PitchEdit() {
             type: (d.documentType ?? d.document_type ?? d.type ?? 'supporting_materials') as DocumentFile['type'],
             title: d.fileName ?? d.file_name ?? d.originalFileName ?? d.original_file_name ?? d.title ?? 'Document',
             url: d.fileUrl ?? d.file_url ?? d.url,
+            size: d.fileSize ?? d.file_size ?? d.size ?? undefined,
             uploadStatus: 'completed',
             uploadProgress: 100,
-            file: undefined as unknown as File,
+            // No File for already-persisted docs — the component null-guards on this.
+            file: undefined,
           })
         ),
         ndaConfig: {
@@ -438,14 +440,16 @@ export default function PitchEdit() {
       // collected rather than aborting the whole save.
       const pendingDocs = formData.documents.filter((d) => d.file && !d.url);
       for (const doc of pendingDocs) {
+        const file = doc.file;
+        if (!file) continue; // already guaranteed by the filter; narrows the optional type
         try {
-          await uploadService.uploadDocument(doc.file, doc.type, {
+          await uploadService.uploadDocument(file, doc.type, {
             pitchId: parseInt(id!),
             requiresNda: doc.type !== 'lookbook',
           });
         } catch (docErr) {
           console.error('Document upload failed:', doc.title, docErr);
-          failedDocs.push(doc.title || doc.file.name);
+          failedDocs.push(doc.title || file.name);
         }
       }
 


### PR DESCRIPTION
Karl production-testing round — frontend fixes (P1, P2, P3-label, P5). **Already deployed** to `pitchey-5o8.pages.dev` (bundle `index-BxgIrNe0.js`) since P1 hard-crashes editing.

> Infra note: Karl tested on `pitchey-5o8.pages.dev`, which the test notes called the "Issue #18 orphan." It isn't — that's the **live production** frontend (the `-5o8` suffix is permanent; the real orphan `pitchey.pages.dev` was deleted 2026-04-21). These bugs are current, not stale-preview artifacts.

## P1 — PitchEdit white-screen `Cannot read properties of undefined (reading 'size')` (CRITICAL)
`DocumentUpload`'s `uploadStatistics` useMemo did `d.file.size`, but documents rehydrated on the **edit** flow carry no `File` (`file: undefined`) — they come from the DB as `{ url, title, ... }`. Made `DocumentFile.file` optional (it always was, in practice) + added `size?`, and null-guarded every `.file.*` site: the size reduce, the list render, the download handler, the dedupe check, and the upload progress math. PitchEdit now maps a `size` for persisted docs.

## P2 — uploads needed two attempts
Click re-entry: the hidden `<input>` lives inside the dropzone `<div>` whose `onClick` calls `fileInputRef.click()`. A programmatic `input.click()` dispatches a click **on the input that bubbles back to that div's onClick → calls `.click()` again**, opening the picker twice and swallowing the first selection. The "Choose Files" button compounded it. Fixed with `stopPropagation` on the input and the button. (The uploading indicator the notes asked for already exists via the `uploadStatus==='uploading'` progress UI.)

## P3 — lookbook vs pitch deck (label only)
Relabelled the uploader options to surface the synonym (`Pitch Deck / Lookbook`). The deeper cause is a **data-model split** — separate `pitch_deck`/`lookbook` document types AND separate top-level `pitch_deck_url`/`lookbookUrl` fields, with the creator view reading the URL field (not uploaded documents). Per the prompt's guard, that's **reported, not migrated** — see the session writeup. Needs a product decision (merge vs keep distinct; NDA-exemption for lookbooks is keyed on the type).

## P5 — removed "Total Invested" marketplace stat
Dropped the card (kept "Avg Budget"), rebalanced the grid 4→3 cols, removed the now-unused `totalInvestment` state + aggregation.

## Not in this PR (report-only, need decisions)
- **P4 (budget)**: `estimated_budget` is a **free-text TEXT** column (placeholder invites "$2.5M, £400K, or a range"), not a number. The requested numeric-USD/$1B-cap/separators rework is a breaking data-model change → reported with options, not implemented.
- **P6 (marketplace latency)**: diagnosed — new pitches are `status='draft'` (worker-integrated.ts:5634), marketplace shows only `status='published'` (:8931), plus a 3-min Redis cache on `browse:pitches:*`. Report-only.
- **P7**: Team Assembly decision doc (separate docs commit).

## Verification
`tsc --noEmit -p tsconfig.app.json` passes. Deployed + canonical bundle confirmed live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)