### PR TITLE
fix: nda/audit column drift + marketplace budget-filter drop & write-time normalization

### DIFF
--- a/frontend/src/pages/MarketplaceEnhanced.tsx
+++ b/frontend/src/pages/MarketplaceEnhanced.tsx
@@ -98,6 +98,36 @@ function getPitchBudgetDisplay(pitch: Pitch): string {
   return '';
 }
 
+// Default upper bound of the budget filter. While the range sits at [0, this],
+// the budget filter is considered inactive and must not exclude any pitch.
+const DEFAULT_BUDGET_MAX = 500000000;
+// Anything above this is treated as unreliable/garbage data (e.g. a free-text
+// `estimated_budget` of "100000000000000000000000000000000000"), not a real
+// budget — parsePitchBudget returns null so it never silently hides a pitch.
+const MAX_REASONABLE_BUDGET = 10000000000; // $10B
+
+// Parse a pitch's budget to a USD number, preferring the structured
+// `estimated_budget_usd` column and falling back to the legacy free-text field.
+// Returns null when no usable/sane budget is present (callers treat null as
+// "unknown budget" and must not exclude the pitch on its account).
+function parsePitchBudget(pitch: Pitch): number | null {
+  const pp = pitch as unknown as Record<string, unknown>;
+  const usd = Number(pp.estimatedBudgetUsd ?? pp.estimated_budget_usd);
+  if (Number.isFinite(usd) && usd > 0) {
+    return usd <= MAX_REASONABLE_BUDGET ? usd : null;
+  }
+  const raw = String(pitch.estimatedBudget || pitch.budgetBracket || '');
+  if (!raw) return null;
+  // Strip grouping separators so "€14,000" parses as 14000, not 14.
+  const match = raw.replace(/[,\s]/g, '').match(/\d+/);
+  if (!match) return null;
+  const n = parseInt(match[0], 10);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  // Short-form values ("5", "25") are millions; large values are absolute.
+  const value = n >= 100000 ? n : n * 1000000;
+  return value <= MAX_REASONABLE_BUDGET ? value : null;
+}
+
 function getCreatorDisplay(pitch: Pitch): string {
   const pp = pitch as unknown as Record<string, unknown>;
   return pitch.creator?.name || pitch.creator?.username
@@ -184,7 +214,7 @@ export default function MarketplaceEnhanced() {
     formats: searchParams.get('formats')?.split(',').filter(Boolean) || [],
     budgetRange: { 
       min: parseInt(searchParams.get('budgetMin') || '0'), 
-      max: parseInt(searchParams.get('budgetMax') || '500000000')
+      max: parseInt(searchParams.get('budgetMax') || String(DEFAULT_BUDGET_MAX))
     },
     status: searchParams.get('status')?.split(',').filter(Boolean) || [],
     hasNDA: searchParams.get('hasNDA') === 'true' ? true : searchParams.get('hasNDA') === 'false' ? false : null,
@@ -253,7 +283,7 @@ export default function MarketplaceEnhanced() {
       formats: searchParams.get('formats')?.split(',').filter(Boolean) || [],
       status: searchParams.get('status')?.split(',').filter(Boolean) || [],
       budgetMin: parseInt(searchParams.get('budgetMin') || '0'),
-      budgetMax: parseInt(searchParams.get('budgetMax') || '500000000'),
+      budgetMax: parseInt(searchParams.get('budgetMax') || String(DEFAULT_BUDGET_MAX)),
       hasNDA: searchParams.get('hasNDA') === 'true' ? true : searchParams.get('hasNDA') === 'false' ? false : null,
       hasInvestment: searchParams.get('hasInvestment') === 'true' ? true : searchParams.get('hasInvestment') === 'false' ? false : null,
     };
@@ -292,7 +322,7 @@ export default function MarketplaceEnhanced() {
     if (filters.formats.length) params.set('formats', filters.formats.join(','));
     if (filters.status.length) params.set('status', filters.status.join(','));
     if (filters.budgetRange.min > 0) params.set('budgetMin', filters.budgetRange.min.toString());
-    if (filters.budgetRange.max < 500000000) params.set('budgetMax', filters.budgetRange.max.toString());
+    if (filters.budgetRange.max < DEFAULT_BUDGET_MAX) params.set('budgetMax', filters.budgetRange.max.toString());
     if (filters.hasNDA !== null) params.set('hasNDA', filters.hasNDA.toString());
     if (filters.hasInvestment !== null) params.set('hasInvestment', filters.hasInvestment.toString());
 
@@ -346,7 +376,7 @@ export default function MarketplaceEnhanced() {
       if (debouncedSearch) params.set('q', debouncedSearch);
       if (filters.searchType !== 'all') params.set('type', filters.searchType);
       if (filters.genres.length > 0) params.set('genres', filters.genres.join(','));
-      if (filters.budgetRange.max < 500000000) params.set('maxBudget', String(filters.budgetRange.max));
+      if (filters.budgetRange.max < DEFAULT_BUDGET_MAX) params.set('maxBudget', String(filters.budgetRange.max));
       if (filters.budgetRange.min > 0) params.set('minBudget', String(filters.budgetRange.min));
       if (filters.location) params.set('location', filters.location);
       params.set('limit', '50');
@@ -472,25 +502,21 @@ export default function MarketplaceEnhanced() {
       );
     }
 
-    // Budget range filter
-    filtered = filtered.filter(pitch => {
-      let budgetValue = 0;
-      const budgetStr = pitch.estimatedBudget || pitch.budgetBracket || '';
-      if (budgetStr) {
-        const match = String(budgetStr).match(/(\d+)/);
-        if (match) {
-          const raw = parseInt(match[1], 10);
-          // If the value is already a large number (e.g. 45000000), use as-is.
-          // Only multiply by 1M for short-form values like "5" or "25" (millions).
-          budgetValue = raw >= 100000 ? raw : raw * 1000000;
-        }
-      }
-
-      // If no budget specified, don't filter it out
-      if (!budgetStr) return true;
-
-      return budgetValue >= filters.budgetRange.min && budgetValue <= filters.budgetRange.max;
-    });
+    // Budget range filter — only applied once the user has actually narrowed it.
+    // While the range sits at its defaults [0, DEFAULT_BUDGET_MAX] it must never
+    // exclude anything; otherwise pitches with a budget above the default ceiling
+    // (incl. garbage values like 1e35) silently vanish from the marketplace while
+    // still showing on the home page, which has no budget filter.
+    const budgetFilterActive =
+      filters.budgetRange.min > 0 || filters.budgetRange.max < DEFAULT_BUDGET_MAX;
+    if (budgetFilterActive) {
+      filtered = filtered.filter(pitch => {
+        const budgetValue = parsePitchBudget(pitch);
+        // Unknown / unparseable / out-of-range budget — don't hide the pitch.
+        if (budgetValue === null) return true;
+        return budgetValue >= filters.budgetRange.min && budgetValue <= filters.budgetRange.max;
+      });
+    }
 
     // Status filter
     if (filters.status.length > 0) {
@@ -530,14 +556,7 @@ export default function MarketplaceEnhanced() {
       const pp = p as unknown as Record<string, unknown>;
       return p.createdAt || (pp.created_at as string) || '';
     };
-    const getBudgetNum = (p: Pitch) => {
-      const budgetStr = p.estimatedBudget || p.budgetBracket || '';
-      if (!budgetStr) return 0;
-      const match = String(budgetStr).match(/(\d+)/);
-      if (!match) return 0;
-      const raw = parseInt(match[1], 10);
-      return raw >= 100000 ? raw : raw * 1000000;
-    };
+    const getBudgetNum = (p: Pitch) => parsePitchBudget(p) ?? 0;
     const getInvestmentGoal = (p: Pitch) => {
       const pp = p as unknown as Record<string, unknown>;
       return Number(pp.investmentGoal) || Number(pp.investment_goal) || 0;
@@ -606,7 +625,7 @@ export default function MarketplaceEnhanced() {
     setFilters({
       genres: [],
       formats: [],
-      budgetRange: { min: 0, max: 500000000 },
+      budgetRange: { min: 0, max: DEFAULT_BUDGET_MAX },
       status: [],
       hasNDA: null,
       hasInvestment: null,
@@ -622,7 +641,7 @@ export default function MarketplaceEnhanced() {
     filters.formats.length > 0 || 
     filters.status.length > 0 ||
     filters.budgetRange.min > 0 || 
-    filters.budgetRange.max < 500000000 ||
+    filters.budgetRange.max < DEFAULT_BUDGET_MAX ||
     filters.hasNDA !== null ||
     filters.hasInvestment !== null ||
     searchQuery !== '';
@@ -1166,7 +1185,7 @@ export default function MarketplaceEnhanced() {
                         aria-label="Budget range slider"
                         type="range"
                         min="0"
-                        max="500000000"
+                        max={DEFAULT_BUDGET_MAX}
                         step="100000"
                         value={filters.budgetRange.max}
                         onChange={(e) => setFilters(f => ({ ...f, budgetRange: { ...f.budgetRange, max: parseInt(e.target.value) } }))}

--- a/src/services/audit-trail.service.ts
+++ b/src/services/audit-trail.service.ts
@@ -121,14 +121,17 @@ export class AuditTrailService {
       const timestamp = new Date().toISOString();
       
       // Insert into audit_logs table
+      // `action` is NOT NULL in audit_logs but wasn't in this insert, so every
+      // logEvent() threw "null value in column action" and the audit event was
+      // dropped. Map it from eventType (the action being audited).
       const query = `
         INSERT INTO audit_logs (
           user_id, event_type, event_category, risk_level,
           description, entity_type, entity_id,
           ip_address, user_agent, session_id, location,
-          changes, metadata, timestamp
+          changes, metadata, timestamp, action
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
       `;
 
       await this.db.query(query, [
@@ -145,7 +148,8 @@ export class AuditTrailService {
         entry.location ? JSON.stringify(entry.location) : null,
         entry.changes ? JSON.stringify(entry.changes) : null,
         entry.metadata ? JSON.stringify(entry.metadata) : null,
-        timestamp
+        timestamp,
+        entry.eventType || 'unknown'
       ]);
 
       // Also log to security_events table if it's a security event

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -6086,7 +6086,7 @@ pitchey_analytics_datapoints_per_minute 1250
             try {
               const ndaFallback = await sql`
                 SELECT 1 FROM ndas
-                WHERE pitch_id = ${pitchId} AND requester_id = ${authUserId}
+                WHERE pitch_id = ${pitchId} AND user_id = ${authUserId}
                   AND (status = 'approved' OR status = 'signed')
                 LIMIT 1
               `;
@@ -8137,14 +8137,14 @@ pitchey_analytics_datapoints_per_minute 1250
 
     try {
       const ndas = await this.db.query(`
-        SELECT 
+        SELECT
           n.*,
           p.title as pitch_title,
           u.name as requester_name
         FROM ndas n
         JOIN pitches p ON n.pitch_id = p.id
-        JOIN users u ON n.requester_id = u.id
-        WHERE n.requester_id = $1 OR n.pitch_id IN (
+        JOIN users u ON n.signer_id = u.id
+        WHERE n.signer_id = $1 OR n.pitch_id IN (
           SELECT id FROM pitches WHERE user_id = $1
         )
         ORDER BY n.created_at DESC
@@ -9385,7 +9385,7 @@ pitchey_analytics_datapoints_per_minute 1250
           COUNT(DISTINCT sp.pitch_id) as saved_pitches
         FROM users u
         LEFT JOIN investments i ON i.investor_id = u.id
-        LEFT JOIN ndas n ON n.requester_id = u.id AND n.status = 'approved'
+        LEFT JOIN ndas n ON n.signer_id = u.id AND n.status = 'approved'
         LEFT JOIN saved_pitches sp ON sp.user_id = u.id
         WHERE u.id = $1
       `, [authResult.user.id]);
@@ -16031,14 +16031,14 @@ pitchey_analytics_datapoints_per_minute 1250
       // Try to get from database first
       try {
         const query = `
-          SELECT n.*, p.title as pitch_title, 
+          SELECT n.*, p.title as pitch_title,
                  u1.first_name || ' ' || u1.last_name as requester_name,
                  u2.first_name || ' ' || u2.last_name as creator_name
           FROM ndas n
           LEFT JOIN pitches p ON n.pitch_id = p.id
-          LEFT JOIN users u1 ON n.requester_id = u1.id  
-          LEFT JOIN users u2 ON n.creator_id = u2.id
-          WHERE n.id = $1 AND (n.requester_id = $2 OR n.creator_id = $2)
+          LEFT JOIN users u1 ON n.signer_id = u1.id
+          LEFT JOIN users u2 ON p.user_id = u2.id
+          WHERE n.id = $1 AND (n.signer_id = $2 OR p.user_id = $2)
         `;
 
         const results = await this.db.query(query, [ndaId, authResult.user.id]);
@@ -16832,7 +16832,7 @@ Signatures: [To be completed upon signing]
           `SELECT n.*, p.title as pitch_title
            FROM ndas n
            LEFT JOIN pitches p ON n.pitch_id = p.id
-           WHERE n.requester_id = $1 OR n.creator_id = $1
+           WHERE n.signer_id = $1 OR p.user_id = $1
            ORDER BY n.created_at DESC
            LIMIT $2 OFFSET $3`,
           [authResult.user.id, limit, offset]
@@ -17058,10 +17058,14 @@ Signatures: [To be completed upon signing]
       // Try database first
       try {
         const results = await this.db.query(
+          // ndas has signer_id (the person who signed), not requester_id/creator_id.
+          // Access = you signed it, OR you own the pitch (checked via subquery).
           `SELECT n.*, u.first_name, u.last_name, u.email
            FROM ndas n
-           LEFT JOIN users u ON n.requester_id = u.id
-           WHERE n.id = $1 AND (n.requester_id = $2 OR n.creator_id = $2)`,
+           LEFT JOIN users u ON n.signer_id = u.id
+           WHERE n.id = $1 AND (n.signer_id = $2 OR n.pitch_id IN (
+             SELECT id FROM pitches WHERE user_id = $2
+           ))`,
           [ndaId, authResult.user.id]
         );
 
@@ -17358,7 +17362,11 @@ Signatures: [To be completed upon signing]
       // For NDAs, users can only see audit trails for their own NDAs
       if (entityType === 'nda') {
         const ndaCheck = await this.db.query(
-          'SELECT id FROM ndas WHERE id = $1 AND (requester_id = $2 OR creator_id = $2)',
+          // ndas has signer_id, not requester_id/creator_id. Access = you signed it,
+          // or you own the pitch it's against.
+          `SELECT id FROM ndas WHERE id = $1 AND (signer_id = $2 OR pitch_id IN (
+             SELECT id FROM pitches WHERE user_id = $2
+           ))`,
           [entityId, authResult.user.id]
         );
 

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -5651,7 +5651,9 @@ pitchey_analytics_datapoints_per_minute 1250
 
     // Structured USD budget (0..$1B, integer) — the source of truth for
     // comparison/averaging. Server clamps; the DB CHECK is the hard backstop.
-    const estBudgetUsd = normalizeBudgetUsd(data.estimatedBudgetUsd);
+    // Fall back to the free-text estimatedBudget when no structured value was
+    // sent (legacy / direct API callers), so the column can't be left unparsed.
+    const estBudgetUsd = normalizeBudgetUsd(data.estimatedBudgetUsd ?? data.estimatedBudget);
 
     try {
       const [pitch] = await this.db.query(`
@@ -5701,7 +5703,10 @@ pitchey_analytics_datapoints_per_minute 1250
         JSON.stringify(data.characters || []),
         aiDisclosure,
         aiDisclosure !== 'none',
-        data.estimatedBudget ?? (estBudgetUsd != null ? String(estBudgetUsd) : null),
+        // Store the canonical normalized figure, never the raw client text —
+        // this is what blocks garbage like "1e35"/"20000000k"/"€14,000" from
+        // ever reaching the column. Free-form bracket labels live in budget_range.
+        estBudgetUsd != null ? String(estBudgetUsd) : null,
         data.budgetBracket ?? null,
         data.productionTimeline ?? null,
         data.targetReleaseDate ?? null,
@@ -6436,6 +6441,18 @@ pitchey_analytics_datapoints_per_minute 1250
       ? (data.aiDisclosure as string)
       : null;
 
+    // Budget update is presence-aware and kept in lockstep across both columns:
+    // when either budget field is sent we recompute the normalized figure (USD
+    // falls back to the free text) and write BOTH estimated_budget_usd and the
+    // text column from it, so they can never drift and raw garbage never lands.
+    const updBudgetPresent =
+      'estimatedBudgetUsd' in (data as Record<string, unknown>) ||
+      'estimatedBudget' in (data as Record<string, unknown>);
+    const updBudgetUsd = updBudgetPresent
+      ? normalizeBudgetUsd(data.estimatedBudgetUsd ?? data.estimatedBudget)
+      : null;
+    const updBudgetText = updBudgetUsd != null ? String(updBudgetUsd) : null;
+
     try {
       // Verify ownership
       const [existing] = await this.db.query(
@@ -6475,14 +6492,17 @@ pitchey_analytics_datapoints_per_minute 1250
           title_image = COALESCE($25, title_image),
           ai_disclosure = COALESCE($26, ai_disclosure),
           ai_used = COALESCE($27, ai_used),
-          estimated_budget = COALESCE($28, estimated_budget),
+          -- Presence-aware ($35), in lockstep with estimated_budget_usd below:
+          -- only touched when a budget field was sent, and always the normalized
+          -- numeric string (or null) — never the raw client text.
+          estimated_budget = CASE WHEN $35 THEN $28 ELSE estimated_budget END,
           budget_bracket = COALESCE($29, budget_bracket),
           production_timeline = COALESCE($30, production_timeline),
           target_release_date = COALESCE($31, target_release_date),
           visibility_settings = COALESCE($32, visibility_settings),
           require_nda = COALESCE($33, require_nda),
-          -- Presence-aware: when the client sends the field ($35 true) we set it
-          -- to $34 — INCLUDING null, so a cleared budget actually clears. COALESCE
+          -- Presence-aware: when the client sends a budget field ($35 true) we set
+          -- it to $34 — INCLUDING null, so a cleared budget actually clears. COALESCE
           -- alone preserved the old value on null, making the field unclearable.
           estimated_budget_usd = CASE WHEN $35 THEN $34 ELSE estimated_budget_usd END,
           updated_at = NOW()
@@ -6516,17 +6536,18 @@ pitchey_analytics_datapoints_per_minute 1250
         data.titleImage,
         updAiDisclosure,
         updAiDisclosure === null ? null : updAiDisclosure !== 'none',
-        data.estimatedBudget ?? null,
+        updBudgetText,
         data.budgetBracket ?? null,
         data.productionTimeline ?? null,
         data.targetReleaseDate ?? null,
         data.visibilitySettings ? JSON.stringify(data.visibilitySettings) : null,
         (data.requireNDA ?? data.require_nda) ?? null,
-        // $34: the value to set when present (null clears). $35: was the field
-        // sent at all — only then do we touch the column (other callers that omit
-        // it leave the budget untouched).
-        ('estimatedBudgetUsd' in (data as Record<string, unknown>)) ? normalizeBudgetUsd(data.estimatedBudgetUsd) : null,
-        ('estimatedBudgetUsd' in (data as Record<string, unknown>))
+        // $34: the normalized USD to set when present (null clears). $35: was a
+        // budget field sent at all — only then do we touch either budget column
+        // (callers that omit it leave the budget untouched). $28 (text) rides the
+        // same flag so the two columns stay consistent.
+        updBudgetUsd,
+        updBudgetPresent
       ]);
 
       // Handle creative attachments if provided


### PR DESCRIPTION
Two bugs found in the overnight observability sweep, both fixed + deployed (worker `9382df86`).

## Bug 1 — `column "requester_id" does not exist` (live today)
`ndas` has `signer_id`/`user_id`, never `requester_id`/`creator_id` — but 7 queries used them. Worst: **`getNDAs` (the NDA list) 500'd on every call**. Fixed all to `signer_id`; "pitch creator" checks now use `pitch_id IN (SELECT id FROM pitches WHERE user_id=…)`. The getPitch fallback now probes `user_id` (exists) instead of `requester_id` (always threw → just log noise).
**Verified**: `/api/ndas`, `/api/creator/ndas`, `/api/investor/ndas` → 200 (were 500).

## Bug 2 — `audit_logs` null `action`
`AuditTrailService.logEvent` omitted the NOT-NULL `action` column, so every audit write was rejected and the event dropped. Added `action` (from `eventType`).

No schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)