### PR TITLE
feat: pitch comparison + Opportunities compare-submissions tie-in

### DIFF
--- a/frontend/src/pages/ComparePage.tsx
+++ b/frontend/src/pages/ComparePage.tsx
@@ -4,7 +4,7 @@ import {
   BarChart3, Plus, X, Search, Loader2, Flame, Eye, Heart, Star, BadgeCheck, Crown, Layers,
 } from 'lucide-react';
 import PortalTopNav from '@shared/components/layout/PortalTopNav';
-import { compareService, type CreatorSubject, type CreatorOption } from '../services/compare.service';
+import { compareService, type CompareSubject, type CreatorOption } from '../services/compare.service';
 
 const MAX_SUBJECTS = 4;
 
@@ -21,7 +21,7 @@ function formatUsd(n: number | null): string {
   return `$${n}`;
 }
 
-function budgetRange(s: CreatorSubject): string {
+function budgetRange(s: CompareSubject): string {
   const lo = formatUsd(num(s.budget_min));
   const hi = formatUsd(num(s.budget_max));
   if (lo === '—' && hi === '—') return '—';
@@ -41,11 +41,11 @@ interface MetricRow {
   key: string;
   label: string;
   icon?: React.ComponentType<{ className?: string }>;
-  value: (s: CreatorSubject) => string;        // display
-  score?: (s: CreatorSubject) => number | null; // for leader highlight (higher = better)
+  value: (s: CompareSubject) => string;        // display
+  score?: (s: CompareSubject) => number | null; // for leader highlight (higher = better)
 }
 
-const METRIC_ROWS: MetricRow[] = [
+const CREATOR_ROWS: MetricRow[] = [
   { key: 'pitches', label: 'Published pitches', icon: Layers, value: (s) => String(num(s.pitch_count) ?? 0), score: (s) => num(s.pitch_count) },
   { key: 'heat', label: 'Avg heat', icon: Flame, value: (s) => (num(s.avg_heat) != null ? num(s.avg_heat)!.toFixed(1) : '—'), score: (s) => num(s.avg_heat) },
   { key: 'pitchey', label: 'Avg Pitchey score', icon: Star, value: (s) => (num(s.avg_pitchey) != null ? `${num(s.avg_pitchey)!.toFixed(1)}/10` : '—'), score: (s) => num(s.avg_pitchey) },
@@ -53,6 +53,16 @@ const METRIC_ROWS: MetricRow[] = [
   { key: 'likes', label: 'Total likes', icon: Heart, value: (s) => String(num(s.total_likes) ?? 0), score: (s) => num(s.total_likes) },
   { key: 'budget', label: 'Budget range', value: (s) => budgetRange(s) },
   { key: 'newest', label: 'Latest pitch', value: (s) => monthYear(s.newest_at) },
+];
+
+const PITCH_ROWS: MetricRow[] = [
+  { key: 'heat', label: 'Heat', icon: Flame, value: (s) => (num(s.avg_heat) != null ? num(s.avg_heat)!.toFixed(1) : '—'), score: (s) => num(s.avg_heat) },
+  { key: 'pitchey', label: 'Pitchey score', icon: Star, value: (s) => (num(s.avg_pitchey) != null ? `${num(s.avg_pitchey)!.toFixed(1)}/10` : '—'), score: (s) => num(s.avg_pitchey) },
+  { key: 'views', label: 'Views', icon: Eye, value: (s) => String(num(s.total_views) ?? 0), score: (s) => num(s.total_views) },
+  { key: 'likes', label: 'Likes', icon: Heart, value: (s) => String(num(s.total_likes) ?? 0), score: (s) => num(s.total_likes) },
+  { key: 'budget', label: 'Budget', value: (s) => budgetRange(s) },
+  { key: 'format', label: 'Format', value: (s) => s.format || '—' },
+  { key: 'newest', label: 'Created', value: (s) => monthYear(s.newest_at) },
 ];
 
 // ---------------------------------------------------------------------------
@@ -126,27 +136,30 @@ function CreatorPicker({ onAdd, disabled, existing }: { onAdd: (id: number) => v
 
 export default function ComparePage() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const type: 'creator' | 'pitch' = searchParams.get('type') === 'pitch' ? 'pitch' : 'creator';
+  const isPitch = type === 'pitch';
+  const rows = isPitch ? PITCH_ROWS : CREATOR_ROWS;
   const ids = useMemo(() => (
     (searchParams.get('ids') || '')
       .split(',').map((s) => parseInt(s, 10)).filter(Number.isFinite).slice(0, MAX_SUBJECTS)
   ), [searchParams]);
 
-  const [subjects, setSubjects] = useState<CreatorSubject[]>([]);
+  const [subjects, setSubjects] = useState<CompareSubject[]>([]);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (ids.length === 0) { setSubjects([]); return; }
     setLoading(true);
-    compareService.creators(ids)
+    compareService.subjects(type, ids)
       .then(setSubjects)
       .catch(() => setSubjects([]))
       .finally(() => setLoading(false));
-  }, [ids.join(',')]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [type, ids.join(',')]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const setIds = (next: number[]) => {
     const uniq = Array.from(new Set(next)).slice(0, MAX_SUBJECTS);
-    if (uniq.length) setSearchParams({ ids: uniq.join(',') });
-    else setSearchParams({});
+    if (uniq.length) setSearchParams(isPitch ? { type, ids: uniq.join(',') } : { ids: uniq.join(',') });
+    else setSearchParams(isPitch ? { type } : {});
   };
   const addId = (id: number) => setIds([...ids, id]);
   const removeId = (id: number) => setIds(ids.filter((x) => x !== id));
@@ -154,7 +167,7 @@ export default function ComparePage() {
   // Per-row leader index (highest score; ties highlight all).
   const leaders = useMemo(() => {
     const map: Record<string, Set<number>> = {};
-    for (const row of METRIC_ROWS) {
+    for (const row of rows) {
       if (!row.score) continue;
       const scores = subjects.map((s) => row.score!(s));
       const max = Math.max(...scores.map((v) => (v ?? -Infinity)));
@@ -162,7 +175,7 @@ export default function ComparePage() {
       map[row.key] = new Set(scores.map((v, i) => (v === max ? i : -1)).filter((i) => i >= 0));
     }
     return map;
-  }, [subjects]);
+  }, [subjects, rows]);
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-stone-50 via-white to-stone-50">
@@ -174,25 +187,33 @@ export default function ComparePage() {
           <div className="inline-flex items-center gap-2 px-3 py-1 mb-3 rounded-full bg-white/10 border border-white/20 text-[11px] font-semibold tracking-[0.18em] uppercase">
             <BarChart3 className="w-3.5 h-3.5" /> Compare
           </div>
-          <h1 className="font-display font-black text-4xl sm:text-5xl tracking-tight mb-2">Compare Creators</h1>
+          <h1 className="font-display font-black text-4xl sm:text-5xl tracking-tight mb-2">{isPitch ? 'Compare Pitches' : 'Compare Creators'}</h1>
           <p className="text-white/85 max-w-2xl text-lg">
-            Put creators’ bodies of work side by side — heat, score, traction, range — to decide who to back.
+            {isPitch
+              ? 'These pitches side by side — heat, score, traction, budget — to decide which to take forward.'
+              : 'Put creators’ bodies of work side by side — heat, score, traction, range — to decide who to back.'}
           </p>
         </div>
       </section>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="mb-6">
-          <CreatorPicker onAdd={addId} disabled={ids.length >= MAX_SUBJECTS} existing={ids} />
-        </div>
+        {!isPitch && (
+          <div className="mb-6">
+            <CreatorPicker onAdd={addId} disabled={ids.length >= MAX_SUBJECTS} existing={ids} />
+          </div>
+        )}
 
         {loading ? (
           <div className="flex justify-center py-20"><Loader2 className="w-8 h-8 text-purple-500 animate-spin" /></div>
         ) : subjects.length === 0 ? (
           <div className="text-center py-20">
             <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-purple-50 text-purple-500 mb-4"><BarChart3 className="w-7 h-7" /></div>
-            <h3 className="font-display font-bold text-xl text-gray-900 mb-1">Add creators to compare</h3>
-            <p className="text-gray-500 max-w-md mx-auto">Search above to add 2–{MAX_SUBJECTS} creators and see their work side by side.</p>
+            <h3 className="font-display font-bold text-xl text-gray-900 mb-1">{isPitch ? 'Nothing to compare' : 'Add creators to compare'}</h3>
+            <p className="text-gray-500 max-w-md mx-auto">
+              {isPitch
+                ? 'Select submissions from a call’s inbox and choose “Compare” to see them here.'
+                : `Search above to add 2–${MAX_SUBJECTS} creators and see their work side by side.`}
+            </p>
           </div>
         ) : (
           <div className="overflow-x-auto">
@@ -204,21 +225,27 @@ export default function ComparePage() {
                     <th key={s.subject_id} className="p-3 align-bottom">
                       <div className="relative rounded-2xl border border-gray-200 bg-white p-4 text-center shadow-sm">
                         <button onClick={() => removeId(s.subject_id)} className="absolute top-2 right-2 text-gray-300 hover:text-gray-600" aria-label="Remove"><X className="w-4 h-4" /></button>
-                        <div className="w-12 h-12 mx-auto mb-2 rounded-full bg-gray-100 flex items-center justify-center text-base font-bold text-gray-500 overflow-hidden">
-                          {s.avatar ? <img src={s.avatar} alt="" className="w-full h-full object-cover" /> : (s.name[0] || '?')}
-                        </div>
+                        {isPitch ? (
+                          <div className="w-full h-20 mb-2 rounded-lg bg-gray-900 overflow-hidden flex items-center justify-center">
+                            {s.thumbnail ? <img src={s.thumbnail} alt="" className="w-full h-full object-cover" /> : <span className="text-gray-500 text-xs">{s.genre || 'Pitch'}</span>}
+                          </div>
+                        ) : (
+                          <div className="w-12 h-12 mx-auto mb-2 rounded-full bg-gray-100 flex items-center justify-center text-base font-bold text-gray-500 overflow-hidden">
+                            {s.avatar ? <img src={s.avatar} alt="" className="w-full h-full object-cover" /> : (s.name[0] || '?')}
+                          </div>
+                        )}
                         <div className="flex items-center justify-center gap-1">
                           <span className="font-bold text-gray-900 text-sm truncate">{s.name}</span>
                           {(s.verification_tier === 'gold' || s.verification_tier === 'silver') && <BadgeCheck className="w-4 h-4 text-amber-500 flex-shrink-0" />}
                         </div>
-                        <div className="text-[11px] text-gray-400 capitalize">{s.user_type}</div>
+                        <div className="text-[11px] text-gray-400 capitalize truncate">{isPitch ? (s.subtitle || '') : s.user_type}</div>
                       </div>
                     </th>
                   ))}
                 </tr>
               </thead>
               <tbody>
-                {METRIC_ROWS.map((row, ri) => (
+                {rows.map((row, ri) => (
                   <tr key={row.key} className={ri % 2 ? 'bg-gray-50/60' : ''}>
                     <td className="px-3 py-3 text-sm font-medium text-gray-500">
                       <span className="inline-flex items-center gap-1.5">{row.icon && <row.icon className="w-3.5 h-3.5 text-gray-400" />}{row.label}</span>

--- a/frontend/src/pages/OpportunitiesBoard.tsx
+++ b/frontend/src/pages/OpportunitiesBoard.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Briefcase, Building2, Wallet, Plus, X, MapPin, CalendarDays, DollarSign,
-  BadgeCheck, Loader2, Pencil, Megaphone, ArrowRight, Send, Inbox, Check, Star,
+  BadgeCheck, Loader2, Pencil, Megaphone, ArrowRight, Send, Inbox, Check, Star, BarChart3,
 } from 'lucide-react';
 import PortalTopNav from '@shared/components/layout/PortalTopNav';
 import { useBetterAuthStore } from '../store/betterAuthStore';
@@ -441,6 +441,7 @@ function SubmissionsModal({ call, onClose }: { call: OpenCall; onClose: () => vo
   const navigate = useNavigate();
   const [subs, setSubs] = useState<CallSubmission[]>([]);
   const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
 
   useEffect(() => {
     callsService.submissions(call.id).then(setSubs).catch(() => setSubs([])).finally(() => setLoading(false));
@@ -452,6 +453,13 @@ function SubmissionsModal({ call, onClose }: { call: OpenCall; onClose: () => vo
     catch (err) { toast.error(err instanceof Error ? err.message : 'Failed to update'); }
   };
 
+  const toggleSelect = (pitchId: number) => setSelected((prev) => {
+    const n = new Set(prev);
+    if (n.has(pitchId)) n.delete(pitchId); else n.add(pitchId);
+    return n;
+  });
+  const compareSelected = () => navigate(`/compare?type=pitch&ids=${Array.from(selected).join(',')}`);
+
   return (
     <div className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm" onClick={onClose}>
       <div className="w-full max-w-2xl bg-white rounded-2xl shadow-2xl max-h-[90vh] overflow-hidden flex flex-col" onClick={(e) => e.stopPropagation()}>
@@ -460,7 +468,14 @@ function SubmissionsModal({ call, onClose }: { call: OpenCall; onClose: () => vo
             <h2 className="font-display font-bold text-lg text-gray-900">Submissions</h2>
             <p className="text-xs text-gray-500">“{call.title}”</p>
           </div>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-700"><X className="w-5 h-5" /></button>
+          <div className="flex items-center gap-3">
+            {selected.size >= 2 && (
+              <button onClick={compareSelected} className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-xs font-semibold shadow shadow-purple-500/25 hover:from-purple-500 hover:to-indigo-500 transition">
+                <BarChart3 className="w-3.5 h-3.5" /> Compare {selected.size}
+              </button>
+            )}
+            <button onClick={onClose} className="text-gray-400 hover:text-gray-700"><X className="w-5 h-5" /></button>
+          </div>
         </div>
         <div className="p-5 overflow-y-auto">
           {loading ? (
@@ -473,9 +488,16 @@ function SubmissionsModal({ call, onClose }: { call: OpenCall; onClose: () => vo
           ) : (
             <div className="space-y-3">
               {subs.map((s) => (
-                <div key={s.id} className="rounded-xl border border-gray-200 p-4">
-                  <div className="flex items-start justify-between gap-3 mb-1">
-                    <div className="min-w-0">
+                <div key={s.id} className={`rounded-xl border p-4 transition ${selected.has(s.pitch_id) ? 'border-purple-300 ring-1 ring-purple-200 bg-purple-50/40' : 'border-gray-200'}`}>
+                  <div className="flex items-start gap-3 mb-1">
+                    <input
+                      type="checkbox"
+                      checked={selected.has(s.pitch_id)}
+                      onChange={() => toggleSelect(s.pitch_id)}
+                      className="mt-1 w-4 h-4 accent-purple-600 cursor-pointer flex-shrink-0"
+                      aria-label="Select for comparison"
+                    />
+                    <div className="min-w-0 flex-1">
                       <button onClick={() => navigate(`/pitch/${s.pitch_id}`)} className="text-sm font-bold text-gray-900 hover:text-purple-700 transition text-left">
                         {s.pitch_title || `Pitch #${s.pitch_id}`}
                       </button>

--- a/frontend/src/services/compare.service.ts
+++ b/frontend/src/services/compare.service.ts
@@ -1,13 +1,20 @@
 import { apiClient } from '../lib/api-client';
 
-export interface CreatorSubject {
+// One shared subject shape for both type=creator and type=pitch. Creator-only
+// fields (username/user_type/avatar/pitch_count) and pitch-only fields
+// (subtitle/thumbnail/genre/format) are optional; the UI picks rows by type.
+export interface CompareSubject {
   subject_id: number;
   name: string;
-  username: string | null;
-  user_type: string | null;
+  username?: string | null;
+  user_type?: string | null;
   verification_tier: string | null;
-  avatar: string | null;
-  pitch_count: number | string;
+  avatar?: string | null;
+  subtitle?: string | null;
+  thumbnail?: string | null;
+  genre?: string | null;
+  format?: string | null;
+  pitch_count?: number | string | null;
   avg_heat: number | string | null;
   avg_pitchey: number | string | null;
   total_views: number | string;
@@ -17,6 +24,9 @@ export interface CreatorSubject {
   newest_at: string | null;
   genres: string[];
 }
+
+/** @deprecated use CompareSubject */
+export type CreatorSubject = CompareSubject;
 
 export interface CreatorOption {
   id: number;
@@ -34,10 +44,14 @@ function unwrap<T>(res: { success: boolean; data?: unknown }, key: string, fallb
 }
 
 class CompareService {
-  async creators(ids: number[]): Promise<CreatorSubject[]> {
+  async subjects(type: 'creator' | 'pitch', ids: number[]): Promise<CompareSubject[]> {
     if (ids.length === 0) return [];
-    const res = await apiClient.get<{ subjects: CreatorSubject[] }>(`/api/compare?type=creator&ids=${ids.join(',')}`);
-    return unwrap<CreatorSubject[]>(res, 'subjects', []);
+    const res = await apiClient.get<{ subjects: CompareSubject[] }>(`/api/compare?type=${type}&ids=${ids.join(',')}`);
+    return unwrap<CompareSubject[]>(res, 'subjects', []);
+  }
+
+  async creators(ids: number[]): Promise<CompareSubject[]> {
+    return this.subjects('creator', ids);
   }
 
   // Picker typeahead — dedicated creator/production search.

--- a/src/handlers/compare.ts
+++ b/src/handlers/compare.ts
@@ -75,7 +75,7 @@ export async function compareHandler(request: Request, env: Env): Promise<Respon
     .filter((n) => Number.isFinite(n));
   const unique = Array.from(new Set(ids)).slice(0, 4);
 
-  if (type !== 'creator') return errorResponse('Only creator comparison is available', origin, 400);
+  if (type !== 'creator' && type !== 'pitch') return errorResponse('Unsupported comparison type', origin, 400);
   if (unique.length === 0) return jsonResponse({ type, subjects: [] }, origin);
 
   const sql = getDb(env);
@@ -83,8 +83,40 @@ export async function compareHandler(request: Request, env: Env): Promise<Respon
 
   try {
     const placeholders = unique.map((_, i) => `$${i + 1}`).join(',');
-    // Aggregate each creator's published pitches. LEFT JOIN keeps creators with
-    // no published pitches (they return zero/null metrics). u.id is the PK so the
+
+    // type=pitch — single-pitch metrics, mapped onto the same bundle field names
+    // so the frontend matrix is shared (it picks metric rows by `type`).
+    if (type === 'pitch') {
+      const pitchQuery = `
+        SELECT
+          p.id AS subject_id,
+          p.title AS name,
+          COALESCE(u.company_name, NULLIF(TRIM(CONCAT(u.first_name, ' ', u.last_name)), ''), u.username) AS subtitle,
+          p.title_image AS thumbnail,
+          u.verification_tier,
+          NULL::int AS pitch_count,
+          ROUND(COALESCE(p.heat_score, 0), 1) AS avg_heat,
+          ROUND(NULLIF(p.pitchey_score_avg, 0), 1) AS avg_pitchey,
+          COALESCE(p.view_count, 0) AS total_views,
+          COALESCE(p.like_count, 0) AS total_likes,
+          NULLIF(p.estimated_budget_usd, 0) AS budget_min,
+          NULLIF(p.estimated_budget_usd, 0) AS budget_max,
+          p.created_at AS newest_at,
+          p.genre,
+          p.format,
+          ARRAY_REMOVE(ARRAY[p.genre], NULL) AS genres
+        FROM pitches p
+        LEFT JOIN users u ON (u.id = p.user_id OR u.id = p.creator_id)
+        WHERE p.id IN (${placeholders})
+      `;
+      const pitchRows = await sql.query(pitchQuery, unique);
+      const byPitch = new Map((pitchRows as Array<Record<string, unknown>>).map((r) => [Number(r.subject_id), r]));
+      const subjects = unique.map((id) => byPitch.get(id)).filter(Boolean);
+      return jsonResponse({ type, subjects }, origin);
+    }
+
+    // type=creator — aggregate each creator's published pitches. LEFT JOIN keeps
+    // creators with no published pitches (zero/null metrics). u.id is the PK so the
     // other u.* columns are functionally dependent — GROUP BY u.id is sufficient.
     const query = `
       SELECT


### PR DESCRIPTION
Closes the Opportunities loop — already deployed + verified on prod.

**post a call → submissions arrive → select them → compare side by side → decide.**

## What's new
- `GET /api/compare?type=pitch&ids=` — single-pitch metrics (heat, Pitchey, views, likes, budget, format, genre, created) mapped onto the same `{ type, subjects }` contract as `type=creator`. **No migration** (read-only).
- `ComparePage` is now type-aware: separate metric-row sets for creator vs pitch, pitch column headers (thumbnail + title + creator), creator-picker hidden for pitch type, `type` carried in the URL.
- Opportunities `SubmissionsModal`: multi-select submissions + a **"Compare N"** button → `/compare?type=pitch&ids=…`.

Builds on #245 (Compare Creators / Opportunities board), now on `main`.

### Verification
On prod as Stellar Pictures: opened the call inbox, selected both submissions (Echoes of Tomorrow + At Ever Las), hit Compare → side-by-side pitch matrix with per-row leader crowns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)