### PR TITLE
feat(karl-r2): numeric budget + browse-cache + deck/lookbook + publish clarity + Team→Creatives

### DIFF
--- a/frontend/src/pages/CreatePitch.tsx
+++ b/frontend/src/pages/CreatePitch.tsx
@@ -390,6 +390,7 @@ export default function CreatePitch() {
           budgetRange: validatedData.budgetRange || undefined,
           budgetBracket: validatedData.budgetRange || undefined,
           estimatedBudget: validatedData.estimatedBudget || undefined,
+          estimatedBudgetUsd: validatedData.estimatedBudget ? Number(validatedData.estimatedBudget) : undefined,
           productionTimeline: validatedData.productionTimeline || undefined,
           targetAudience: validatedData.targetAudience || undefined,
           targetReleaseDate: validatedData.targetReleaseDate || undefined,
@@ -1221,23 +1222,34 @@ export default function CreatePitch() {
                 </div>
               </div>
 
-              {/* Budget — free-form, set by the creator (no fixed ranges) */}
+              {/* Budget — numeric USD, capped at $1B (Karl P4). Stored as a clean
+                  integer; the "$"/"USD" affordances + comma formatting keep it readable
+                  and inside the box at max length. */}
               <div>
                 <label htmlFor="estimatedBudget" className="block text-sm font-medium text-gray-700 mb-2">
-                  Budget <span className="text-gray-400 font-normal">(optional)</span>
+                  Budget <span className="text-gray-400 font-normal">(optional, USD)</span>
                 </label>
-                <input
-                  type="text"
-                  id="estimatedBudget"
-                  name="estimatedBudget"
-                  value={formData.estimatedBudget || ''}
-                  onChange={handleInputChange}
-                  maxLength={100}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
-                  placeholder="Set your budget — e.g. $2.5M, £400K, or a range you're comfortable sharing"
-                />
-                <p className="text-xs text-gray-500 mt-1">
-                  Free text — set whatever's right for your project.
+                <div className="relative">
+                  <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">$</span>
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    id="estimatedBudget"
+                    name="estimatedBudget"
+                    value={formData.estimatedBudget ? Number(formData.estimatedBudget).toLocaleString('en-US') : ''}
+                    onChange={(e) => {
+                      const digits = e.target.value.replace(/[^0-9]/g, '');
+                      const capped = digits ? String(Math.min(Number(digits), 1000000000)) : '';
+                      setValue('estimatedBudget', capped);
+                    }}
+                    className="w-full pl-7 pr-14 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 truncate"
+                    placeholder="50,000,000"
+                    aria-describedby="budget-help"
+                  />
+                  <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs font-medium text-gray-400">USD</span>
+                </div>
+                <p id="budget-help" className="text-xs text-gray-500 mt-1">
+                  Shown in US dollars so budgets are comparable globally (payments are still processed in EUR). Max $1,000,000,000.
                 </p>
               </div>
             </div>

--- a/frontend/src/pages/CreatePitch.tsx
+++ b/frontend/src/pages/CreatePitch.tsx
@@ -490,7 +490,13 @@ export default function CreatePitch() {
         // Announce success to screen readers
         a11y.validation.announceSuccess(SUCCESS_MESSAGES.PITCH_CREATED || 'Pitch created successfully');
 
-        success(SUCCESS_MESSAGES.PITCH_CREATED || 'Pitch created successfully', 'Your pitch has been created and is ready for review.');
+        // A new pitch is saved as a DRAFT — it does NOT appear on the marketplace
+        // until it's published. Say so explicitly so creators don't wait for it to
+        // show up on its own (the "takes a while to appear" confusion).
+        success(
+          'Pitch saved as a draft',
+          'It won\'t appear on the marketplace until you publish it — open it from "My Pitches" and hit Publish.'
+        );
 
         // PHASE 4: Navigate only after everything completes
         navigate(isProduction ? '/production/pitches' : '/creator/pitches');

--- a/frontend/src/pages/MarketplaceEnhanced.tsx
+++ b/frontend/src/pages/MarketplaceEnhanced.tsx
@@ -415,12 +415,18 @@ export default function MarketplaceEnhanced() {
       return;
     }
 
-    // Use estimatedBudget (camelCase from interface) with fallbacks for API snake_case
-    const avgBudget = pitchData.reduce((sum, p) => {
-      const pp = p as unknown as Record<string, unknown>;
-      const budget = Number(p.estimatedBudget) || Number(pp.estimated_budget) || 0;
-      return sum + budget;
-    }, 0) / (pitchData.length || 1);
+    // Average the structured USD budget (estimated_budget_usd) over only the pitches
+    // that have one — averaging over all pitches (incl. budget-less ones) understates
+    // it, and the legacy free-text estimated_budget can't be summed reliably.
+    const budgets = pitchData
+      .map((p) => {
+        const pp = p as unknown as Record<string, unknown>;
+        return Number(pp.estimatedBudgetUsd ?? pp.estimated_budget_usd ?? 0) || 0;
+      })
+      .filter((b) => b > 0);
+    const avgBudget = budgets.length
+      ? Math.round(budgets.reduce((s, b) => s + b, 0) / budgets.length)
+      : 0;
     const activeCreators = new Set(pitchData.map(p => {
       const pp = p as unknown as Record<string, unknown>;
       return p.creator?.id || (pp.creator_id as string | undefined) || p.userId;

--- a/frontend/src/pages/PitchEdit.tsx
+++ b/frontend/src/pages/PitchEdit.tsx
@@ -211,7 +211,11 @@ export default function PitchEdit() {
         worldDescription: pitch.worldDescription || '',
         longSynopsis: (pitch as any).longSynopsis ?? (pitch as any).long_synopsis ?? '',
         budgetRange: (pitch as any).budgetRange ?? (pitch as any).budget_range ?? pitch.budget ?? '',
-        estimatedBudget: (pitch as any).estimatedBudget ?? (pitch as any).estimated_budget ?? '',
+        // Numeric USD budget — load the structured column only (the legacy free-text
+        // estimated_budget may be "£400K"/ranges that don't fit a numeric input).
+        estimatedBudget: (pitch as any).estimated_budget_usd != null
+          ? String((pitch as any).estimated_budget_usd)
+          : ((pitch as any).estimatedBudgetUsd != null ? String((pitch as any).estimatedBudgetUsd) : ''),
         targetAudience: (pitch as any).targetAudience ?? (pitch as any).target_audience ?? '',
         productionTimeline: (pitch as any).productionTimeline ?? (pitch as any).production_timeline ?? '',
         targetReleaseDate: (pitch as any).targetReleaseDate ?? (pitch as any).target_release_date ?? '',
@@ -379,6 +383,7 @@ export default function PitchEdit() {
         worldDescription: formData.worldDescription,
         longSynopsis: formData.longSynopsis || undefined,
         budgetRange: formData.budgetRange || undefined,
+        estimatedBudgetUsd: formData.estimatedBudget ? Number(formData.estimatedBudget) : undefined,
         targetAudience: formData.targetAudience || undefined,
         productionTimeline: formData.productionTimeline || undefined,
         targetReleaseDate: formData.targetReleaseDate || undefined,
@@ -767,24 +772,33 @@ export default function PitchEdit() {
             </div>
           </div>
 
-          {/* Budget Section */}
+          {/* Budget Section — numeric USD, capped at $1B (Karl P4) */}
           <div className="bg-white rounded-xl shadow-sm p-6">
-            <label htmlFor="budgetRange" className="block text-sm font-medium text-gray-700 mb-2">
-              Budget
+            <label htmlFor="estimatedBudget" className="block text-sm font-medium text-gray-700 mb-2">
+              Budget <span className="text-gray-400 font-normal">(USD)</span>
             </label>
-            <input
-              type="text"
-              id="budgetRange"
-              name="budgetRange"
-              value={formData.budgetRange}
-              onChange={handleInputChange}
-              disabled={isSubmitting}
-              maxLength={100}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:outline-none"
-              placeholder="Set your budget — e.g. $2.5M, £400K, or a range you're comfortable sharing"
-            />
-            <p className="text-xs text-gray-500 mt-1">
-              Enter the budget you want to share with investors. Free text — set whatever's right for your project.
+            <div className="relative">
+              <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">$</span>
+              <input
+                type="text"
+                inputMode="numeric"
+                id="estimatedBudget"
+                name="estimatedBudget"
+                value={formData.estimatedBudget ? Number(formData.estimatedBudget).toLocaleString('en-US') : ''}
+                onChange={(e) => {
+                  const digits = e.target.value.replace(/[^0-9]/g, '');
+                  const capped = digits ? String(Math.min(Number(digits), 1000000000)) : '';
+                  setFormData((prev) => ({ ...prev, estimatedBudget: capped }));
+                }}
+                disabled={isSubmitting}
+                className="w-full pl-7 pr-14 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:outline-none truncate"
+                placeholder="50,000,000"
+                aria-describedby="budget-help-edit"
+              />
+              <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs font-medium text-gray-400">USD</span>
+            </div>
+            <p id="budget-help-edit" className="text-xs text-gray-500 mt-1">
+              Shown in US dollars so budgets are comparable globally (payments are still processed in EUR). Max $1,000,000,000.
             </p>
           </div>
 

--- a/frontend/src/pages/ProductionDashboard.tsx
+++ b/frontend/src/pages/ProductionDashboard.tsx
@@ -1103,21 +1103,6 @@ function ProductionDashboard() {
                     <div className="mb-4">
                       <h4 className="text-xs font-semibold text-gray-700 uppercase tracking-wide mb-2">Uploaded Media</h4>
                       <div className="grid grid-cols-3 gap-2">
-                        {/* Lookbook */}
-                        <div className={`flex flex-col items-center p-2 rounded-lg ${
-                          pitch.mediaFiles?.find(m => m.type === 'lookbook' && m.uploaded)
-                            ? 'bg-green-50 text-green-600'
-                            : 'bg-gray-50 text-gray-400'
-                        }`}>
-                          <BookOpen className="w-4 h-4" />
-                          <span className="text-xs mt-1">Lookbook</span>
-                          {pitch.mediaFiles?.find(m => m.type === 'lookbook') && (
-                            <span className="text-xs font-semibold">
-                              {pitch.mediaFiles.find(m => m.type === 'lookbook')?.count || 0}
-                            </span>
-                          )}
-                        </div>
-
                         {/* Script */}
                         <div className={`flex flex-col items-center p-2 rounded-lg ${
                           pitch.mediaFiles?.find(m => m.type === 'script' && m.uploaded)
@@ -1148,17 +1133,20 @@ function ProductionDashboard() {
                           )}
                         </div>
 
-                        {/* Pitch Deck */}
+                        {/* Pitch Deck / Lookbook — treated as one concept (industry
+                            synonyms). Present if either a pitch_deck or a lookbook was
+                            uploaded; count is the sum. */}
                         <div className={`flex flex-col items-center p-2 rounded-lg ${
-                          pitch.mediaFiles?.find(m => m.type === 'pitch_deck' && m.uploaded)
+                          pitch.mediaFiles?.find(m => (m.type === 'pitch_deck' || m.type === 'lookbook') && m.uploaded)
                             ? 'bg-purple-50 text-purple-600'
                             : 'bg-gray-50 text-gray-400'
                         }`}>
                           <BarChart3 className="w-4 h-4" />
-                          <span className="text-xs mt-1">Pitch Deck</span>
-                          {pitch.mediaFiles?.find(m => m.type === 'pitch_deck') && (
+                          <span className="text-xs mt-1">Pitch Deck / Lookbook</span>
+                          {pitch.mediaFiles?.find(m => m.type === 'pitch_deck' || m.type === 'lookbook') && (
                             <span className="text-xs font-semibold">
-                              {pitch.mediaFiles.find(m => m.type === 'pitch_deck')?.count || 0}
+                              {(pitch.mediaFiles.find(m => m.type === 'pitch_deck')?.count || 0) +
+                               (pitch.mediaFiles.find(m => m.type === 'lookbook')?.count || 0)}
                             </span>
                           )}
                         </div>

--- a/frontend/src/portals/production/pages/ProductionPitchView.tsx
+++ b/frontend/src/portals/production/pages/ProductionPitchView.tsx
@@ -207,18 +207,12 @@ const ProductionPitchView: React.FC = () => {
   const workspaceScopeNote = ownerIsProduction
     ? (canEditWorkspace ? 'Shared workspace — visible to your whole company team.' : 'Read-only access granted by your signed NDA.')
     : isCollaborating
-    ? `Shared with ${evalCreatorName} — you're co-developing this pitch together. Both of you can edit the Team Plan and Notes.`
+    ? `Shared with ${evalCreatorName} — you're co-developing this pitch together. Both of you can edit the Attached Creatives and Notes.`
     : `You're planning ${evalCreatorName}'s pitch as a possible production — it isn't your project. Private to your company: ${evalCreatorName} can’t see any of this.`;
   // In evaluation mode (a creator-owned pitch you didn't create), the private
   // Team/Notes workspace stays HIDDEN until you opt in by saving the pitch to
   // your slate. Your own production pitches always have it.
   const workspaceUnlocked = !evaluationMode || isShortlisted;
-  const teamStatusMeta: Record<string, { label: string; cls: string }> = {
-    confirmed:   { label: 'Confirmed',   cls: 'bg-emerald-100 text-emerald-700 ring-emerald-200' },
-    considering: { label: 'Considering', cls: 'bg-amber-100 text-amber-700 ring-amber-200' },
-    pending:     { label: 'Open',        cls: 'bg-slate-100 text-slate-500 ring-slate-200' },
-  };
-
   const [isLiked, setIsLiked] = useState(false);
   const [isLiking, setIsLiking] = useState(false);
   const [autoFillLoading, setAutoFillLoading] = useState(false);
@@ -372,9 +366,9 @@ const ProductionPitchView: React.FC = () => {
     const filledRoles = teamMembers.filter(m => m.name && m.name.trim() !== '').length;
     const hasTeam = filledRoles > 0;
     fields.push({
-      label: `Team (${filledRoles}/${teamMembers.length} roles)`,
+      label: `Creatives (${filledRoles}/${teamMembers.length} roles)`,
       present: hasTeam,
-      hint: 'Assign key crew — pitches with attached talent signal production readiness',
+      hint: 'Attach key creative names — pitches with attached talent read as more bankable',
     });
 
     const presentCount = fields.filter(f => f.present).length;
@@ -800,7 +794,7 @@ const ProductionPitchView: React.FC = () => {
                       {tab === 'production'
                         ? 'Feasibility'
                         : tab === 'team'
-                        ? (evaluationMode ? 'My Team Plan' : 'Team')
+                        ? (evaluationMode ? 'My Creatives' : 'Creatives')
                         : tab === 'notes'
                         ? (evaluationMode ? 'My Notes' : 'Notes')
                         : tab}
@@ -1122,7 +1116,7 @@ const ProductionPitchView: React.FC = () => {
                     <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 ring-1 ring-inset ring-indigo-100">
                       <Users className="h-5 w-5" />
                     </span>
-                    <h2 className="text-xl font-bold tracking-tight text-gray-900">{evaluationMode ? 'Your Team Plan' : 'Team Assembly'}</h2>
+                    <h2 className="text-xl font-bold tracking-tight text-gray-900">{evaluationMode ? 'Your Attached Creatives' : 'Attached Creatives'}</h2>
                   </div>
                   {accessChip}
                 </div>
@@ -1154,7 +1148,6 @@ const ProductionPitchView: React.FC = () => {
                 <p className="mb-2 pl-0.5 text-[0.68rem] font-semibold uppercase tracking-wide text-gray-400">Creative roster</p>
                 <div className="space-y-2.5">
                   {teamMembers.map((member, index) => {
-                    const meta = teamStatusMeta[member.status] || teamStatusMeta.pending;
                     const initials = member.name
                       ? member.name.trim().split(/\s+/).map((w) => w[0]).slice(0, 2).join('').toUpperCase()
                       : '';
@@ -1162,8 +1155,8 @@ const ProductionPitchView: React.FC = () => {
                       <div
                         key={index}
                         className={`flex items-center gap-4 rounded-xl border p-3.5 transition ${
-                          member.status === 'confirmed' && member.name
-                            ? 'border-emerald-200 bg-emerald-50/60'
+                          member.name
+                            ? 'border-indigo-200 bg-indigo-50/40'
                             : 'border-gray-100 bg-gray-50/60'
                         }`}
                       >
@@ -1188,21 +1181,8 @@ const ProductionPitchView: React.FC = () => {
                             </p>
                           )}
                         </div>
-                        {canEditWorkspace ? (
-                          <select
-                            value={member.status}
-                            onChange={(e) => handleTeamUpdate(index, 'status', e.target.value)}
-                            className={`shrink-0 cursor-pointer appearance-none rounded-full border-0 px-3 py-1 text-xs font-semibold ring-1 ring-inset focus:outline-none focus:ring-2 focus:ring-indigo-400 ${meta.cls}`}
-                          >
-                            <option value="pending">Open</option>
-                            <option value="considering">Considering</option>
-                            <option value="confirmed">Confirmed</option>
-                          </select>
-                        ) : (
-                          <span className={`shrink-0 rounded-full px-3 py-1 text-xs font-semibold ring-1 ring-inset ${meta.cls}`}>
-                            {meta.label}
-                          </span>
-                        )}
+                        {/* No status/workflow chrome — these are just names attached to
+                            the pitch as metadata, not a crew-confirmation pipeline. */}
                       </div>
                     );
                   })}
@@ -1213,7 +1193,7 @@ const ProductionPitchView: React.FC = () => {
                     onClick={async () => {
                       try {
                         await ProductionService.updatePitchTeam(parseInt(id!, 10), teamMembers);
-                        toast.success('Team configuration saved');
+                        toast.success('Attached creatives saved');
                       } catch (err) {
                         const e = err instanceof Error ? err : new Error(String(err));
                         toast.error(e.message);
@@ -1221,7 +1201,7 @@ const ProductionPitchView: React.FC = () => {
                     }}
                     className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700"
                   >
-                    <CheckCircle className="h-4 w-4" /> Save Team Configuration
+                    <CheckCircle className="h-4 w-4" /> Save Creatives
                   </button>
                 )}
               </div>

--- a/frontend/src/shared/types/api.ts
+++ b/frontend/src/shared/types/api.ts
@@ -459,6 +459,7 @@ export interface CreatePitchInput {
   budgetBracket?: string;
   budgetRange?: string;
   estimatedBudget?: number;
+  estimatedBudgetUsd?: number;
   productionTimeline?: string;
   titleImage?: string;
   lookbookUrl?: string;

--- a/src/db/migrations/100_pitch_estimated_budget_usd.sql
+++ b/src/db/migrations/100_pitch_estimated_budget_usd.sql
@@ -1,0 +1,38 @@
+-- 100_pitch_estimated_budget_usd.sql
+-- Karl round-2 (P4): give budget a real numeric home.
+--
+-- `pitches.estimated_budget` is a free-text TEXT column (held values like
+-- "12000000", "20000000k", "€14,000", and a 36-digit joke). That can't be
+-- compared, capped, or averaged. Add a structured USD integer column instead,
+-- bounded to 0..$1,000,000,000 at the DB level, and best-effort backfill the
+-- unambiguous numeric rows. The free-text column is kept for legacy display /
+-- non-USD/range values that don't convert.
+
+ALTER TABLE pitches
+  ADD COLUMN IF NOT EXISTS estimated_budget_usd BIGINT;
+
+-- Hard cap + non-negative, enforced regardless of the app layer.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'pitches_estimated_budget_usd_range'
+  ) THEN
+    ALTER TABLE pitches
+      ADD CONSTRAINT pitches_estimated_budget_usd_range
+      CHECK (estimated_budget_usd IS NULL
+             OR (estimated_budget_usd >= 0 AND estimated_budget_usd <= 1000000000));
+  END IF;
+END $$;
+
+-- Best-effort backfill: only rows whose free text is an UNAMBIGUOUS plain number
+-- ≤ $1B. Excludes anything with a letter (k/m/b suffix ambiguity), a range
+-- separator, or more than 10 digits (the 36-digit "ton of 000s" joke). Lossy by
+-- design — unconverted rows keep their text in estimated_budget and stay NULL here.
+UPDATE pitches
+SET estimated_budget_usd = CAST(regexp_replace(estimated_budget, '[^0-9]', '', 'g') AS BIGINT)
+WHERE estimated_budget_usd IS NULL
+  AND estimated_budget IS NOT NULL
+  AND estimated_budget !~ '[A-Za-z]'
+  AND estimated_budget !~ '[-–—]'
+  AND regexp_replace(estimated_budget, '[^0-9]', '', 'g') ~ '^[0-9]{1,10}$'
+  AND CAST(regexp_replace(estimated_budget, '[^0-9]', '', 'g') AS BIGINT) BETWEEN 0 AND 1000000000;

--- a/src/services/upstash-cache.service.ts
+++ b/src/services/upstash-cache.service.ts
@@ -75,6 +75,30 @@ export class UpstashCacheService {
   }
 
   /**
+   * Delete every key matching a prefix (e.g. "browse:pitches:"). Uses SCAN so a
+   * single publish/overwrite can invalidate all cached permutations without
+   * enumerating them by hand. Returns the number of keys deleted; no-op (0) if
+   * Redis isn't configured. Best-effort — failures are logged, not thrown.
+   */
+  async delByPrefix(prefix: string): Promise<number> {
+    if (!this.redis) return 0;
+    try {
+      let cursor = '0';
+      const toDelete: string[] = [];
+      do {
+        const [next, keys] = await this.redis.scan(cursor, { match: `${prefix}*`, count: 200 });
+        cursor = String(next);
+        if (keys.length) toDelete.push(...keys);
+      } while (cursor !== '0');
+      if (toDelete.length) await this.redis.del(...toDelete);
+      return toDelete.length;
+    } catch (err) {
+      console.warn(`Redis SCAN/DEL error for prefix "${prefix}":`, err);
+      return 0;
+    }
+  }
+
+  /**
    * Increment a counter (useful for rate limiting).
    * Returns the new value, or -1 on failure.
    */

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -287,6 +287,17 @@ function parseVisibilitySettings(raw: unknown): Record<string, boolean> | null {
   return null;
 }
 
+// Normalize a client-supplied USD budget to a clean integer in [0, $1B], or null.
+// Backstop for the DB CHECK (pitches_estimated_budget_usd_range). Rejects junk,
+// negatives, and the "ton of 000s" overflow by clamping to the $1B cap.
+const MAX_BUDGET_USD = 1_000_000_000;
+function normalizeBudgetUsd(raw: unknown): number | null {
+  if (raw === null || raw === undefined || raw === '') return null;
+  const n = typeof raw === 'string' ? Number(raw.replace(/[^0-9.]/g, '')) : Number(raw);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return Math.min(Math.round(n), MAX_BUDGET_USD);
+}
+
 function getOrCreateRouter(env: Env): RouteRegistry {
   const currentHash = getEnvHash(env);
 
@@ -5546,6 +5557,7 @@ pitchey_analytics_datapoints_per_minute 1250
       budgetRange?: string;
       budgetBracket?: string;
       estimatedBudget?: string;
+      estimatedBudgetUsd?: number | string | null;
       productionTimeline?: string;
       targetReleaseDate?: string;
       comparableTitles?: string;
@@ -5618,6 +5630,10 @@ pitchey_analytics_datapoints_per_minute 1250
       );
     }
 
+    // Structured USD budget (0..$1B, integer) — the source of truth for
+    // comparison/averaging. Server clamps; the DB CHECK is the hard backstop.
+    const estBudgetUsd = normalizeBudgetUsd(data.estimatedBudgetUsd);
+
     try {
       const [pitch] = await this.db.query(`
         INSERT INTO pitches (
@@ -5631,12 +5647,12 @@ pitchey_analytics_datapoints_per_minute 1250
           themes, world_description, characters,
           ai_disclosure, ai_used,
           estimated_budget, budget_bracket, production_timeline,
-          target_release_date, visibility_settings
+          target_release_date, visibility_settings, estimated_budget_usd
         ) VALUES (
           $1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, 'draft', 'private', NOW(), NOW(), $13,
           $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25,
           $26, $27,
-          $28, $29, $30, $31, $32
+          $28, $29, $30, $31, $32, $33
         ) RETURNING *
       `, [
         authResult.user.id,
@@ -5666,11 +5682,12 @@ pitchey_analytics_datapoints_per_minute 1250
         JSON.stringify(data.characters || []),
         aiDisclosure,
         aiDisclosure !== 'none',
-        data.estimatedBudget ?? null,
+        data.estimatedBudget ?? (estBudgetUsd != null ? String(estBudgetUsd) : null),
         data.budgetBracket ?? null,
         data.productionTimeline ?? null,
         data.targetReleaseDate ?? null,
-        data.visibilitySettings ? JSON.stringify(data.visibilitySettings) : null
+        data.visibilitySettings ? JSON.stringify(data.visibilitySettings) : null,
+        estBudgetUsd
       ]) as unknown as DatabaseRow[];
 
       // Handle creative attachments if provided
@@ -6347,6 +6364,7 @@ pitchey_analytics_datapoints_per_minute 1250
       budgetRange?: string;
       budgetBracket?: string;
       estimatedBudget?: string;
+      estimatedBudgetUsd?: number | string | null;
       productionTimeline?: string;
       targetReleaseDate?: string;
       comparableTitles?: string;
@@ -6444,6 +6462,7 @@ pitchey_analytics_datapoints_per_minute 1250
           target_release_date = COALESCE($31, target_release_date),
           visibility_settings = COALESCE($32, visibility_settings),
           require_nda = COALESCE($33, require_nda),
+          estimated_budget_usd = COALESCE($34, estimated_budget_usd),
           updated_at = NOW()
         WHERE id = $1
         RETURNING *
@@ -6480,7 +6499,8 @@ pitchey_analytics_datapoints_per_minute 1250
         data.productionTimeline ?? null,
         data.targetReleaseDate ?? null,
         data.visibilitySettings ? JSON.stringify(data.visibilitySettings) : null,
-        (data.requireNDA ?? data.require_nda) ?? null
+        (data.requireNDA ?? data.require_nda) ?? null,
+        data.estimatedBudgetUsd !== undefined ? normalizeBudgetUsd(data.estimatedBudgetUsd) : null
       ]);
 
       // Handle creative attachments if provided
@@ -9147,7 +9167,7 @@ pitchey_analytics_datapoints_per_minute 1250
     const result = await safeQuery(
       () => this.db.query(`
         SELECT p.id, p.title, p.logline, p.genre, p.format,
-               p.budget_range, p.estimated_budget,
+               p.budget_range, p.estimated_budget, p.estimated_budget_usd,
                COALESCE(p.heat_score, 0) AS heat_score
         FROM pitches p
         WHERE p.status = 'published'

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -2463,7 +2463,9 @@ class RouteRegistry {
     this.register('GET', '/api/media/user/:userId', this.getUserMedia.bind(this));
 
     // === PHASE 3: SEARCH AND FILTER ROUTES ===
-    this.register('GET', '/api/search', this.search.bind(this));
+    // NB: GET /api/search is registered to searchPitches below (~:2537). The
+    // route map is keyed by path, so the later registration wins — this line
+    // (→ this.search) was dead. Removed to kill the duplicate-route confusion.
     this.register('GET', '/api/search/advanced', this.advancedSearch.bind(this));
     this.register('GET', '/api/filters', this.getFilters.bind(this));
     this.register('POST', '/api/search/save', this.saveSearch.bind(this));
@@ -12105,28 +12107,14 @@ pitchey_analytics_datapoints_per_minute 1250
    */
   private async invalidateBrowseCache(): Promise<void> {
     try {
-      // Delete known cache key prefixes for browse endpoints
-      // Upstash doesn't support wildcard DEL, so we clear the most common keys
-      const keysToDelete: string[] = [];
-      const tabs = ['trending', 'new', 'popular', 'default'];
-      const genres = ['all', 'Drama', 'Comedy', 'Action', 'Thriller', 'Horror', 'Sci-Fi', 'Romance', 'Documentary'];
-
-      for (const tab of tabs) {
-        for (let page = 1; page <= 3; page++) {
-          keysToDelete.push(`browse:pitches:${tab}:p${page}:l20`);
-          keysToDelete.push(`browse:pitches:${tab}:p${page}:l10`);
-        }
-      }
-      for (const genre of genres) {
-        for (let page = 1; page <= 3; page++) {
-          keysToDelete.push(`browse:top-rated:${genre}:p${page}:l20`);
-          keysToDelete.push(`browse:top-rated:${genre}:p${page}:l10`);
-        }
-      }
-
-      if (keysToDelete.length > 0) {
-        await this.cache.del(...keysToDelete);
-      }
+      // SCAN-sweep every browse cache key by prefix. The old approach enumerated
+      // a fixed tab×page×limit permutation list, so any key outside it (other
+      // tab, page ≥ 4, other limit) stayed stale up to the 3-min TTL — a silent
+      // "published but not visible" window. Prefix sweep covers them all.
+      await Promise.all([
+        this.cache.delByPrefix('browse:pitches:'),
+        this.cache.delByPrefix('browse:top-rated:'),
+      ]);
     } catch (err) {
       console.warn('invalidateBrowseCache failed (non-blocking):', err);
     }
@@ -20501,36 +20489,9 @@ Signatures: [To be completed upon signing]
 
   // ======= PHASE 3: SEARCH AND FILTER ENDPOINTS IMPLEMENTATION =======
 
-  private async search(request: Request): Promise<Response> {
-    try {
-      const authCheck = await this.requireAuth(request);
-      if (!authCheck.authorized) return authCheck.response;
-
-      const url = new URL(request.url);
-      const query = url.searchParams.get('q') || '';
-      const filters = {
-        type: url.searchParams.get('type'),
-        genre: url.searchParams.get('genre'),
-        minBudget: url.searchParams.get('minBudget'),
-        maxBudget: url.searchParams.get('maxBudget'),
-        status: url.searchParams.get('status'),
-        sortBy: url.searchParams.get('sortBy'),
-        limit: parseInt(url.searchParams.get('limit') || '20'),
-        offset: parseInt(url.searchParams.get('offset') || '0')
-      };
-
-      const handler = new (await import('./handlers/search-filters')).SearchFiltersHandler(this.db);
-      const result = await handler.search(authCheck.user.id, query, filters);
-
-      const origin = request.headers.get('Origin');
-      return new Response(JSON.stringify(result), {
-        headers: getCorsHeaders(origin),
-        status: 200
-      });
-    } catch (error) {
-      return errorHandler(error, request);
-    }
-  }
+  // (removed) private async search() — was registered to GET /api/search but
+  // overwritten by searchPitches in the route map; dead. The live marketplace
+  // search is searchPitches. See the route-registration note in PHASE 3.
 
   private async advancedSearch(request: Request): Promise<Response> {
     try {


### PR DESCRIPTION
Karl round-2 — executes the four decisions (P3 alias, P4 migrate-numeric, P6 publish+cache, P7 minimise). **All deployed** (worker `2e6bf5ff`, frontend `index-Cz0Whf4t.js`).

### P4 — numeric USD budget (migration 100, applied to prod)
`pitches.estimated_budget` was free-text TEXT. Added `estimated_budget_usd BIGINT` + CHECK (0..$1B) + conservative backfill (4 rows; letter-suffixed/ranges/the 36-digit joke left NULL). Backend `normalizeBudgetUsd()` clamps; createPitch/updatePitch persist it. Frontend: `$`/`USD` numeric inputs with live thousands separators, $1B cap, overflow-safe, USD-vs-EUR helper (CreatePitch + PitchEdit). Marketplace "Avg Budget" averages the numeric column over pitches that have one.

### P6 — publish clarity + cache + dead route
- Post-create toast now says **"saved as a draft … publish from My Pitches"** (was "ready for review", which hid that it's not live).
- `invalidateBrowseCache()` SCAN-sweeps by prefix (added `delByPrefix`) instead of a fixed key list that missed permutations (stale ≤3 min).
- Removed the dead duplicate `GET /api/search` registration + orphaned `search()`.

### P3 — lookbook = pitch deck (presence)
Merged the ProductionDashboard Lookbook + Pitch Deck media tiles into one "Pitch Deck / Lookbook" (either type, summed). Backend completeness/facet checks that gate on `pitch_deck_url` are **orphan** (handler not imported; drizzle-era) — left untouched.

### P7 — Team Assembly → "Attached Creatives"
Dropped the Open/Considering/Confirmed workflow pipeline + "assembly/configuration" language; kept the role→name roster + auto-Collaborators block. Reframed as pitch metadata, not a crew-management flow.

`tsc` clean both sides; worker dry-run clean. Migration 100 recorded in `schema_migrations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)