### PR TITLE
fix(media): same-origin doc URLs + group Attachments by type (icons + NDA lock)

### DIFF
--- a/frontend/src/portals/creator/pages/CreatorPitchView.tsx
+++ b/frontend/src/portals/creator/pages/CreatorPitchView.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams, Link } from 'react-router-dom';
 import { 
   ArrowLeft, Eye, Heart, Share2, Edit, Trash2, BarChart3, 
   Shield, MessageSquare, Clock, Calendar, User, Tag, 
-  Film, DollarSign, Briefcase, TrendingUp, Users,
+  DollarSign, Briefcase, TrendingUp, Users,
   FileText, Download, Lock, Unlock, BookOpen, Image as ImageIcon
 } from 'lucide-react';
 
@@ -766,7 +766,7 @@ const CreatorPitchView: React.FC = () => {
             </div>
 
             {/* Attachments */}
-            {(pitch.pitchDeck || pitch.script || pitch.trailer || (pitch.documents && pitch.documents.length > 0)) && (
+            {pitch.documents && pitch.documents.length > 0 && (
               <div className="bg-white rounded-xl shadow-lg p-6">
                 <h3 className="text-lg font-semibold text-gray-900 mb-4">Attachments</h3>
                 <div className="space-y-2">
@@ -813,48 +813,6 @@ const CreatorPitchView: React.FC = () => {
                         );
                       });
                   })()}
-                  {pitch.pitchDeck && (
-                    <a
-                      href={pitch.pitchDeck}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center justify-between p-2 hover:bg-gray-50 rounded"
-                    >
-                      <span className="flex items-center text-blue-600">
-                        <FileText className="h-4 w-4 mr-2" />
-                        Pitch Deck
-                      </span>
-                      <Download className="h-4 w-4 text-gray-400" />
-                    </a>
-                  )}
-                  {pitch.script && (
-                    <a
-                      href={pitch.script}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center justify-between p-2 hover:bg-gray-50 rounded"
-                    >
-                      <span className="flex items-center text-blue-600">
-                        <FileText className="h-4 w-4 mr-2" />
-                        Script
-                      </span>
-                      <Download className="h-4 w-4 text-gray-400" />
-                    </a>
-                  )}
-                  {pitch.trailer && (
-                    <a
-                      href={pitch.trailer}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center justify-between p-2 hover:bg-gray-50 rounded"
-                    >
-                      <span className="flex items-center text-blue-600">
-                        <Film className="h-4 w-4 mr-2" />
-                        Trailer
-                      </span>
-                      <Download className="h-4 w-4 text-gray-400" />
-                    </a>
-                  )}
                 </div>
               </div>
             )}

--- a/frontend/src/portals/creator/pages/CreatorPitchView.tsx
+++ b/frontend/src/portals/creator/pages/CreatorPitchView.tsx
@@ -4,8 +4,22 @@ import {
   ArrowLeft, Eye, Heart, Share2, Edit, Trash2, BarChart3, 
   Shield, MessageSquare, Clock, Calendar, User, Tag, 
   Film, DollarSign, Briefcase, TrendingUp, Users,
-  FileText, Download, Lock, Unlock
+  FileText, Download, Lock, Unlock, BookOpen, Image as ImageIcon
 } from 'lucide-react';
+
+// Per-document-type display metadata for the grouped Attachments list. Mirrors the
+// types the uploader offers (DocumentUpload DOCUMENT_TYPES); the type a creator picks
+// on upload drives the icon + group here. Order controls group sequence.
+const DOC_TYPE_META: Record<string, { label: string; Icon: typeof FileText; color: string; order: number }> = {
+  pitch_deck:           { label: 'Pitch Deck / Lookbook', Icon: BarChart3,  color: 'text-purple-600', order: 1 },
+  lookbook:             { label: 'Lookbooks',             Icon: BookOpen,   color: 'text-pink-600',   order: 2 },
+  script:               { label: 'Scripts',               Icon: FileText,   color: 'text-blue-600',   order: 3 },
+  treatment:            { label: 'Treatments',            Icon: FileText,   color: 'text-emerald-600',order: 4 },
+  budget:               { label: 'Budget',                Icon: DollarSign, color: 'text-amber-600',  order: 5 },
+  nda:                  { label: 'NDA Documents',         Icon: Shield,     color: 'text-red-600',    order: 6 },
+  supporting_materials: { label: 'Supporting Materials',  Icon: ImageIcon,  color: 'text-gray-500',   order: 7 },
+};
+const DOC_TYPE_FALLBACK = { label: 'Other', Icon: FileText, color: 'text-gray-500', order: 99 };
 import { pitchAPI } from '@/lib/api';
 import apiClient from '@/lib/api-client';
 import { useBetterAuthStore } from '@/store/betterAuthStore';
@@ -756,21 +770,49 @@ const CreatorPitchView: React.FC = () => {
               <div className="bg-white rounded-xl shadow-lg p-6">
                 <h3 className="text-lg font-semibold text-gray-900 mb-4">Attachments</h3>
                 <div className="space-y-2">
-                  {pitch.documents && pitch.documents.map((doc) => (
-                    <a
-                      key={doc.id}
-                      href={doc.file_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center justify-between p-2 hover:bg-gray-50 rounded"
-                    >
-                      <span className="flex items-center text-blue-600">
-                        <FileText className="h-4 w-4 mr-2 shrink-0" />
-                        <span className="truncate">{doc.original_file_name || doc.file_name}</span>
-                      </span>
-                      <Download className="h-4 w-4 text-gray-400 shrink-0" />
-                    </a>
-                  ))}
+                  {/* Group documents by their type so like files sit together, each
+                      with the icon for that type and a lock when NDA-gated. */}
+                  {pitch.documents && pitch.documents.length > 0 && (() => {
+                    const groups = new Map<string, PitchDocument[]>();
+                    for (const d of pitch.documents) {
+                      const t = d.document_type || 'other';
+                      if (!groups.has(t)) groups.set(t, []);
+                      groups.get(t)!.push(d);
+                    }
+                    return [...groups.entries()]
+                      .sort((a, b) => (DOC_TYPE_META[a[0]]?.order ?? 99) - (DOC_TYPE_META[b[0]]?.order ?? 99))
+                      .map(([type, docs]) => {
+                        const meta = DOC_TYPE_META[type] || DOC_TYPE_FALLBACK;
+                        const Icon = meta.Icon;
+                        return (
+                          <div key={type} className="mb-3 last:mb-0">
+                            <p className="flex items-center gap-1.5 mb-1.5 text-[0.68rem] font-semibold uppercase tracking-wide text-gray-400">
+                              <Icon className={`h-3.5 w-3.5 ${meta.color}`} /> {meta.label}
+                            </p>
+                            <div className="space-y-1">
+                              {docs.map((doc) => (
+                                <a
+                                  key={doc.id}
+                                  href={doc.file_url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="flex items-center justify-between p-2 hover:bg-gray-50 rounded"
+                                >
+                                  <span className="flex items-center min-w-0 text-blue-600">
+                                    <Icon className={`h-4 w-4 mr-2 shrink-0 ${meta.color}`} />
+                                    <span className="truncate">{doc.original_file_name || doc.file_name}</span>
+                                    {doc.requires_nda && (
+                                      <Lock className="h-3 w-3 ml-2 shrink-0 text-gray-400" aria-label="NDA required to view" />
+                                    )}
+                                  </span>
+                                  <Download className="h-4 w-4 text-gray-400 shrink-0" />
+                                </a>
+                              ))}
+                            </div>
+                          </div>
+                        );
+                      });
+                  })()}
                   {pitch.pitchDeck && (
                     <a
                       href={pitch.pitchDeck}

--- a/src/handlers/media-access.ts
+++ b/src/handlers/media-access.ts
@@ -222,9 +222,14 @@ export class MediaAccessHandler {
 
   // Helper: Generate access URL for download (serves via worker endpoint)
   public async generateSignedUrl(storagePath: string, fileName: string): Promise<string> {
-    const baseUrl = this.env?.BACKEND_URL || 'https://pitchey-api-prod.ndlovucavelle.workers.dev';
+    // SAME-ORIGIN (relative) on purpose. An absolute BACKEND_URL (workers.dev) is
+    // a DIFFERENT origin from the app (pages.dev), so the browser does not forward
+    // the `pitchey-session` cookie to it — which made NDA-protected documents 403
+    // even for their own owner (serveMediaFile couldn't identify the requester).
+    // A relative path routes through the Pages Functions proxy, which forwards the
+    // session, so owner + NDA-signer access works. Public assets are unaffected.
     const token = btoa(`${storagePath}:${Date.now()}`);
-    return `${baseUrl}/api/media/file/${encodeURIComponent(storagePath)}?token=${token}&filename=${encodeURIComponent(fileName)}`;
+    return `/api/media/file/${encodeURIComponent(storagePath)}?token=${token}&filename=${encodeURIComponent(fileName)}`;
   }
 
   // Helper: Generate upload URL (serves via worker endpoint)

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -308,6 +308,15 @@ function normalizeBudgetUsd(raw: unknown): number | null {
   return Math.min(Math.round(n), MAX_BUDGET_USD);
 }
 
+// Rewrite an absolute /api/media/file URL (legacy rows stored the full
+// workers.dev origin) to a same-origin relative path, so document links route
+// through the Pages proxy and carry the session cookie. New uploads are already
+// relative (generateSignedUrl). No-op for already-relative or non-media URLs.
+function toRelativeMediaUrl<T>(url: T): T {
+  if (typeof url !== 'string') return url;
+  return url.replace(/^https?:\/\/[^/]+(\/api\/media\/file\/)/, '$1') as unknown as T;
+}
+
 function getOrCreateRouter(env: Env): RouteRegistry {
   const currentHash = getEnvHash(env);
 
@@ -5887,7 +5896,7 @@ pitchey_analytics_datapoints_per_minute 1250
           `, [pitchId]);
           documents = (docRows || []).filter((d: any) =>
             isOwner || d.is_public === true || (hasNDAAccess && d.requires_nda)
-          );
+          ).map((d: any) => ({ ...d, file_url: toRelativeMediaUrl(d.file_url) }));
         } catch (_e) { /* pitch_documents may not exist in all envs */ }
         const findDoc = (...types: string[]): string | undefined => {
           const hit = documents.find((d: any) =>
@@ -6194,7 +6203,7 @@ pitchey_analytics_datapoints_per_minute 1250
         `;
         documents = (docRows || []).filter((d: any) =>
           isOwner || d.is_public === true || (hasNDAAccess && d.requires_nda)
-        );
+        ).map((d: any) => ({ ...d, file_url: toRelativeMediaUrl(d.file_url) }));
       } catch { /* pitch_documents may not exist in all envs */ }
       const findDoc = (...types: string[]): string | undefined => {
         const hit = documents.find((d: any) =>


### PR DESCRIPTION
Two related improvements to viewing uploaded documents (both deployed + browser-verified).

## 1. Same-origin document URLs (bug fix)
NDA-protected documents 403'd *even for the owner*. `generateSignedUrl` built an absolute `workers.dev` URL; the app is on `pages.dev`, so it's cross-origin → session cookie not forwarded → `serveMediaFile` can't see the owner → 403. Fixed: relative path routes through the Pages proxy with the session. Legacy absolute URLs rewritten at read (`toRelativeMediaUrl`). Verified: owner's link now returns `200 application/pdf`.

## 2. Grouped Attachments with per-type icons (feature)
The document type is already chosen on upload (stored as `document_type`) but the creator view ignored it (flat list, generic icon). Now the Attachments block **groups by type** (Lookbooks / Scripts / Pitch Deck / Budget / NDA / Supporting), each with the type's icon, and **NDA-required files show a lock**. Display-only — does not touch the upload flow (the single-upload fix is unaffected). Verified live with lookbook + script + budget docs → three groups, correct icons + locks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)