### PR TITLE
ci: strip source maps from public bundle (close the leak)

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -63,6 +63,14 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           NODE_ENV: production
 
+      - name: 🧹 Strip source maps from the public bundle
+        # The build step already uploaded them to Sentry (debug IDs). Remove the
+        # .map files before the public deploy so source isn't fetchable from
+        # pitchey-5o8.pages.dev. Deterministic — doesn't rely on the vite plugin's
+        # filesToDeleteAfterUpload glob (which didn't fire). No-op if none exist.
+        working-directory: frontend
+        run: find dist -name '*.map' -type f -delete -print | wc -l | xargs echo "stripped source maps:"
+
       - name: 🚀 Deploy to Cloudflare Pages (using Wrangler)
         working-directory: frontend
         run: |


### PR DESCRIPTION
Follow-up to #235: the vite-plugin's filesToDeleteAfterUpload didn't fire, so .map files stayed public (200). Added a deterministic find+delete after the Sentry upload, before deploy. Sentry keeps the maps; public bundle won't. Workflow-only.