### PR TITLE
fix(publish): single publish path — drop dead-end Submit-for-review (Karl R3 P2)

### DIFF
--- a/docs/decisions/2026-06-09-publish-path.md
+++ b/docs/decisions/2026-06-09-publish-path.md
@@ -1,0 +1,49 @@
+# Decision: collapse the draft → marketplace path — 2026-06-09
+
+**Status:** Decided (A) + implemented
+**Trigger:** Karl R3 P2. Round-2 fixed the "where's my pitch" *messaging* but left two
+competing draft actions, which confused the first real tester.
+
+## Current states & transitions (verified against prod)
+
+`SELECT status, COUNT(*) FROM pitches GROUP BY status` (2026-06-09):
+
+| status | count | notes |
+|--------|------:|-------|
+| `draft` | 10 | default on create (`createPitch` inserts `'draft'`) |
+| `published` | 9 | the ONLY status the marketplace shows (`searchPitches` filters `status='published'`) |
+| `active` | 1 | legacy (2025-11-15) — not produced by current code; invisible to the marketplace |
+| `under_review` | **0** | **nobody is in it** |
+
+Who sets/reads what:
+- **create** → `'draft'`.
+- **ManagePitches "Submit for review"** (`submitForReview`) → `'under_review'`. **Dead-end:**
+  there is no reviewer/moderation process, and the marketplace ignores `under_review`. A pitch
+  sent here simply disappears from the creator's reach-the-market path.
+- **ManagePitches "Publish"** (`toggleStatus` → `pitchService.publish` → `POST /api/pitches/:id/publish`)
+  → `'published'`; this is what actually lists a pitch. It also calls `invalidateBrowseCache()`
+  (round-2 prefix sweep).
+- **marketplace** (`searchPitches`) reads `status='published'` only.
+
+So a creator faced **two buttons on a draft** — a green "Submit for review" (→ a dead-end
+state) and a separate "Publish" — with no signal that only the latter reaches the marketplace.
+
+## Options
+
+- **A) Single-action publish (chosen).** Drafts get one CTA: "Publish to marketplace". Remove the
+  "Submit for review" button for creators. Keep `under_review` in the enum (future moderation)
+  but route nothing to it. Keep unpublish (published → draft).
+- **B) Keep both, auto-promote `under_review` → `published`.** Defeats the purpose; rejected.
+- **C) Status quo with better labels.** Already confused a real tester; rejected.
+
+## Decision: **A.** No data migration needed — `under_review` is empty, so nothing is stranded.
+The single legacy `active` row is out of scope (separate legacy-status cleanup; it's invisible
+to the marketplace and harmless).
+
+## Implementation
+- ManagePitches: removed the draft "Submit for review" button + the now-unused `submitForReview`
+  handler. Drafts now show a single primary **Publish** action (green); published pitches keep
+  Unpublish. `POST /api/pitches/:id/publish` already busts the browse cache, so a freshly
+  published pitch is visible immediately (round-2 made the search path uncached + the cache
+  invalidation a prefix sweep).
+- Not introducing any moderation/approval system — out of scope.

--- a/frontend/src/pages/ManagePitches.tsx
+++ b/frontend/src/pages/ManagePitches.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Plus, Eye, Edit3, Trash2, BarChart3, Search, Filter, RefreshCw, Send } from 'lucide-react';
+import { Plus, Eye, Edit3, Trash2, BarChart3, Search, Filter, RefreshCw } from 'lucide-react';
 import { pitchService } from '@features/pitches/services/pitch.service';
 import type { Pitch } from '@shared/types/api';
 import FormatDisplay from '../components/FormatDisplay';
@@ -164,23 +164,9 @@ export default function ManagePitches() {
     }
   };
 
-  const submitForReview = async (pitchId: number) => {
-    setLoadingState(pitchId, 'submitting');
-
-    try {
-      const updatedPitch = await pitchService.update(pitchId, { status: 'under_review' });
-      setPitches(prev => prev.map(pitch =>
-        pitch.id === pitchId ? { ...pitch, ...updatedPitch, status: 'under_review' } : pitch
-      ));
-      addNotification('Pitch submitted for review', 'success');
-    } catch (err: unknown) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      console.error('Failed to submit pitch for review:', error);
-      addNotification(error.message || 'Failed to submit for review', 'error');
-    } finally {
-      clearLoadingState(pitchId);
-    }
-  };
+  // (removed) submitForReview → status 'under_review'. There is no review process;
+  // it was a dead-end state that hid pitches from the only path to the marketplace.
+  // Creators now have a single action on a draft: Publish (see toggleStatus). Karl R3 P2.
 
   const getStatusBadge = (status: string) => {
     switch (status) {
@@ -454,24 +440,6 @@ export default function ManagePitches() {
                       <BarChart3 className="w-4 h-4" />
                     </button>
 
-                    {pitch.status === 'draft' && (
-                      <button
-                        onClick={() => void submitForReview(pitch.id)}
-                        disabled={loadingStates[pitch.id] === 'submitting'}
-                        className={`flex items-center justify-center gap-2 px-3 py-2 rounded-lg transition text-sm ${
-                          loadingStates[pitch.id] === 'submitting'
-                            ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
-                            : 'bg-orange-100 text-orange-700 hover:bg-orange-200'
-                        }`}
-                        title="Submit for review"
-                      >
-                        {loadingStates[pitch.id] === 'submitting' ? (
-                          <div className="w-4 h-4 border-2 border-gray-400 border-t-transparent rounded-full animate-spin"></div>
-                        ) : (
-                          <Send className="w-4 h-4" />
-                        )}
-                      </button>
-                    )}
 
                     <button
                       onClick={() => void toggleStatus(pitch.id, pitch.status)}


### PR DESCRIPTION
Decision + implementation for the draft→marketplace dual path. Decision doc: `docs/decisions/2026-06-09-publish-path.md`.

**Prod status counts**: draft=10, published=9, active=1, **under_review=0** → no stranded rows, no data migration.

**Change**: removed the draft "Submit for review" button (→ dead-end 'under_review' — no reviewer exists, marketplace ignores it) and its handler. Creators now have one action on a draft: **Publish**. Publish/Unpublish path unchanged; `POST /api/pitches/:id/publish` busts the browse cache (round-2) so a published pitch is visible immediately.

Frontend-only; tsc clean. No moderation system introduced (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)