### PR TITLE
fix(homepage): upright "find life" — clean f (drop swashy italic Fraunces)

### DIFF
--- a/frontend/src/pages/Homepage.tsx
+++ b/frontend/src/pages/Homepage.tsx
@@ -337,10 +337,12 @@ export default function Homepage() {
           <h1 className="font-display font-black tracking-tight leading-[0.92] text-5xl sm:text-7xl lg:text-8xl mb-6">
             Where stories
             <br />
-            {/* inline-block + roomier leading + padding so the italic gradient "f"
-                ascender/overhang isn't clipped by WebKit bg-clip-text under the
-                tight 0.92 line-height (Karl: "the F in find is messy"). */}
-            <span className="inline-block italic font-semibold leading-[1.15] pb-1 pr-2 bg-gradient-to-r from-violet-300 via-fuchsia-300 to-purple-300 bg-clip-text text-transparent">
+            {/* Upright Fraunces for "find life". The messy "f" (Karl) was NOT
+                clipping — it's Fraunces' italic calligraphic swash (long curling
+                descender); the loaded font URL has no WONK axis so CSS can't tame
+                it. Upright keeps the editorial serif + gradient with a clean f.
+                Do NOT re-add `italic` here. */}
+            <span className="inline-block font-semibold leading-[1.15] bg-gradient-to-r from-violet-300 via-fuchsia-300 to-purple-300 bg-clip-text text-transparent">
               find life
             </span>
           </h1>


### PR DESCRIPTION
The hero "find life" messy `f` (Karl) was misdiagnosed as bg-clip-text clipping. Real cause: **Fraunces' italic lowercase f is a calligraphic swash** with a long curling descender, and the loaded Google Fonts URL has no WONK axis — so CSS can't dial it down.

Fix: drop `italic` (and the now-pointless clip-avoidance `pb-1 pr-2`) → upright Fraunces renders a clean `f` while keeping the editorial serif + violet→fuchsia gradient. Comment rewritten so it isn't re-added.

Verified in-browser (upright `f`/`fi` ligature reads clean). Frontend-only, deployed to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)