### PR TITLE
feat(compare): saved & shareable comparisons (Phase 3)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -112,6 +112,7 @@ const OnboardingPage = lazyRetry(() => import('@portals/creator/pages/CreatorOnb
 const Marketplace = lazyRetry(() => import('./pages/MarketplaceEnhanced'));
 const OpportunitiesBoard = lazyRetry(() => import('./pages/OpportunitiesBoard'));
 const ComparePage = lazyRetry(() => import('./pages/ComparePage'));
+const SharedComparePage = lazyRetry(() => import('./pages/SharedComparePage'));
 const PublicPitchView = lazyRetry(() => import('./pages/PublicPitchView'));
 
 // Creator Pages
@@ -427,6 +428,7 @@ function App() {
           <Route path="/marketplace" element={<Marketplace />} />
           <Route path="/opportunities" element={<OpportunitiesBoard />} />
           <Route path="/compare" element={<ComparePage />} />
+          <Route path="/compare/s/:token" element={<SharedComparePage />} />
           <Route path="/marketplace-old" element={<Marketplace />} />
           
           {/* Browse Route */}

--- a/frontend/src/pages/ComparePage.tsx
+++ b/frontend/src/pages/ComparePage.tsx
@@ -2,9 +2,11 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   BarChart3, Plus, X, Search, Loader2, Flame, Eye, Heart, Star, BadgeCheck, Crown, Layers,
+  Share2, Bookmark, Trash2, Copy, Check,
 } from 'lucide-react';
 import PortalTopNav from '@shared/components/layout/PortalTopNav';
-import { compareService, type CompareSubject, type PickerItem } from '../services/compare.service';
+import { useToast } from '@shared/components/feedback/ToastProvider';
+import { compareService, type CompareSubject, type PickerItem, type SavedComparison } from '../services/compare.service';
 
 const MAX_SUBJECTS = 4;
 
@@ -141,16 +143,208 @@ function Picker({ onAdd, disabled, existing, noun, search }: { onAdd: (id: numbe
 }
 
 // ---------------------------------------------------------------------------
+// Matrix (shared by the live page and the public shared view)
+// ---------------------------------------------------------------------------
+
+export function ComparisonMatrix({ type, subjects, onRemove }: { type: 'creator' | 'pitch' | 'slate'; subjects: CompareSubject[]; onRemove?: (id: number) => void }) {
+  const isSlate = type === 'slate';
+  const rows = type === 'pitch' ? PITCH_ROWS : isSlate ? SLATE_ROWS : CREATOR_ROWS;
+  const leaders = useMemo(() => {
+    const map: Record<string, Set<number>> = {};
+    for (const row of rows) {
+      if (!row.score) continue;
+      const scores = subjects.map((s) => row.score!(s));
+      const max = Math.max(...scores.map((v) => (v ?? -Infinity)));
+      if (!Number.isFinite(max) || max <= 0) continue;
+      map[row.key] = new Set(scores.map((v, i) => (v === max ? i : -1)).filter((i) => i >= 0));
+    }
+    return map;
+  }, [subjects, rows]);
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-separate border-spacing-0 min-w-[640px]">
+        <thead>
+          <tr>
+            <th className="w-44 align-bottom" />
+            {subjects.map((s) => (
+              <th key={s.subject_id} className="p-3 align-bottom">
+                <div className="relative rounded-2xl border border-gray-200 bg-white p-4 text-center shadow-sm">
+                  {onRemove && <button onClick={() => onRemove(s.subject_id)} className="absolute top-2 right-2 text-gray-300 hover:text-gray-600" aria-label="Remove"><X className="w-4 h-4" /></button>}
+                  {type === 'creator' ? (
+                    <div className="w-12 h-12 mx-auto mb-2 rounded-full bg-gray-100 flex items-center justify-center text-base font-bold text-gray-500 overflow-hidden">
+                      {s.avatar ? <img src={s.avatar} alt="" className="w-full h-full object-cover" /> : (s.name[0] || '?')}
+                    </div>
+                  ) : (
+                    <div className="w-full h-20 mb-2 rounded-lg bg-gray-900 overflow-hidden flex items-center justify-center">
+                      {s.thumbnail ? <img src={s.thumbnail} alt="" className="w-full h-full object-cover" /> : <span className="text-gray-500 text-xs">{(isSlate ? 'Slate' : s.genre) || 'Pitch'}</span>}
+                    </div>
+                  )}
+                  <div className="flex items-center justify-center gap-1">
+                    <span className="font-bold text-gray-900 text-sm truncate">{s.name}</span>
+                    {(s.verification_tier === 'gold' || s.verification_tier === 'silver') && <BadgeCheck className="w-4 h-4 text-amber-500 flex-shrink-0" />}
+                  </div>
+                  <div className="text-[11px] text-gray-400 capitalize truncate">{type === 'creator' ? s.user_type : (s.subtitle || '')}</div>
+                </div>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, ri) => (
+            <tr key={row.key} className={ri % 2 ? 'bg-gray-50/60' : ''}>
+              <td className="px-3 py-3 text-sm font-medium text-gray-500">
+                <span className="inline-flex items-center gap-1.5">{row.icon && <row.icon className="w-3.5 h-3.5 text-gray-400" />}{row.label}</span>
+              </td>
+              {subjects.map((s, si) => {
+                const isLeader = leaders[row.key]?.has(si);
+                return (
+                  <td key={s.subject_id} className="px-3 py-3 text-center">
+                    <span className={`inline-flex items-center gap-1 text-sm ${isLeader ? 'font-bold text-purple-700' : 'text-gray-800'}`}>
+                      {isLeader && <Crown className="w-3.5 h-3.5 text-amber-500" />}
+                      {row.value(s)}
+                    </span>
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+          <tr>
+            <td className="px-3 py-3 text-sm font-medium text-gray-500 align-top">Genres</td>
+            {subjects.map((s) => (
+              <td key={s.subject_id} className="px-3 py-3 align-top">
+                <div className="flex flex-wrap justify-center gap-1">
+                  {(s.genres || []).slice(0, 5).map((g) => (
+                    <span key={g} className="inline-flex rounded-full bg-purple-50 text-purple-700 ring-1 ring-purple-100 px-2 py-0.5 text-[11px] font-medium">{g}</span>
+                  ))}
+                  {(!s.genres || s.genres.length === 0) && <span className="text-sm text-gray-400">—</span>}
+                </div>
+              </td>
+            ))}
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Save & share
+// ---------------------------------------------------------------------------
+
+function SaveModal({ type, ids, onClose }: { type: string; ids: number[]; onClose: () => void }) {
+  const toast = useToast();
+  const [title, setTitle] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [link, setLink] = useState<string | null>(null);
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const { share_token } = await compareService.save(title.trim() || 'Comparison', type, ids);
+      const url = `${window.location.origin}/compare/s/${share_token}`;
+      setLink(url);
+      try { await navigator.clipboard.writeText(url); } catch { /* clipboard blocked */ }
+      toast.success('Saved · link copied');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to save');
+    } finally { setSaving(false); }
+  };
+  const copy = async () => { if (link) { try { await navigator.clipboard.writeText(link); toast.success('Link copied'); } catch { /* blocked */ } } };
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm" onClick={onClose}>
+      <div className="w-full max-w-md bg-white rounded-2xl shadow-2xl" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between p-5 border-b border-gray-100">
+          <h2 className="font-display font-bold text-lg text-gray-900">Save &amp; share</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-700"><X className="w-5 h-5" /></button>
+        </div>
+        <div className="p-5">
+          {!link ? (
+            <>
+              <label className="block text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1.5">Name this comparison</label>
+              <input autoFocus value={title} onChange={(e) => setTitle(e.target.value)} placeholder="e.g. Sci-fi finalists" maxLength={160}
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500" />
+              <p className="text-xs text-gray-400 mt-2">Anyone with the link can view this comparison (read-only, recomputed live).</p>
+            </>
+          ) : (
+            <>
+              <p className="text-sm text-gray-600 mb-2">Shareable link (copied to your clipboard):</p>
+              <div className="flex items-center gap-2">
+                <input readOnly value={link} className="flex-1 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-700" />
+                <button onClick={copy} className="inline-flex items-center gap-1 px-3 py-2 rounded-lg bg-gray-100 text-gray-700 text-sm hover:bg-gray-200 transition"><Copy className="w-4 h-4" /></button>
+              </div>
+            </>
+          )}
+        </div>
+        <div className="p-5 border-t border-gray-100 flex justify-end gap-2">
+          {!link ? (
+            <>
+              <button onClick={onClose} className="px-4 py-2 rounded-lg text-sm font-medium text-gray-600 hover:bg-gray-100 transition">Cancel</button>
+              <button onClick={save} disabled={saving} className="inline-flex items-center gap-2 px-5 py-2 rounded-lg bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-sm font-semibold shadow-lg shadow-purple-500/25 hover:from-purple-500 hover:to-indigo-500 disabled:opacity-60 transition">
+                {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Share2 className="w-4 h-4" />} Save
+              </button>
+            </>
+          ) : (
+            <button onClick={onClose} className="px-5 py-2 rounded-lg bg-gray-900 text-white text-sm font-semibold hover:bg-gray-800 transition">Done</button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SavedMenu({ onLoad }: { onLoad: (c: SavedComparison) => void }) {
+  const toast = useToast();
+  const [open, setOpen] = useState(false);
+  const [items, setItems] = useState<SavedComparison[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const toggle = async () => {
+    const next = !open; setOpen(next);
+    if (next) { setLoading(true); try { setItems(await compareService.listSaved()); } catch { setItems([]); } finally { setLoading(false); } }
+  };
+  const del = async (e: React.MouseEvent, id: number) => {
+    e.stopPropagation();
+    try { await compareService.deleteSaved(id); setItems((prev) => prev.filter((x) => x.id !== id)); }
+    catch { toast.error('Failed to delete'); }
+  };
+
+  return (
+    <div className="relative">
+      <button onClick={toggle} className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium text-gray-600 ring-1 ring-gray-200 bg-white hover:ring-purple-300 transition">
+        <Bookmark className="w-4 h-4" /> Saved
+      </button>
+      {open && (
+        <div className="absolute right-0 z-30 mt-1 w-72 bg-white rounded-xl border border-gray-200 shadow-lg max-h-72 overflow-y-auto">
+          {loading ? <div className="p-4 flex justify-center"><Loader2 className="w-5 h-5 text-purple-400 animate-spin" /></div>
+            : items.length === 0 ? <div className="p-4 text-sm text-gray-400 text-center">No saved comparisons yet.</div>
+              : items.map((c) => (
+                <div key={c.id} className="flex items-center gap-2 px-3 py-2 hover:bg-purple-50 transition">
+                  <button onClick={() => { onLoad(c); setOpen(false); }} className="flex-1 min-w-0 text-left">
+                    <span className="block text-sm font-semibold text-gray-900 truncate">{c.title}</span>
+                    <span className="block text-[11px] text-gray-400 capitalize">{c.subject_type} · {c.subject_ids.split(',').length}</span>
+                  </button>
+                  <button onClick={(e) => del(e, c.id)} className="text-gray-300 hover:text-red-500 flex-shrink-0" aria-label="Delete"><Trash2 className="w-4 h-4" /></button>
+                </div>
+              ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
 export default function ComparePage() {
+  const [saveOpen, setSaveOpen] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const rawType = searchParams.get('type');
   const type: 'creator' | 'pitch' | 'slate' = rawType === 'pitch' ? 'pitch' : rawType === 'slate' ? 'slate' : 'creator';
   const isPitch = type === 'pitch';
   const isSlate = type === 'slate';
-  const rows = isPitch ? PITCH_ROWS : isSlate ? SLATE_ROWS : CREATOR_ROWS;
   const ids = useMemo(() => (
     (searchParams.get('ids') || '')
       .split(',').map((s) => parseInt(s, 10)).filter(Number.isFinite).slice(0, MAX_SUBJECTS)
@@ -182,19 +376,11 @@ export default function ComparePage() {
   };
   const addId = (id: number) => setIds([...ids, id]);
   const removeId = (id: number) => setIds(ids.filter((x) => x !== id));
-
-  // Per-row leader index (highest score; ties highlight all).
-  const leaders = useMemo(() => {
-    const map: Record<string, Set<number>> = {};
-    for (const row of rows) {
-      if (!row.score) continue;
-      const scores = subjects.map((s) => row.score!(s));
-      const max = Math.max(...scores.map((v) => (v ?? -Infinity)));
-      if (!Number.isFinite(max) || max <= 0) continue;
-      map[row.key] = new Set(scores.map((v, i) => (v === max ? i : -1)).filter((i) => i >= 0));
-    }
-    return map;
-  }, [subjects, rows]);
+  const loadSaved = (c: SavedComparison) => {
+    const params: Record<string, string> = { ids: c.subject_ids };
+    if (c.subject_type !== 'creator') params.type = c.subject_type;
+    setSearchParams(params);
+  };
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-stone-50 via-white to-stone-50">
@@ -218,6 +404,15 @@ export default function ComparePage() {
       </section>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Save / Saved controls */}
+        <div className="flex items-center justify-end gap-2 mb-4">
+          <SavedMenu onLoad={loadSaved} />
+          {subjects.length >= 2 && (
+            <button onClick={() => setSaveOpen(true)} className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-sm font-semibold shadow shadow-purple-500/25 hover:from-purple-500 hover:to-indigo-500 transition">
+              <Share2 className="w-4 h-4" /> Save &amp; share
+            </button>
+          )}
+        </div>
         {!isPitch && (
           <>
             {/* Creators / Slates toggle */}
@@ -257,72 +452,13 @@ export default function ComparePage() {
             </p>
           </div>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full border-separate border-spacing-0 min-w-[640px]">
-              <thead>
-                <tr>
-                  <th className="w-44 align-bottom" />
-                  {subjects.map((s) => (
-                    <th key={s.subject_id} className="p-3 align-bottom">
-                      <div className="relative rounded-2xl border border-gray-200 bg-white p-4 text-center shadow-sm">
-                        <button onClick={() => removeId(s.subject_id)} className="absolute top-2 right-2 text-gray-300 hover:text-gray-600" aria-label="Remove"><X className="w-4 h-4" /></button>
-                        {type === 'creator' ? (
-                          <div className="w-12 h-12 mx-auto mb-2 rounded-full bg-gray-100 flex items-center justify-center text-base font-bold text-gray-500 overflow-hidden">
-                            {s.avatar ? <img src={s.avatar} alt="" className="w-full h-full object-cover" /> : (s.name[0] || '?')}
-                          </div>
-                        ) : (
-                          <div className="w-full h-20 mb-2 rounded-lg bg-gray-900 overflow-hidden flex items-center justify-center">
-                            {s.thumbnail ? <img src={s.thumbnail} alt="" className="w-full h-full object-cover" /> : <span className="text-gray-500 text-xs">{(isSlate ? 'Slate' : s.genre) || 'Pitch'}</span>}
-                          </div>
-                        )}
-                        <div className="flex items-center justify-center gap-1">
-                          <span className="font-bold text-gray-900 text-sm truncate">{s.name}</span>
-                          {(s.verification_tier === 'gold' || s.verification_tier === 'silver') && <BadgeCheck className="w-4 h-4 text-amber-500 flex-shrink-0" />}
-                        </div>
-                        <div className="text-[11px] text-gray-400 capitalize truncate">{type === 'creator' ? s.user_type : (s.subtitle || '')}</div>
-                      </div>
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {rows.map((row, ri) => (
-                  <tr key={row.key} className={ri % 2 ? 'bg-gray-50/60' : ''}>
-                    <td className="px-3 py-3 text-sm font-medium text-gray-500">
-                      <span className="inline-flex items-center gap-1.5">{row.icon && <row.icon className="w-3.5 h-3.5 text-gray-400" />}{row.label}</span>
-                    </td>
-                    {subjects.map((s, si) => {
-                      const isLeader = leaders[row.key]?.has(si);
-                      if (row.key === 'genres') return null;
-                      return (
-                        <td key={s.subject_id} className="px-3 py-3 text-center">
-                          <span className={`inline-flex items-center gap-1 text-sm ${isLeader ? 'font-bold text-purple-700' : 'text-gray-800'}`}>
-                            {isLeader && <Crown className="w-3.5 h-3.5 text-amber-500" />}
-                            {row.value(s)}
-                          </span>
-                        </td>
-                      );
-                    })}
-                  </tr>
-                ))}
-                <tr>
-                  <td className="px-3 py-3 text-sm font-medium text-gray-500 align-top">Genres</td>
-                  {subjects.map((s) => (
-                    <td key={s.subject_id} className="px-3 py-3 align-top">
-                      <div className="flex flex-wrap justify-center gap-1">
-                        {(s.genres || []).slice(0, 5).map((g) => (
-                          <span key={g} className="inline-flex rounded-full bg-purple-50 text-purple-700 ring-1 ring-purple-100 px-2 py-0.5 text-[11px] font-medium">{g}</span>
-                        ))}
-                        {(!s.genres || s.genres.length === 0) && <span className="text-sm text-gray-400">—</span>}
-                      </div>
-                    </td>
-                  ))}
-                </tr>
-              </tbody>
-            </table>
-          </div>
+          <ComparisonMatrix type={type} subjects={subjects} onRemove={removeId} />
         )}
       </div>
+
+      {saveOpen && (
+        <SaveModal type={type} ids={ids} onClose={() => setSaveOpen(false)} />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/SharedComparePage.tsx
+++ b/frontend/src/pages/SharedComparePage.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { BarChart3, Loader2 } from 'lucide-react';
+import PortalTopNav from '@shared/components/layout/PortalTopNav';
+import { compareService, type CompareSubject } from '../services/compare.service';
+import { ComparisonMatrix } from './ComparePage';
+
+export default function SharedComparePage() {
+  const { token } = useParams();
+  const [data, setData] = useState<{ title: string; type: 'creator' | 'pitch' | 'slate'; subjects: CompareSubject[] } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!token) { setLoading(false); setError(true); return; }
+    compareService.shared(token)
+      .then(setData)
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
+  }, [token]);
+
+  const typeLabel = data?.type === 'pitch' ? 'pitches' : data?.type === 'slate' ? 'slates' : 'creators';
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-stone-50 via-white to-stone-50">
+      <PortalTopNav />
+
+      <section className="relative overflow-hidden bg-gradient-to-r from-purple-700 via-purple-600 to-indigo-600 text-white">
+        <div aria-hidden className="absolute inset-0 bg-[radial-gradient(50%_60%_at_85%_0%,rgba(245,158,11,0.18),transparent_60%)]" />
+        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+          <div className="inline-flex items-center gap-2 px-3 py-1 mb-3 rounded-full bg-white/10 border border-white/20 text-[11px] font-semibold tracking-[0.18em] uppercase">
+            <BarChart3 className="w-3.5 h-3.5" /> Shared comparison
+          </div>
+          <h1 className="font-display font-black text-4xl sm:text-5xl tracking-tight mb-2">{data?.title || 'Comparison'}</h1>
+          {data && <p className="text-white/85 text-lg">A side-by-side comparison of {data.subjects.length} {typeLabel}.</p>}
+        </div>
+      </section>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {loading ? (
+          <div className="flex justify-center py-20"><Loader2 className="w-8 h-8 text-purple-500 animate-spin" /></div>
+        ) : error || !data || data.subjects.length === 0 ? (
+          <div className="text-center py-20">
+            <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-purple-50 text-purple-500 mb-4"><BarChart3 className="w-7 h-7" /></div>
+            <h3 className="font-display font-bold text-xl text-gray-900 mb-1">Comparison not found</h3>
+            <p className="text-gray-500 max-w-md mx-auto">This shared link may have been removed or is invalid.</p>
+          </div>
+        ) : (
+          <ComparisonMatrix type={data.type} subjects={data.subjects} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/compare.service.ts
+++ b/frontend/src/services/compare.service.ts
@@ -51,6 +51,21 @@ function unwrap<T>(res: { success: boolean; data?: unknown }, key: string, fallb
   return ((inner?.[key] as T) ?? fallback);
 }
 
+function errMessage(res: { error?: unknown }, def: string): string {
+  const e = res.error as { message?: string } | string | undefined;
+  if (typeof e === 'string') return e || def;
+  return e?.message || def;
+}
+
+export interface SavedComparison {
+  id: number;
+  title: string;
+  subject_type: 'creator' | 'pitch' | 'slate';
+  subject_ids: string;
+  share_token: string;
+  created_at: string;
+}
+
 class CompareService {
   async subjects(type: 'creator' | 'pitch' | 'slate', ids: number[]): Promise<CompareSubject[]> {
     if (ids.length === 0) return [];
@@ -73,6 +88,35 @@ class CompareService {
       sub: u.user_type as string | undefined,
       image: (u.avatar as string | null | undefined) ?? null,
     })).filter((u) => Number.isFinite(u.id));
+  }
+
+  async shared(token: string): Promise<{ title: string; type: 'creator' | 'pitch' | 'slate'; subjects: CompareSubject[] }> {
+    const res = await apiClient.get<{ title: string; type: string; subjects: CompareSubject[] }>(`/api/compare/shared/${encodeURIComponent(token)}`);
+    if (!res.success) throw new Error(errMessage(res, 'Comparison not found'));
+    const d = (res.data as Record<string, unknown>) || {};
+    const inner = (d.data as Record<string, unknown> | undefined) ?? d;
+    return {
+      title: String(inner.title ?? 'Comparison'),
+      type: (inner.type as 'creator' | 'pitch' | 'slate') ?? 'creator',
+      subjects: (inner.subjects as CompareSubject[]) ?? [],
+    };
+  }
+
+  async save(title: string, type: string, ids: number[]): Promise<{ id: number; share_token: string }> {
+    const res = await apiClient.post<{ id: number; share_token: string }>('/api/compare/saved', { title, type, ids: ids.join(',') });
+    if (!res.success) throw new Error(errMessage(res, 'Failed to save'));
+    const d = (res.data as Record<string, unknown>) || {};
+    const inner = (d.data as Record<string, unknown> | undefined) ?? d;
+    return { id: Number(inner.id), share_token: String(inner.share_token) };
+  }
+
+  async listSaved(): Promise<SavedComparison[]> {
+    const res = await apiClient.get<{ comparisons: SavedComparison[] }>('/api/compare/saved');
+    return unwrap<SavedComparison[]>(res, 'comparisons', []);
+  }
+
+  async deleteSaved(id: number): Promise<void> {
+    await apiClient.delete(`/api/compare/saved/${id}`);
   }
 
   async searchSlates(q: string): Promise<PickerItem[]> {

--- a/src/db/migrations/104_saved_comparisons.sql
+++ b/src/db/migrations/104_saved_comparisons.sql
@@ -1,0 +1,16 @@
+-- Compare Phase 3: saved & shareable comparisons.
+-- A user can save a comparison (subject type + the ids) and share it via a token
+-- (read-only public view). No metric snapshot is stored — the share view always
+-- recomputes live from current data.
+
+CREATE TABLE IF NOT EXISTS saved_comparisons (
+  id           SERIAL PRIMARY KEY,
+  user_id      INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title        VARCHAR(160) NOT NULL DEFAULT 'Comparison',
+  subject_type VARCHAR(12) NOT NULL CHECK (subject_type IN ('creator', 'pitch', 'slate')),
+  subject_ids  TEXT NOT NULL,                 -- comma-separated subject ids
+  share_token  VARCHAR(64) NOT NULL UNIQUE,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_saved_comparisons_user ON saved_comparisons (user_id, created_at DESC);

--- a/src/handlers/compare.ts
+++ b/src/handlers/compare.ts
@@ -98,6 +98,86 @@ export async function searchSlatesHandler(request: Request, env: Env): Promise<R
   }
 }
 
+// Aggregate the metric bundle per subject. Shared by the live compare endpoint
+// and the public shared-token view so the matrix always reflects current data.
+async function computeSubjects(sql: ReturnType<typeof getDb>, type: string, unique: number[]): Promise<unknown[]> {
+  if (!sql || unique.length === 0) return [];
+  const placeholders = unique.map((_, i) => `$${i + 1}`).join(',');
+  let query: string;
+
+  if (type === 'pitch') {
+    query = `
+      SELECT
+        p.id AS subject_id, p.title AS name,
+        COALESCE(u.company_name, NULLIF(TRIM(CONCAT(u.first_name, ' ', u.last_name)), ''), u.username) AS subtitle,
+        p.title_image AS thumbnail, u.verification_tier, NULL::int AS pitch_count,
+        ROUND(COALESCE(p.heat_score, 0), 1) AS avg_heat,
+        ROUND(NULLIF(p.pitchey_score_avg, 0), 1) AS avg_pitchey,
+        COALESCE(p.view_count, 0) AS total_views, COALESCE(p.like_count, 0) AS total_likes,
+        NULLIF(p.estimated_budget_usd, 0) AS budget_min, NULLIF(p.estimated_budget_usd, 0) AS budget_max,
+        p.created_at AS newest_at, p.genre, p.format,
+        ARRAY_REMOVE(ARRAY[p.genre], NULL) AS genres
+      FROM pitches p
+      LEFT JOIN users u ON (u.id = p.user_id OR u.id = p.creator_id)
+      WHERE p.id IN (${placeholders})
+    `;
+  } else if (type === 'slate') {
+    query = `
+      SELECT
+        s.id AS subject_id, s.title AS name,
+        COALESCE(u.company_name, NULLIF(TRIM(CONCAT(u.first_name, ' ', u.last_name)), ''), u.username) AS subtitle,
+        s.cover_image AS thumbnail, u.verification_tier,
+        COUNT(p.id) AS pitch_count,
+        ROUND(AVG(p.heat_score), 1) AS avg_heat,
+        ROUND(AVG(NULLIF(p.pitchey_score_avg, 0)), 1) AS avg_pitchey,
+        COALESCE(SUM(p.view_count), 0) AS total_views, COALESCE(SUM(p.like_count), 0) AS total_likes,
+        MIN(p.estimated_budget_usd) FILTER (WHERE p.estimated_budget_usd > 0) AS budget_min,
+        MAX(p.estimated_budget_usd) AS budget_max, MAX(p.created_at) AS newest_at,
+        ARRAY_REMOVE(ARRAY_AGG(DISTINCT p.genre), NULL) AS genres
+      FROM slates s
+      LEFT JOIN users u ON u.id = s.user_id
+      LEFT JOIN slate_pitches sp ON sp.slate_id = s.id
+      LEFT JOIN pitches p ON p.id = sp.pitch_id AND p.status = 'published'
+      WHERE s.id IN (${placeholders})
+      GROUP BY s.id, u.id
+    `;
+  } else {
+    query = `
+      SELECT
+        u.id AS subject_id,
+        COALESCE(u.company_name, NULLIF(TRIM(CONCAT(u.first_name, ' ', u.last_name)), ''), u.username) AS name,
+        u.username, u.user_type, u.verification_tier,
+        COALESCE(u.profile_image_url, u.profile_image, u.avatar_url, u.image) AS avatar,
+        COUNT(p.id) AS pitch_count,
+        ROUND(AVG(p.heat_score), 1) AS avg_heat,
+        ROUND(AVG(NULLIF(p.pitchey_score_avg, 0)), 1) AS avg_pitchey,
+        COALESCE(SUM(p.view_count), 0) AS total_views, COALESCE(SUM(p.like_count), 0) AS total_likes,
+        MIN(p.estimated_budget_usd) FILTER (WHERE p.estimated_budget_usd > 0) AS budget_min,
+        MAX(p.estimated_budget_usd) AS budget_max, MAX(p.created_at) AS newest_at,
+        ARRAY_REMOVE(ARRAY_AGG(DISTINCT p.genre), NULL) AS genres
+      FROM users u
+      LEFT JOIN pitches p ON (p.user_id = u.id OR p.creator_id = u.id) AND p.status = 'published'
+      WHERE u.id IN (${placeholders})
+      GROUP BY u.id
+    `;
+  }
+
+  const rows = await sql.query(query, unique);
+  // Preserve the requested order so UI columns line up.
+  const byId = new Map((rows as Array<Record<string, unknown>>).map((r) => [Number(r.subject_id), r]));
+  return unique.map((id) => byId.get(id)).filter(Boolean);
+}
+
+function parseIds(raw: string): number[] {
+  const ids = raw.split(',').map((s) => parseInt(s.trim(), 10)).filter((n) => Number.isFinite(n));
+  return Array.from(new Set(ids)).slice(0, 4);
+}
+
+function lastSegment(request: Request): string {
+  const segs = new URL(request.url).pathname.split('/').filter(Boolean);
+  return segs[segs.length - 1] || '';
+}
+
 export async function compareHandler(request: Request, env: Env): Promise<Response> {
   const origin = request.headers.get('Origin');
   const userId = await getUserId(request, env);
@@ -105,117 +185,116 @@ export async function compareHandler(request: Request, env: Env): Promise<Respon
 
   const url = new URL(request.url);
   const type = (url.searchParams.get('type') || 'creator').toLowerCase();
-  const ids = (url.searchParams.get('ids') || '')
-    .split(',')
-    .map((s) => parseInt(s.trim(), 10))
-    .filter((n) => Number.isFinite(n));
-  const unique = Array.from(new Set(ids)).slice(0, 4);
-
   if (type !== 'creator' && type !== 'pitch' && type !== 'slate') return errorResponse('Unsupported comparison type', origin, 400);
+  const unique = parseIds(url.searchParams.get('ids') || '');
   if (unique.length === 0) return jsonResponse({ type, subjects: [] }, origin);
 
   const sql = getDb(env);
   if (!sql) return jsonResponse({ type, subjects: [] }, origin);
 
   try {
-    const placeholders = unique.map((_, i) => `$${i + 1}`).join(',');
-
-    // type=pitch — single-pitch metrics, mapped onto the same bundle field names
-    // so the frontend matrix is shared (it picks metric rows by `type`).
-    if (type === 'pitch') {
-      const pitchQuery = `
-        SELECT
-          p.id AS subject_id,
-          p.title AS name,
-          COALESCE(u.company_name, NULLIF(TRIM(CONCAT(u.first_name, ' ', u.last_name)), ''), u.username) AS subtitle,
-          p.title_image AS thumbnail,
-          u.verification_tier,
-          NULL::int AS pitch_count,
-          ROUND(COALESCE(p.heat_score, 0), 1) AS avg_heat,
-          ROUND(NULLIF(p.pitchey_score_avg, 0), 1) AS avg_pitchey,
-          COALESCE(p.view_count, 0) AS total_views,
-          COALESCE(p.like_count, 0) AS total_likes,
-          NULLIF(p.estimated_budget_usd, 0) AS budget_min,
-          NULLIF(p.estimated_budget_usd, 0) AS budget_max,
-          p.created_at AS newest_at,
-          p.genre,
-          p.format,
-          ARRAY_REMOVE(ARRAY[p.genre], NULL) AS genres
-        FROM pitches p
-        LEFT JOIN users u ON (u.id = p.user_id OR u.id = p.creator_id)
-        WHERE p.id IN (${placeholders})
-      `;
-      const pitchRows = await sql.query(pitchQuery, unique);
-      const byPitch = new Map((pitchRows as Array<Record<string, unknown>>).map((r) => [Number(r.subject_id), r]));
-      const subjects = unique.map((id) => byPitch.get(id)).filter(Boolean);
-      return jsonResponse({ type, subjects }, origin);
-    }
-
-    // type=slate — aggregate each slate's published pitches (via slate_pitches).
-    // GROUP BY both PKs (s.id, u.id) so slate + owner columns are dependent.
-    if (type === 'slate') {
-      const slateQuery = `
-        SELECT
-          s.id AS subject_id,
-          s.title AS name,
-          COALESCE(u.company_name, NULLIF(TRIM(CONCAT(u.first_name, ' ', u.last_name)), ''), u.username) AS subtitle,
-          s.cover_image AS thumbnail,
-          u.verification_tier,
-          COUNT(p.id) AS pitch_count,
-          ROUND(AVG(p.heat_score), 1) AS avg_heat,
-          ROUND(AVG(NULLIF(p.pitchey_score_avg, 0)), 1) AS avg_pitchey,
-          COALESCE(SUM(p.view_count), 0) AS total_views,
-          COALESCE(SUM(p.like_count), 0) AS total_likes,
-          MIN(p.estimated_budget_usd) FILTER (WHERE p.estimated_budget_usd > 0) AS budget_min,
-          MAX(p.estimated_budget_usd) AS budget_max,
-          MAX(p.created_at) AS newest_at,
-          ARRAY_REMOVE(ARRAY_AGG(DISTINCT p.genre), NULL) AS genres
-        FROM slates s
-        LEFT JOIN users u ON u.id = s.user_id
-        LEFT JOIN slate_pitches sp ON sp.slate_id = s.id
-        LEFT JOIN pitches p ON p.id = sp.pitch_id AND p.status = 'published'
-        WHERE s.id IN (${placeholders})
-        GROUP BY s.id, u.id
-      `;
-      const slateRows = await sql.query(slateQuery, unique);
-      const bySlate = new Map((slateRows as Array<Record<string, unknown>>).map((r) => [Number(r.subject_id), r]));
-      const subjects = unique.map((id) => bySlate.get(id)).filter(Boolean);
-      return jsonResponse({ type, subjects }, origin);
-    }
-
-    // type=creator — aggregate each creator's published pitches. LEFT JOIN keeps
-    // creators with no published pitches (zero/null metrics). u.id is the PK so the
-    // other u.* columns are functionally dependent — GROUP BY u.id is sufficient.
-    const query = `
-      SELECT
-        u.id AS subject_id,
-        COALESCE(u.company_name, NULLIF(TRIM(CONCAT(u.first_name, ' ', u.last_name)), ''), u.username) AS name,
-        u.username,
-        u.user_type,
-        u.verification_tier,
-        COALESCE(u.profile_image_url, u.profile_image, u.avatar_url, u.image) AS avatar,
-        COUNT(p.id) AS pitch_count,
-        ROUND(AVG(p.heat_score), 1) AS avg_heat,
-        ROUND(AVG(NULLIF(p.pitchey_score_avg, 0)), 1) AS avg_pitchey,
-        COALESCE(SUM(p.view_count), 0) AS total_views,
-        COALESCE(SUM(p.like_count), 0) AS total_likes,
-        MIN(p.estimated_budget_usd) FILTER (WHERE p.estimated_budget_usd > 0) AS budget_min,
-        MAX(p.estimated_budget_usd) AS budget_max,
-        MAX(p.created_at) AS newest_at,
-        ARRAY_REMOVE(ARRAY_AGG(DISTINCT p.genre), NULL) AS genres
-      FROM users u
-      LEFT JOIN pitches p
-        ON (p.user_id = u.id OR p.creator_id = u.id) AND p.status = 'published'
-      WHERE u.id IN (${placeholders})
-      GROUP BY u.id
-    `;
-    const rows = await sql.query(query, unique);
-    // Return in the requested order so the UI columns line up with the picker.
-    const byId = new Map((rows as Array<Record<string, unknown>>).map((r) => [Number(r.subject_id), r]));
-    const subjects = unique.map((id) => byId.get(id)).filter(Boolean);
+    const subjects = await computeSubjects(sql, type, unique);
     return jsonResponse({ type, subjects }, origin);
   } catch (err) {
     console.error('compareHandler error:', err instanceof Error ? err.message : String(err));
     return errorResponse('Failed to build comparison', origin, 500);
+  }
+}
+
+// ===========================================================================
+// Saved & shareable comparisons (Phase 3)
+// ===========================================================================
+
+// POST /api/compare/saved — save the current comparison, returns a share token.
+export async function saveComparisonHandler(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+  const userId = await getUserId(request, env);
+  if (!userId) return errorResponse('Authentication required', origin, 401);
+
+  const sql = getDb(env);
+  if (!sql) return errorResponse('Database unavailable', origin, 503);
+
+  try {
+    const body = (await request.json()) as Record<string, unknown>;
+    const type = String(body.type ?? 'creator').toLowerCase();
+    if (type !== 'creator' && type !== 'pitch' && type !== 'slate') return errorResponse('Unsupported comparison type', origin, 400);
+    const unique = parseIds(Array.isArray(body.ids) ? body.ids.join(',') : String(body.ids ?? ''));
+    if (unique.length < 2) return errorResponse('Add at least 2 to save a comparison', origin, 400);
+    const title = (String(body.title ?? '').trim() || 'Comparison').slice(0, 160);
+    const token = crypto.randomUUID().replace(/-/g, '');
+
+    const [row] = await sql`
+      INSERT INTO saved_comparisons (user_id, title, subject_type, subject_ids, share_token)
+      VALUES (${userId}, ${title}, ${type}, ${unique.join(',')}, ${token})
+      RETURNING id, share_token
+    `;
+    return jsonResponse({ id: row?.id, share_token: row?.share_token }, origin, 201);
+  } catch (err) {
+    console.error('saveComparisonHandler error:', err instanceof Error ? err.message : String(err));
+    return errorResponse('Failed to save comparison', origin, 500);
+  }
+}
+
+// GET /api/compare/saved — the user's saved comparisons.
+export async function listSavedComparisonsHandler(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+  const userId = await getUserId(request, env);
+  if (!userId) return errorResponse('Authentication required', origin, 401);
+
+  const sql = getDb(env);
+  if (!sql) return jsonResponse({ comparisons: [] }, origin);
+
+  try {
+    const rows = await sql`
+      SELECT id, title, subject_type, subject_ids, share_token, created_at
+      FROM saved_comparisons WHERE user_id = ${userId}
+      ORDER BY created_at DESC LIMIT 50
+    `;
+    return jsonResponse({ comparisons: rows }, origin);
+  } catch (err) {
+    console.error('listSavedComparisonsHandler error:', err instanceof Error ? err.message : String(err));
+    return jsonResponse({ comparisons: [] }, origin);
+  }
+}
+
+// DELETE /api/compare/saved/:id — delete one of the user's saved comparisons.
+export async function deleteSavedComparisonHandler(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+  const userId = await getUserId(request, env);
+  if (!userId) return errorResponse('Authentication required', origin, 401);
+
+  const id = parseInt(lastSegment(request), 10);
+  if (!Number.isFinite(id)) return errorResponse('Invalid id', origin, 400);
+
+  const sql = getDb(env);
+  if (!sql) return errorResponse('Database unavailable', origin, 503);
+
+  try {
+    await sql`DELETE FROM saved_comparisons WHERE id = ${id} AND user_id = ${userId}`;
+    return jsonResponse({ deleted: true }, origin);
+  } catch (err) {
+    console.error('deleteSavedComparisonHandler error:', err instanceof Error ? err.message : String(err));
+    return errorResponse('Failed to delete', origin, 500);
+  }
+}
+
+// GET /api/compare/shared/:token — PUBLIC read-only view (recomputed live).
+export async function sharedComparisonHandler(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+  const token = lastSegment(request);
+  if (!token) return errorResponse('Invalid link', origin, 400);
+
+  const sql = getDb(env);
+  if (!sql) return errorResponse('Database unavailable', origin, 503);
+
+  try {
+    const [saved] = await sql`SELECT title, subject_type, subject_ids FROM saved_comparisons WHERE share_token = ${token}`;
+    if (!saved) return errorResponse('Comparison not found', origin, 404);
+    const unique = parseIds(String(saved.subject_ids));
+    const subjects = await computeSubjects(sql, String(saved.subject_type), unique);
+    return jsonResponse({ title: saved.title, type: saved.subject_type, subjects }, origin);
+  } catch (err) {
+    console.error('sharedComparisonHandler error:', err instanceof Error ? err.message : String(err));
+    return errorResponse('Failed to load comparison', origin, 500);
   }
 }

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -2630,6 +2630,24 @@ class RouteRegistry {
       const { searchSlatesHandler } = await import('./handlers/compare');
       return searchSlatesHandler(req, this.env);
     });
+    // Saved & shareable comparisons. Static `saved`/`shared` registered before
+    // the bare `/api/compare`. The shared-token view is public (publicEndpoints).
+    this.register('GET', '/api/compare/saved', async (req) => {
+      const { listSavedComparisonsHandler } = await import('./handlers/compare');
+      return listSavedComparisonsHandler(req, this.env);
+    });
+    this.register('POST', '/api/compare/saved', async (req) => {
+      const { saveComparisonHandler } = await import('./handlers/compare');
+      return saveComparisonHandler(req, this.env);
+    });
+    this.register('DELETE', '/api/compare/saved/:id', async (req) => {
+      const { deleteSavedComparisonHandler } = await import('./handlers/compare');
+      return deleteSavedComparisonHandler(req, this.env);
+    });
+    this.register('GET', '/api/compare/shared/:token', async (req) => {
+      const { sharedComparisonHandler } = await import('./handlers/compare');
+      return sharedComparisonHandler(req, this.env);
+    });
     this.register('GET', '/api/compare', async (req) => {
       const { compareHandler } = await import('./handlers/compare');
       return compareHandler(req, this.env);
@@ -4107,6 +4125,7 @@ class RouteRegistry {
       '/api/search/facets',
       '/api/browse',
       '/api/calls',
+      '/api/compare/shared',
       '/api/pitches',
       '/api/pitches/public',
       '/api/pitches/public/trending',


### PR DESCRIPTION
Final deferred Compare item. Save a comparison → get a **read-only public share link** (`/compare/s/:token`), recomputed live from current data.

- Migration 104 `saved_comparisons`; `POST/GET /api/compare/saved`, `DELETE /api/compare/saved/:id`, public `GET /api/compare/shared/:token`.
- Refactored aggregation into `computeSubjects()` (shared by live + shared views). Extracted `ComparisonMatrix` (reused by the page + the public `SharedComparePage`). Save&share modal + Saved menu.

Migration 104 applied to prod + recorded. Verified end-to-end (save → link → public view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)