### PR TITLE
feat(uploads): explicit per-document NDA toggle (Karl R3 follow-up)

### DIFF
--- a/frontend/src/features/uploads/components/DocumentUpload/DocumentUpload.tsx
+++ b/frontend/src/features/uploads/components/DocumentUpload/DocumentUpload.tsx
@@ -34,6 +34,11 @@ export interface DocumentFile {
   // Byte size for persisted docs where the File isn't available (the backend
   // may send it); used as the fallback for the size readout. Unknown is fine.
   size?: number;
+  // Whether viewers must sign an NDA to see this document. When undefined it
+  // defaults from the type (lookbook = public, everything else = NDA-gated) —
+  // but the uploader can now set it explicitly per document instead of having
+  // it silently derived from the type name.
+  requiresNda?: boolean;
   title: string;
   description?: string;
   uploadProgress?: number;
@@ -372,7 +377,7 @@ export default function DocumentUpload({
         document.type,
         {
           pitchId,
-          requiresNda: document.type !== 'lookbook',
+          requiresNda: document.requiresNda ?? (document.type !== 'lookbook'),
           signal: controller.signal,
           onProgress: (progress) => {
             const stats = uploadStats.current.get(document.id);
@@ -910,7 +915,32 @@ export default function DocumentUpload({
                           ))}
                         </select>
                       </div>
-                      
+
+                      {/* Per-document NDA control — makes the protection
+                          consequence explicit and overridable. Previously this was
+                          derived silently from the type name (a "lookbook" defaulted
+                          to public without telling the uploader), which surprised
+                          real creators. Default still follows the type; the creator
+                          can change it knowingly. */}
+                      {(() => {
+                        const ndaOn = document.requiresNda ?? (document.type !== 'lookbook');
+                        return (
+                          <button
+                            type="button"
+                            onClick={() => updateDocument(document.id, { requiresNda: !ndaOn })}
+                            className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium ring-1 ring-inset transition ${
+                              ndaOn
+                                ? 'bg-red-50 text-red-700 ring-red-200 hover:bg-red-100'
+                                : 'bg-emerald-50 text-emerald-700 ring-emerald-200 hover:bg-emerald-100'
+                            }`}
+                            title="Click to change who can view this document"
+                          >
+                            {ndaOn ? <Shield className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+                            {ndaOn ? 'NDA required to view' : 'Public — anyone can view'}
+                          </button>
+                        );
+                      })()}
+
                       {/* Description (only in list view) */}
                       {currentViewMode === 'list' && (
                         <textarea

--- a/frontend/src/pages/CreatePitch.tsx
+++ b/frontend/src/pages/CreatePitch.tsx
@@ -435,7 +435,7 @@ export default function CreatePitch() {
             try {
               await uploadService.uploadDocument((doc as any).file, (doc as any).type, {
                 pitchId,
-                requiresNda: (doc as any).type !== 'lookbook',
+                requiresNda: (doc as any).requiresNda ?? ((doc as any).type !== 'lookbook'),
               });
             } catch (docErr) {
               console.error('Document upload failed:', (doc as any).title, docErr);

--- a/frontend/src/pages/PitchEdit.tsx
+++ b/frontend/src/pages/PitchEdit.tsx
@@ -241,6 +241,8 @@ export default function PitchEdit() {
             title: d.fileName ?? d.file_name ?? d.originalFileName ?? d.original_file_name ?? d.title ?? 'Document',
             url: d.fileUrl ?? d.file_url ?? d.url,
             size: d.fileSize ?? d.file_size ?? d.size ?? undefined,
+            // Reflect the saved NDA state so the toggle shows reality on edit.
+            requiresNda: d.requiresNda ?? d.requires_nda ?? undefined,
             uploadStatus: 'completed',
             uploadProgress: 100,
             // No File for already-persisted docs — the component null-guards on this.
@@ -453,7 +455,7 @@ export default function PitchEdit() {
         try {
           await uploadService.uploadDocument(file, doc.type, {
             pitchId: parseInt(id!),
-            requiresNda: doc.type !== 'lookbook',
+            requiresNda: doc.requiresNda ?? (doc.type !== 'lookbook'),
           });
         } catch (docErr) {
           console.error('Document upload failed:', doc.title, docErr);


### PR DESCRIPTION
The root cause under the deck/lookbook confusion: the **NDA consequence was invisible at upload time**. Picking "lookbook" silently meant *publicly viewable*, "pitch deck" meant *NDA-protected* — derived from the type name, never shown. A real creator's lookbook (Karl's own "The Coin Lookbook.pdf", 5 copies, all `requires_nda=false`/published) went public unknowingly.

## Change
Each document row now has a clickable NDA badge:
- 🛡 **NDA required to view** (red) vs 👁 **Public — anyone can view** (green)
- Defaults from the type (lookbook → public, else → NDA-gated) but is **overridable**.
- Effective value `requiresNda ?? (type !== 'lookbook')` wired through all 3 upload sites (DocumentUpload auto-upload, CreatePitch, PitchEdit). PitchEdit loads saved `requires_nda` so the toggle shows reality on edit.

Gives real signal: if creators flip NDA **on** for lookbooks, the "lookbook is public" assumption was wrong and the type-merge decision (deferred) makes itself.

Frontend-only; tsc clean. Does not touch existing data or the data model (round-2 alias-only decision stands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)