### PR TITLE
fix(uploads): NDA-gate lookbooks + upload once + staged-state visibility (Karl R3)

### DIFF
--- a/frontend/src/features/uploads/components/DocumentUpload/DocumentUpload.tsx
+++ b/frontend/src/features/uploads/components/DocumentUpload/DocumentUpload.tsx
@@ -216,7 +216,7 @@ export default function DocumentUpload({
     if (duplicate) {
       return {
         valid: false,
-        error: `File ${file.name} has already been added.`
+        error: `“${file.name}” is already in your list — it’ll upload when you save. No need to add it again.`
       };
     }
 
@@ -377,7 +377,7 @@ export default function DocumentUpload({
         document.type,
         {
           pitchId,
-          requiresNda: document.requiresNda ?? (document.type !== 'lookbook'),
+          requiresNda: document.requiresNda ?? true,
           signal: controller.signal,
           onProgress: (progress) => {
             const stats = uploadStats.current.get(document.id);
@@ -923,7 +923,10 @@ export default function DocumentUpload({
                           real creators. Default still follows the type; the creator
                           can change it knowingly. */}
                       {(() => {
-                        const ndaOn = document.requiresNda ?? (document.type !== 'lookbook');
+                        // Default ALL documents (incl. lookbooks) to NDA-required —
+                        // the old lookbook=public default surprised creators by exposing
+                        // material they assumed was protected. Toggle to make it public.
+                        const ndaOn = document.requiresNda ?? true;
                         return (
                           <button
                             type="button"
@@ -1000,6 +1003,17 @@ export default function DocumentUpload({
                         {document.uploadStatus === 'completed' && (
                           <div className="text-xs text-green-600 bg-green-50 p-2 rounded">
                             Upload completed successfully
+                          </div>
+                        )}
+
+                        {/* Staged (not yet uploaded). Without this, a captured-but-
+                            not-uploaded file looked like nothing happened, so creators
+                            re-added it and hit the "already added" wall. Make it clear
+                            the file is held and will upload on save. */}
+                        {document.uploadStatus === 'idle' && document.file && (
+                          <div className="flex items-center gap-1.5 text-xs text-blue-700 bg-blue-50 p-2 rounded">
+                            <CheckCircle className="h-3.5 w-3.5" />
+                            Ready — uploads when you save your pitch
                           </div>
                         )}
                       </div>

--- a/frontend/src/pages/CreatePitch.tsx
+++ b/frontend/src/pages/CreatePitch.tsx
@@ -435,7 +435,7 @@ export default function CreatePitch() {
             try {
               await uploadService.uploadDocument((doc as any).file, (doc as any).type, {
                 pitchId,
-                requiresNda: (doc as any).requiresNda ?? ((doc as any).type !== 'lookbook'),
+                requiresNda: (doc as any).requiresNda ?? true,
               });
             } catch (docErr) {
               console.error('Document upload failed:', (doc as any).title, docErr);

--- a/frontend/src/pages/PitchEdit.tsx
+++ b/frontend/src/pages/PitchEdit.tsx
@@ -455,7 +455,7 @@ export default function PitchEdit() {
         try {
           await uploadService.uploadDocument(file, doc.type, {
             pitchId: parseInt(id!),
-            requiresNda: doc.requiresNda ?? (doc.type !== 'lookbook'),
+            requiresNda: doc.requiresNda ?? true,
           });
         } catch (docErr) {
           console.error('Document upload failed:', doc.title, docErr);
@@ -866,6 +866,10 @@ export default function PitchEdit() {
               maxFiles={15}
               maxFileSize={10}
               disabled={isSubmitting}
+              // Single upload path: stage here, upload once on Save (the save loop).
+              // With autoUpload=true the component ALSO uploaded on-add, racing the
+              // save loop and causing the same file to upload twice. Karl R3.
+              autoUpload={false}
               showProgress={true}
               enableDragDrop={true}
               showPreview={true}


### PR DESCRIPTION
Karl: his lookbook was public, and uploads needed two tries with errors that didn't recognise the upload. Three fixes + a data fix.

## 1. Lookbooks NDA-gated by default
Default flipped from `requiresNda ?? (type !== 'lookbook')` (lookbook = public) to **`?? true`** at all 4 sites. The per-document toggle (shipped #233) still lets creators make something public deliberately. **Karl's 5 existing public lookbooks** (all "The Coin Lookbook.pdf", pitches 1473/2000/2487) set `requires_nda=true` directly — consented, safe direction (more protected).

## 2. Upload once (the double-upload)
PitchEdit mounted DocumentUpload with `autoUpload` defaulting **true**, so a file uploaded **on-add** AND the save loop uploaded it **again** — a race → double upload. Set `autoUpload={false}`: stage on add, upload once on Save. Single path, same as CreatePitch. (Backend verified fine end-to-end: returns url, links `pitch_documents`, honors `requiresNda`; round-1 click-re-entry fix still present.)

## 3. "Can't recognise the upload"
A staged (captured, not-yet-uploaded) file showed **no status**, so it looked like nothing happened → creators re-added it → hit the "already added" wall. Added a clear **"Ready — uploads when you save your pitch"** indicator for idle docs + softened the duplicate message.

Frontend-only; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)