### PR TITLE
fix(budget): clearable budget + reject junk strings (Karl R3 P1)

### DIFF
--- a/docs/sessions/2026-06-09-budget-verification.md
+++ b/docs/sessions/2026-06-09-budget-verification.md
@@ -1,0 +1,72 @@
+# Numeric USD budget — runtime verification (2026-06-09)
+
+Verified the round-2 budget path (PR #228) end-to-end against **production** using a
+throwaway pitch (id 2551, alex.creator/1025), read-only SQL on prod Neon
+(`patient-surf-83998605`), and direct authenticated API calls. Two real bugs surfaced;
+fixed in **PR #230** (`fix/budget-clear-and-normalize`).
+
+## Results
+
+| # | Step | Current prod (worker `2e6bf5ff`) | Verdict |
+|---|------|----------------------------------|---------|
+| 1 | CREATE budget `50,000,000` | DB `estimated_budget_usd=50000000`, `estimated_budget="50000000"` | ✅ pass |
+| 2 | EDIT `50M → 75M` | DB updates to 75000000 | ✅ pass |
+| 3 | **CLEAR (send `null`)** | set 60M → clear → **still 60000000** | ❌ **BUG** |
+| 4 | CAP `2,000,000,000` | clamped to `1000000000`, HTTP 200 (DB CHECK never hit) | ✅ pass |
+| 5 | **JUNK `"£400K"`** | **mangled to `400`** | ❌ **BUG** |
+| 6 | MARKETPLACE Avg Budget | averages `estimated_budget_usd` over pitches that have one (code-verified; renders compact via `formatBudgetCompact`) | ✅ pass |
+| 7 | LEGACY free-text coexist | rows with only legacy `estimated_budget` (e.g. "£400K") keep their text, contribute 0 to avg, display unaffected | ✅ pass |
+
+## The two bugs (root cause)
+
+**Bug 1 — budget can't be cleared.** `updatePitch` used
+`estimated_budget_usd = COALESCE($34, estimated_budget_usd)`. PitchEdit sent `undefined`
+on an empty field (JSON drops the key), the handler turned absent → `null`, and
+`COALESCE(null, old)` **preserves**. So once set, a budget could never be removed.
+
+*Fix:* PitchEdit always sends the key (`number | null`). `updatePitch` is presence-aware:
+`estimated_budget_usd = CASE WHEN $35 THEN $34 ELSE estimated_budget_usd END`, where
+`$35 = 'estimatedBudgetUsd' in data`. Explicit `null` clears; an absent key (other
+callers) still preserves.
+
+**Bug 2 — junk strings mangled.** `normalizeBudgetUsd("£400K")` stripped non-digits →
+`"400"` → **$400**. Silent, wrong.
+
+*Fix:* reject any string containing a letter or dash (k/m/b suffix, range, currency word)
+→ `null`. Plain numbers (with separators/decimal/currency symbol) still parse
+(`"€14,000"` → 14000).
+
+## The COALESCE-null question (explicit answer)
+
+**Yes — clearing was impossible on the deployed code**, confirmed at runtime (step 3). The
+COALESCE meant any `null` (whether from an omitted key or an explicit null) preserved the
+prior value. Fixed via the presence flag (`$35`) so the column is only touched when the
+client actually sends the field.
+
+## Reported, not changed (minimal-fix discipline)
+
+- **`budgetRange` still sent from PitchEdit** — the visible Budget input was repointed to the
+  numeric field in round 2, so `budgetRange` is no longer user-editable there. It round-trips
+  its loaded value through `COALESCE` on update = a no-op preserve, **not a clobber**. Safe to
+  drop from the payload later; left for now.
+- **CreatePitch valibot `EstimatedBudgetSchema`** still types budget as a `maxLength(100)`
+  string. The numeric input only ever emits digit strings, so this is permissive-but-safe;
+  the real enforcement is `normalizeBudgetUsd` + the DB CHECK. Left as-is.
+
+## Post-deploy re-verification
+
+After PR #230 merges + deploys, re-run steps 3 and 5 on prod:
+- Clear → `estimated_budget_usd` becomes NULL.
+- `"£400K"` → rejected (column unchanged / NULL, not 400).
+
+(Results appended below once the fix is live.)
+
+## Karl-facing summary
+
+The numeric USD budget field works for create, edit, the $1B cap, and the marketplace
+average. Two issues were found and fixed before retest: **a budget couldn't be cleared once
+set**, and **non-numeric text like "£400K" was silently turned into $400**. With PR #230 live,
+the field is safe to retest — set, change, clear, and over-cap all behave correctly.
+
+> Cleanup: throwaway verification pitch **2551** ("BUDGET VERIFY TEST (delete me)") to be
+> deleted after the post-deploy re-check.

--- a/frontend/src/pages/PitchEdit.tsx
+++ b/frontend/src/pages/PitchEdit.tsx
@@ -383,7 +383,10 @@ export default function PitchEdit() {
         worldDescription: formData.worldDescription,
         longSynopsis: formData.longSynopsis || undefined,
         budgetRange: formData.budgetRange || undefined,
-        estimatedBudgetUsd: formData.estimatedBudget ? Number(formData.estimatedBudget) : undefined,
+        // Always send the key (number or null) so the server can tell "cleared"
+        // (null → clears) from "not edited" (key absent → preserved). undefined
+        // would drop the key and make the budget unclearable.
+        estimatedBudgetUsd: formData.estimatedBudget ? Number(formData.estimatedBudget) : null,
         targetAudience: formData.targetAudience || undefined,
         productionTimeline: formData.productionTimeline || undefined,
         targetReleaseDate: formData.targetReleaseDate || undefined,

--- a/frontend/src/shared/types/api.ts
+++ b/frontend/src/shared/types/api.ts
@@ -459,7 +459,7 @@ export interface CreatePitchInput {
   budgetBracket?: string;
   budgetRange?: string;
   estimatedBudget?: number;
-  estimatedBudgetUsd?: number;
+  estimatedBudgetUsd?: number | null;
   productionTimeline?: string;
   titleImage?: string;
   lookbookUrl?: string;

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -293,7 +293,17 @@ function parseVisibilitySettings(raw: unknown): Record<string, boolean> | null {
 const MAX_BUDGET_USD = 1_000_000_000;
 function normalizeBudgetUsd(raw: unknown): number | null {
   if (raw === null || raw === undefined || raw === '') return null;
-  const n = typeof raw === 'string' ? Number(raw.replace(/[^0-9.]/g, '')) : Number(raw);
+  if (typeof raw === 'string') {
+    // Reject ambiguous strings (k/m/b suffixes, ranges, currency words) rather
+    // than silently mangling them — e.g. "£400K" must NOT become 400. Only a
+    // plain number (digits, optional separators/decimal/currency symbol) is
+    // accepted; anything with a letter or a dash is unparseable → null.
+    if (/[^\d.,\s$€£]/.test(raw)) return null;
+    const cleaned = raw.replace(/[^0-9.]/g, '');
+    if (cleaned === '') return null;
+    raw = cleaned;
+  }
+  const n = Number(raw);
   if (!Number.isFinite(n) || n < 0) return null;
   return Math.min(Math.round(n), MAX_BUDGET_USD);
 }
@@ -6462,7 +6472,10 @@ pitchey_analytics_datapoints_per_minute 1250
           target_release_date = COALESCE($31, target_release_date),
           visibility_settings = COALESCE($32, visibility_settings),
           require_nda = COALESCE($33, require_nda),
-          estimated_budget_usd = COALESCE($34, estimated_budget_usd),
+          -- Presence-aware: when the client sends the field ($35 true) we set it
+          -- to $34 — INCLUDING null, so a cleared budget actually clears. COALESCE
+          -- alone preserved the old value on null, making the field unclearable.
+          estimated_budget_usd = CASE WHEN $35 THEN $34 ELSE estimated_budget_usd END,
           updated_at = NOW()
         WHERE id = $1
         RETURNING *
@@ -6500,7 +6513,11 @@ pitchey_analytics_datapoints_per_minute 1250
         data.targetReleaseDate ?? null,
         data.visibilitySettings ? JSON.stringify(data.visibilitySettings) : null,
         (data.requireNDA ?? data.require_nda) ?? null,
-        data.estimatedBudgetUsd !== undefined ? normalizeBudgetUsd(data.estimatedBudgetUsd) : null
+        // $34: the value to set when present (null clears). $35: was the field
+        // sent at all — only then do we touch the column (other callers that omit
+        // it leave the budget untouched).
+        ('estimatedBudgetUsd' in (data as Record<string, unknown>)) ? normalizeBudgetUsd(data.estimatedBudgetUsd) : null,
+        ('estimatedBudgetUsd' in (data as Record<string, unknown>))
       ]);
 
       // Handle creative attachments if provided


### PR DESCRIPTION
Runtime verification of the round-2 numeric budget path (PR #228) against prod surfaced two real bugs. Fixed here; **PR before deploy** per money-path discipline.

## Verified on prod (throwaway pitch 2551, alex.creator)
| Check | Current prod | Expected after fix |
|---|---|---|
| Create budget 50M | ✅ `estimated_budget_usd=50000000` | unchanged |
| Update 50M→75M | ✅ | unchanged |
| **Clear (null)** | ❌ set 60M → clear → **still 60M** | clears to NULL |
| Cap 2e9 | ✅ clamped to 1e9, no 500 | unchanged |
| **Junk "£400K"** | ❌ mangled to **400** | rejected → null |

## Fixes
1. **Clearable budget**: PitchEdit sends the key always (number\|null); updatePitch presence-aware `CASE WHEN $35 THEN $34 ELSE estimated_budget_usd END` (null clears, absent preserves). Was `COALESCE($34, …)` which made null preserve.
2. **normalizeBudgetUsd**: reject strings with letters/dashes (`£400K`, `1-2M`) → null instead of mangling; plain numbers still parse.

## Notes (reported, not changed — minimal-fix)
- `budgetRange` is still sent from PitchEdit but no longer user-editable there; it round-trips its loaded value through COALESCE (no clobber). Left as-is.
- CreatePitch valibot `EstimatedBudgetSchema` still types budget as a maxLength-100 string; the numeric input only emits digit strings, so it's permissive-but-safe. Left as-is.

Full results: `docs/sessions/2026-06-09-budget-verification.md`. Re-verify on prod after merge+deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)