### PR TITLE
feat(compare): slate comparison (creator/pitch/slate complete)

### DIFF
--- a/frontend/src/pages/ComparePage.tsx
+++ b/frontend/src/pages/ComparePage.tsx
@@ -4,7 +4,7 @@ import {
   BarChart3, Plus, X, Search, Loader2, Flame, Eye, Heart, Star, BadgeCheck, Crown, Layers,
 } from 'lucide-react';
 import PortalTopNav from '@shared/components/layout/PortalTopNav';
-import { compareService, type CompareSubject, type CreatorOption } from '../services/compare.service';
+import { compareService, type CompareSubject, type PickerItem } from '../services/compare.service';
 
 const MAX_SUBJECTS = 4;
 
@@ -65,13 +65,23 @@ const PITCH_ROWS: MetricRow[] = [
   { key: 'newest', label: 'Created', value: (s) => monthYear(s.newest_at) },
 ];
 
+const SLATE_ROWS: MetricRow[] = [
+  { key: 'pitches', label: 'Pitches', icon: Layers, value: (s) => String(num(s.pitch_count) ?? 0), score: (s) => num(s.pitch_count) },
+  { key: 'heat', label: 'Avg heat', icon: Flame, value: (s) => (num(s.avg_heat) != null ? num(s.avg_heat)!.toFixed(1) : '—'), score: (s) => num(s.avg_heat) },
+  { key: 'pitchey', label: 'Avg Pitchey score', icon: Star, value: (s) => (num(s.avg_pitchey) != null ? `${num(s.avg_pitchey)!.toFixed(1)}/10` : '—'), score: (s) => num(s.avg_pitchey) },
+  { key: 'views', label: 'Total views', icon: Eye, value: (s) => String(num(s.total_views) ?? 0), score: (s) => num(s.total_views) },
+  { key: 'likes', label: 'Total likes', icon: Heart, value: (s) => String(num(s.total_likes) ?? 0), score: (s) => num(s.total_likes) },
+  { key: 'budget', label: 'Budget range', value: (s) => budgetRange(s) },
+  { key: 'newest', label: 'Latest pitch', value: (s) => monthYear(s.newest_at) },
+];
+
 // ---------------------------------------------------------------------------
 // Creator picker
 // ---------------------------------------------------------------------------
 
-function CreatorPicker({ onAdd, disabled, existing }: { onAdd: (id: number) => void; disabled: boolean; existing: number[] }) {
+function Picker({ onAdd, disabled, existing, noun, search }: { onAdd: (id: number) => void; disabled: boolean; existing: number[]; noun: string; search: (q: string) => Promise<PickerItem[]> }) {
   const [q, setQ] = useState('');
-  const [results, setResults] = useState<CreatorOption[]>([]);
+  const [results, setResults] = useState<PickerItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -81,12 +91,12 @@ function CreatorPicker({ onAdd, disabled, existing }: { onAdd: (id: number) => v
     if (!q.trim()) { setResults([]); return; }
     setLoading(true);
     timer.current = setTimeout(async () => {
-      try { setResults(await compareService.searchCreators(q)); }
+      try { setResults(await search(q)); }
       catch { setResults([]); }
       finally { setLoading(false); setOpen(true); }
     }, 300);
     return () => { if (timer.current) clearTimeout(timer.current); };
-  }, [q]);
+  }, [q, search]);
 
   return (
     <div className="relative max-w-md">
@@ -97,7 +107,7 @@ function CreatorPicker({ onAdd, disabled, existing }: { onAdd: (id: number) => v
           onChange={(e) => setQ(e.target.value)}
           onFocus={() => results.length && setOpen(true)}
           disabled={disabled}
-          placeholder={disabled ? `Up to ${MAX_SUBJECTS} creators` : 'Search creators to add…'}
+          placeholder={disabled ? `Up to ${MAX_SUBJECTS} ${noun}s` : `Search ${noun}s to add…`}
           className="flex-1 py-2.5 text-sm bg-transparent focus:outline-none disabled:opacity-50"
         />
         {loading && <Loader2 className="w-4 h-4 text-purple-400 animate-spin" />}
@@ -113,12 +123,12 @@ function CreatorPicker({ onAdd, disabled, existing }: { onAdd: (id: number) => v
                 onClick={() => { onAdd(r.id); setQ(''); setResults([]); setOpen(false); }}
                 className="w-full flex items-center gap-3 px-3 py-2.5 text-left hover:bg-purple-50 disabled:opacity-40 transition"
               >
-                <span className="w-7 h-7 rounded-full bg-gray-100 flex items-center justify-center text-xs font-bold text-gray-500 overflow-hidden">
-                  {r.avatar ? <img src={r.avatar} alt="" className="w-full h-full object-cover" /> : (r.name[0] || '?')}
+                <span className="w-7 h-7 rounded bg-gray-100 flex items-center justify-center text-xs font-bold text-gray-500 overflow-hidden">
+                  {r.image ? <img src={r.image} alt="" className="w-full h-full object-cover" /> : (r.name[0] || '?')}
                 </span>
                 <span className="min-w-0">
                   <span className="block text-sm font-semibold text-gray-900 truncate">{r.name}</span>
-                  {r.userType && <span className="block text-[11px] text-gray-400 capitalize">{r.userType}</span>}
+                  {r.sub && <span className="block text-[11px] text-gray-400 capitalize truncate">{r.sub}</span>}
                 </span>
                 {added ? <span className="ml-auto text-[11px] text-gray-400">Added</span> : <Plus className="ml-auto w-4 h-4 text-purple-500" />}
               </button>
@@ -136,9 +146,11 @@ function CreatorPicker({ onAdd, disabled, existing }: { onAdd: (id: number) => v
 
 export default function ComparePage() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const type: 'creator' | 'pitch' = searchParams.get('type') === 'pitch' ? 'pitch' : 'creator';
+  const rawType = searchParams.get('type');
+  const type: 'creator' | 'pitch' | 'slate' = rawType === 'pitch' ? 'pitch' : rawType === 'slate' ? 'slate' : 'creator';
   const isPitch = type === 'pitch';
-  const rows = isPitch ? PITCH_ROWS : CREATOR_ROWS;
+  const isSlate = type === 'slate';
+  const rows = isPitch ? PITCH_ROWS : isSlate ? SLATE_ROWS : CREATOR_ROWS;
   const ids = useMemo(() => (
     (searchParams.get('ids') || '')
       .split(',').map((s) => parseInt(s, 10)).filter(Number.isFinite).slice(0, MAX_SUBJECTS)
@@ -158,8 +170,15 @@ export default function ComparePage() {
 
   const setIds = (next: number[]) => {
     const uniq = Array.from(new Set(next)).slice(0, MAX_SUBJECTS);
-    if (uniq.length) setSearchParams(isPitch ? { type, ids: uniq.join(',') } : { ids: uniq.join(',') });
-    else setSearchParams(isPitch ? { type } : {});
+    const params: Record<string, string> = {};
+    if (type !== 'creator') params.type = type;
+    if (uniq.length) params.ids = uniq.join(',');
+    setSearchParams(params);
+  };
+  const switchType = (next: 'creator' | 'slate') => {
+    const params: Record<string, string> = {};
+    if (next !== 'creator') params.type = next;
+    setSearchParams(params);
   };
   const addId = (id: number) => setIds([...ids, id]);
   const removeId = (id: number) => setIds(ids.filter((x) => x !== id));
@@ -187,20 +206,42 @@ export default function ComparePage() {
           <div className="inline-flex items-center gap-2 px-3 py-1 mb-3 rounded-full bg-white/10 border border-white/20 text-[11px] font-semibold tracking-[0.18em] uppercase">
             <BarChart3 className="w-3.5 h-3.5" /> Compare
           </div>
-          <h1 className="font-display font-black text-4xl sm:text-5xl tracking-tight mb-2">{isPitch ? 'Compare Pitches' : 'Compare Creators'}</h1>
+          <h1 className="font-display font-black text-4xl sm:text-5xl tracking-tight mb-2">{isPitch ? 'Compare Pitches' : isSlate ? 'Compare Slates' : 'Compare Creators'}</h1>
           <p className="text-white/85 max-w-2xl text-lg">
             {isPitch
               ? 'These pitches side by side — heat, score, traction, budget — to decide which to take forward.'
-              : 'Put creators’ bodies of work side by side — heat, score, traction, range — to decide who to back.'}
+              : isSlate
+                ? 'Curated slates side by side — depth, heat, score and range — to see which collection lands hardest.'
+                : 'Put creators’ bodies of work side by side — heat, score, traction, range — to decide who to back.'}
           </p>
         </div>
       </section>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {!isPitch && (
-          <div className="mb-6">
-            <CreatorPicker onAdd={addId} disabled={ids.length >= MAX_SUBJECTS} existing={ids} />
-          </div>
+          <>
+            {/* Creators / Slates toggle */}
+            <div className="inline-flex items-center gap-1 p-1 mb-5 rounded-full bg-gray-100">
+              {(['creator', 'slate'] as const).map((t) => (
+                <button
+                  key={t}
+                  onClick={() => switchType(t)}
+                  className={`px-4 py-1.5 rounded-full text-sm font-semibold transition ${type === t ? 'bg-white text-purple-700 shadow-sm' : 'text-gray-500 hover:text-gray-800'}`}
+                >
+                  {t === 'creator' ? 'Creators' : 'Slates'}
+                </button>
+              ))}
+            </div>
+            <div className="mb-6">
+              <Picker
+                onAdd={addId}
+                disabled={ids.length >= MAX_SUBJECTS}
+                existing={ids}
+                noun={isSlate ? 'slate' : 'creator'}
+                search={isSlate ? compareService.searchSlates.bind(compareService) : compareService.searchCreators.bind(compareService)}
+              />
+            </div>
+          </>
         )}
 
         {loading ? (
@@ -208,11 +249,11 @@ export default function ComparePage() {
         ) : subjects.length === 0 ? (
           <div className="text-center py-20">
             <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-purple-50 text-purple-500 mb-4"><BarChart3 className="w-7 h-7" /></div>
-            <h3 className="font-display font-bold text-xl text-gray-900 mb-1">{isPitch ? 'Nothing to compare' : 'Add creators to compare'}</h3>
+            <h3 className="font-display font-bold text-xl text-gray-900 mb-1">{isPitch ? 'Nothing to compare' : isSlate ? 'Add slates to compare' : 'Add creators to compare'}</h3>
             <p className="text-gray-500 max-w-md mx-auto">
               {isPitch
                 ? 'Select submissions from a call’s inbox and choose “Compare” to see them here.'
-                : `Search above to add 2–${MAX_SUBJECTS} creators and see their work side by side.`}
+                : `Search above to add 2–${MAX_SUBJECTS} ${isSlate ? 'slates' : 'creators'} and see them side by side.`}
             </p>
           </div>
         ) : (
@@ -225,20 +266,20 @@ export default function ComparePage() {
                     <th key={s.subject_id} className="p-3 align-bottom">
                       <div className="relative rounded-2xl border border-gray-200 bg-white p-4 text-center shadow-sm">
                         <button onClick={() => removeId(s.subject_id)} className="absolute top-2 right-2 text-gray-300 hover:text-gray-600" aria-label="Remove"><X className="w-4 h-4" /></button>
-                        {isPitch ? (
-                          <div className="w-full h-20 mb-2 rounded-lg bg-gray-900 overflow-hidden flex items-center justify-center">
-                            {s.thumbnail ? <img src={s.thumbnail} alt="" className="w-full h-full object-cover" /> : <span className="text-gray-500 text-xs">{s.genre || 'Pitch'}</span>}
-                          </div>
-                        ) : (
+                        {type === 'creator' ? (
                           <div className="w-12 h-12 mx-auto mb-2 rounded-full bg-gray-100 flex items-center justify-center text-base font-bold text-gray-500 overflow-hidden">
                             {s.avatar ? <img src={s.avatar} alt="" className="w-full h-full object-cover" /> : (s.name[0] || '?')}
+                          </div>
+                        ) : (
+                          <div className="w-full h-20 mb-2 rounded-lg bg-gray-900 overflow-hidden flex items-center justify-center">
+                            {s.thumbnail ? <img src={s.thumbnail} alt="" className="w-full h-full object-cover" /> : <span className="text-gray-500 text-xs">{(isSlate ? 'Slate' : s.genre) || 'Pitch'}</span>}
                           </div>
                         )}
                         <div className="flex items-center justify-center gap-1">
                           <span className="font-bold text-gray-900 text-sm truncate">{s.name}</span>
                           {(s.verification_tier === 'gold' || s.verification_tier === 'silver') && <BadgeCheck className="w-4 h-4 text-amber-500 flex-shrink-0" />}
                         </div>
-                        <div className="text-[11px] text-gray-400 capitalize truncate">{isPitch ? (s.subtitle || '') : s.user_type}</div>
+                        <div className="text-[11px] text-gray-400 capitalize truncate">{type === 'creator' ? s.user_type : (s.subtitle || '')}</div>
                       </div>
                     </th>
                   ))}

--- a/frontend/src/services/compare.service.ts
+++ b/frontend/src/services/compare.service.ts
@@ -36,6 +36,14 @@ export interface CreatorOption {
   userType?: string;
 }
 
+// Generic picker item used by the compare page for both creators and slates.
+export interface PickerItem {
+  id: number;
+  name: string;
+  sub?: string;          // username/userType, or slate owner
+  image?: string | null; // avatar or slate cover
+}
+
 function unwrap<T>(res: { success: boolean; data?: unknown }, key: string, fallback: T): T {
   if (!res.success) return fallback;
   const d = res.data as Record<string, unknown> | undefined;
@@ -44,7 +52,7 @@ function unwrap<T>(res: { success: boolean; data?: unknown }, key: string, fallb
 }
 
 class CompareService {
-  async subjects(type: 'creator' | 'pitch', ids: number[]): Promise<CompareSubject[]> {
+  async subjects(type: 'creator' | 'pitch' | 'slate', ids: number[]): Promise<CompareSubject[]> {
     if (ids.length === 0) return [];
     const res = await apiClient.get<{ subjects: CompareSubject[] }>(`/api/compare?type=${type}&ids=${ids.join(',')}`);
     return unwrap<CompareSubject[]>(res, 'subjects', []);
@@ -55,17 +63,28 @@ class CompareService {
   }
 
   // Picker typeahead — dedicated creator/production search.
-  async searchCreators(q: string): Promise<CreatorOption[]> {
+  async searchCreators(q: string): Promise<PickerItem[]> {
     if (!q.trim()) return [];
     const res = await apiClient.get<{ creators: Array<Record<string, unknown>> }>(`/api/compare/creators?q=${encodeURIComponent(q)}`);
     const creators = unwrap<Array<Record<string, unknown>>>(res, 'creators', []);
     return creators.map((u) => ({
       id: Number(u.id),
       name: String(u.name || u.username || 'Unknown'),
-      username: u.username as string | undefined,
-      avatar: (u.avatar as string | null | undefined) ?? null,
-      userType: u.user_type as string | undefined,
+      sub: u.user_type as string | undefined,
+      image: (u.avatar as string | null | undefined) ?? null,
     })).filter((u) => Number.isFinite(u.id));
+  }
+
+  async searchSlates(q: string): Promise<PickerItem[]> {
+    if (!q.trim()) return [];
+    const res = await apiClient.get<{ slates: Array<Record<string, unknown>> }>(`/api/compare/slates?q=${encodeURIComponent(q)}`);
+    const slates = unwrap<Array<Record<string, unknown>>>(res, 'slates', []);
+    return slates.map((s) => ({
+      id: Number(s.id),
+      name: String(s.name || 'Untitled slate'),
+      sub: s.owner as string | undefined,
+      image: (s.thumbnail as string | null | undefined) ?? null,
+    })).filter((s) => Number.isFinite(s.id));
   }
 }
 

--- a/src/handlers/compare.ts
+++ b/src/handlers/compare.ts
@@ -62,6 +62,42 @@ export async function searchCreatorsHandler(request: Request, env: Env): Promise
   }
 }
 
+// GET /api/compare/slates?q= — typeahead for the slate comparison picker.
+// Returns published slates + the current user's own slates.
+export async function searchSlatesHandler(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+  const userId = await getUserId(request, env);
+  if (!userId) return errorResponse('Authentication required', origin, 401);
+
+  const q = (new URL(request.url).searchParams.get('q') || '').trim();
+  if (q.length < 1) return jsonResponse({ slates: [] }, origin);
+
+  const sql = getDb(env);
+  if (!sql) return jsonResponse({ slates: [] }, origin);
+
+  try {
+    const rows = await sql`
+      SELECT
+        s.id,
+        s.title AS name,
+        s.cover_image AS thumbnail,
+        s.status,
+        COALESCE(u.company_name, NULLIF(TRIM(CONCAT(u.first_name, ' ', u.last_name)), ''), u.username) AS owner,
+        (SELECT COUNT(*) FROM slate_pitches sp WHERE sp.slate_id = s.id) AS pitch_count
+      FROM slates s
+      LEFT JOIN users u ON u.id = s.user_id
+      WHERE (s.status = 'published' OR s.user_id = ${userId})
+        AND s.title ILIKE ${'%' + q + '%'}
+      ORDER BY s.title
+      LIMIT 10
+    `;
+    return jsonResponse({ slates: rows }, origin);
+  } catch (err) {
+    console.error('searchSlatesHandler error:', err instanceof Error ? err.message : String(err));
+    return jsonResponse({ slates: [] }, origin);
+  }
+}
+
 export async function compareHandler(request: Request, env: Env): Promise<Response> {
   const origin = request.headers.get('Origin');
   const userId = await getUserId(request, env);
@@ -75,7 +111,7 @@ export async function compareHandler(request: Request, env: Env): Promise<Respon
     .filter((n) => Number.isFinite(n));
   const unique = Array.from(new Set(ids)).slice(0, 4);
 
-  if (type !== 'creator' && type !== 'pitch') return errorResponse('Unsupported comparison type', origin, 400);
+  if (type !== 'creator' && type !== 'pitch' && type !== 'slate') return errorResponse('Unsupported comparison type', origin, 400);
   if (unique.length === 0) return jsonResponse({ type, subjects: [] }, origin);
 
   const sql = getDb(env);
@@ -112,6 +148,38 @@ export async function compareHandler(request: Request, env: Env): Promise<Respon
       const pitchRows = await sql.query(pitchQuery, unique);
       const byPitch = new Map((pitchRows as Array<Record<string, unknown>>).map((r) => [Number(r.subject_id), r]));
       const subjects = unique.map((id) => byPitch.get(id)).filter(Boolean);
+      return jsonResponse({ type, subjects }, origin);
+    }
+
+    // type=slate — aggregate each slate's published pitches (via slate_pitches).
+    // GROUP BY both PKs (s.id, u.id) so slate + owner columns are dependent.
+    if (type === 'slate') {
+      const slateQuery = `
+        SELECT
+          s.id AS subject_id,
+          s.title AS name,
+          COALESCE(u.company_name, NULLIF(TRIM(CONCAT(u.first_name, ' ', u.last_name)), ''), u.username) AS subtitle,
+          s.cover_image AS thumbnail,
+          u.verification_tier,
+          COUNT(p.id) AS pitch_count,
+          ROUND(AVG(p.heat_score), 1) AS avg_heat,
+          ROUND(AVG(NULLIF(p.pitchey_score_avg, 0)), 1) AS avg_pitchey,
+          COALESCE(SUM(p.view_count), 0) AS total_views,
+          COALESCE(SUM(p.like_count), 0) AS total_likes,
+          MIN(p.estimated_budget_usd) FILTER (WHERE p.estimated_budget_usd > 0) AS budget_min,
+          MAX(p.estimated_budget_usd) AS budget_max,
+          MAX(p.created_at) AS newest_at,
+          ARRAY_REMOVE(ARRAY_AGG(DISTINCT p.genre), NULL) AS genres
+        FROM slates s
+        LEFT JOIN users u ON u.id = s.user_id
+        LEFT JOIN slate_pitches sp ON sp.slate_id = s.id
+        LEFT JOIN pitches p ON p.id = sp.pitch_id AND p.status = 'published'
+        WHERE s.id IN (${placeholders})
+        GROUP BY s.id, u.id
+      `;
+      const slateRows = await sql.query(slateQuery, unique);
+      const bySlate = new Map((slateRows as Array<Record<string, unknown>>).map((r) => [Number(r.subject_id), r]));
+      const subjects = unique.map((id) => bySlate.get(id)).filter(Boolean);
       return jsonResponse({ type, subjects }, origin);
     }
 

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -2626,6 +2626,10 @@ class RouteRegistry {
       const { searchCreatorsHandler } = await import('./handlers/compare');
       return searchCreatorsHandler(req, this.env);
     });
+    this.register('GET', '/api/compare/slates', async (req) => {
+      const { searchSlatesHandler } = await import('./handlers/compare');
+      return searchSlatesHandler(req, this.env);
+    });
     this.register('GET', '/api/compare', async (req) => {
       const { compareHandler } = await import('./handlers/compare');
       return compareHandler(req, this.env);


### PR DESCRIPTION
Extends Compare to `type=slate` — completing the three subject types (creator / pitch / slate). Aggregates each slate's published pitches into the shared `{ type, subjects }` contract; `GET /api/compare/slates?q=` powers the picker. Creators/Slates toggle on the page. **No migration** (read-only). Verified on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)