### PR TITLE
fix(sentry): TaggedEventFilter match 'is'

### DIFF
--- a/.github/workflows/sentry-money-path-alerts.yml
+++ b/.github/workflows/sentry-money-path-alerts.yml
@@ -59,7 +59,7 @@ jobs:
               { "id": "sentry.rules.conditions.reappeared_event.ReappearedEventCondition" }
             ],
             "filters": [
-              { "id": "sentry.rules.filters.tagged_event.TaggedEventFilter", "key": "$tagkey", "match": "is_set", "value": "" }
+              { "id": "sentry.rules.filters.tagged_event.TaggedEventFilter", "key": "$tagkey", "match": "is" }
             ],
             "actions": [
               { "id": "sentry.mail.actions.NotifyEmailAction", "targetType": "IssueOwners", "targetIdentifier": "", "fallthroughType": "ActiveMembers" }


### PR DESCRIPTION
One-char fix to the alert-rule workflow: Sentry's TaggedEventFilter wants `match: "is"` (is-set), not `is_set`. Verified: both rules created successfully (workflow run 27247222171).