### PR TITLE
feat(how-it-works): cinematic redesign + role-tabbed restructure

### DIFF
--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Film, ArrowLeft, Loader } from 'lucide-react';
+import { Loader } from 'lucide-react';
 import { contentService } from '../services/content.service';
-import Logo from '../components/Logo';
+import PublicTopNav from '@shared/components/layout/PublicTopNav';
 
 interface AboutContent {
   title?: string;
@@ -115,21 +115,7 @@ const About: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-white to-pink-50">
-      {/* Header */}
-      <header className="bg-white/80 backdrop-blur-sm shadow-sm sticky top-0 z-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-          <div className="flex items-center justify-between">
-            <Logo size="lg" onClick={() => navigate('/')} />
-            <button 
-              onClick={() => navigate(-1)}
-              className="flex items-center gap-2 px-4 py-2 text-gray-600 hover:text-purple-600 transition"
-            >
-              <ArrowLeft className="w-4 h-4" />
-              Back
-            </button>
-          </div>
-        </div>
-      </header>
+      <PublicTopNav variant="solid" />
 
       {/* Content */}
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
@@ -194,18 +180,18 @@ const About: React.FC = () => {
             </div>
           )}
 
-          <div className="mt-12 flex gap-4">
-            <button 
-              onClick={() => navigate('/login')}
+          <div className="mt-12 flex flex-col sm:flex-row gap-4">
+            <button
+              onClick={() => navigate('/register')}
               className="px-6 py-3 bg-purple-600 text-white font-semibold rounded-lg hover:bg-purple-700 transition"
             >
-              Get Started
+              Create your account
             </button>
-            <button 
-              onClick={() => navigate('/how-it-works')}
+            <button
+              onClick={() => navigate('/marketplace')}
               className="px-6 py-3 border border-purple-600 text-purple-600 font-semibold rounded-lg hover:bg-purple-50 transition"
             >
-              How It Works
+              Browse the marketplace
             </button>
           </div>
         </div>

--- a/frontend/src/pages/Homepage.tsx
+++ b/frontend/src/pages/Homepage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Film, TrendingUp, Search, Play, Star, Eye, Heart, Calendar, ArrowRight, Sparkles, User, Building2, Wallet, LogOut, Flame, Menu, X } from 'lucide-react';
+import { Film, TrendingUp, Search, Play, Star, Eye, Heart, Calendar, ArrowRight, Sparkles, User, Building2, Wallet, Flame } from 'lucide-react';
 import { useBetterAuthStore } from '../store/betterAuthStore';
 import { pitchService } from '@features/pitches/services/pitch.service';
 import { pitchAPI } from '../lib/api';
@@ -10,8 +10,8 @@ import FormatDisplay from '../components/FormatDisplay';
 import GenrePlaceholder from '@shared/components/GenrePlaceholder';
 import { getHeatScore, getPitcheyScore } from '../components/HeatBadge';
 import PitcheyRating from '../components/PitcheyRating';
-import { getPortalPath, getDashboardRoute } from '@/utils/navigation';
-import { getPortalTheme } from '@shared/hooks/usePortalTheme';
+import { getDashboardRoute } from '@/utils/navigation';
+import PublicTopNav from '@shared/components/layout/PublicTopNav';
 
 
 
@@ -26,20 +26,9 @@ export default function Homepage() {
   const [newReleases, setNewReleases] = useState<Pitch[]>([]);
   const [hotPitches, setHotPitches] = useState<Pitch[]>([]);
   const [loading, setLoading] = useState(true);
-  // Header blends with the dark hero at the top, then turns solid-white once the user scrolls
-  // PAST the hero into the bright content (so it stays readable on light backgrounds).
+  // Hero is pulled up behind the sticky nav (-mt-16) so PublicTopNav's backdrop is the
+  // hero itself; the nav flips transparent → white once the hero clears it.
   const heroRef = useRef<HTMLElement>(null);
-  const [scrolled, setScrolled] = useState(false);
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  useEffect(() => {
-    const onScroll = () => {
-      const heroBottom = heroRef.current?.getBoundingClientRect().bottom ?? 0;
-      setScrolled(heroBottom <= 64); // 64 = header height; switch when the hero clears the nav
-    };
-    onScroll();
-    window.addEventListener('scroll', onScroll, { passive: true });
-    return () => window.removeEventListener('scroll', onScroll);
-  }, []);
   // likedPitches state removed — replaced by Pitchey Score
 
   // Like handler removed — replaced by Pitchey Score rating system
@@ -117,181 +106,7 @@ export default function Homepage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-gray-50 via-purple-50 to-white">
-      {/* Navigation Header */}
-      <header className={`sticky top-0 z-50 transition-colors duration-300 ${
-        scrolled
-          ? 'bg-white/95 backdrop-blur-md border-b border-gray-200 shadow-sm'
-          : mobileMenuOpen
-            ? 'bg-[#1f1934] border-b border-white/10'
-            : 'bg-[#0a0a12]/70 backdrop-blur-md border-b border-white/5'
-      }`}>
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-16">
-            <div className="flex items-center gap-8">
-              <a href="/" className="flex items-center">
-                <img src={scrolled ? '/pitchey-logotype.png' : '/pitchey-logotype-white.png'} alt="Pitchey" className="h-8 w-auto" />
-              </a>
-              <nav className="hidden md:flex items-center gap-6">
-                <button
-                  onClick={() => navigate('/marketplace')}
-                  className={`text-nav-link transition ${scrolled ? 'hover:text-purple-600' : 'text-white/90 hover:text-white'}`}
-                >
-                  Browse Pitches
-                </button>
-                <button
-                  onClick={() => navigate('/opportunities')}
-                  className={`text-nav-link transition ${scrolled ? 'hover:text-purple-600' : 'text-white/90 hover:text-white'}`}
-                >
-                  Opportunities
-                </button>
-                <button
-                  onClick={() => navigate('/how-it-works')}
-                  className={`text-nav-link transition ${scrolled ? 'hover:text-purple-600' : 'text-white/90 hover:text-white'}`}
-                >
-                  How It Works
-                </button>
-                <button
-                  onClick={() => navigate('/about')}
-                  className={`text-nav-link transition ${scrolled ? 'hover:text-purple-600' : 'text-white/90 hover:text-white'}`}
-                >
-                  About
-                </button>
-              </nav>
-            </div>
-            <div className="hidden md:flex items-center gap-4">
-              {isAuthenticated && user ? (
-                <>
-                  {/* User Status Badge — tint comes from the portal theme so the
-                      badge matches sidebars and the identity strip. Don't reintroduce
-                      hardcoded colors (investor was 'green' before — the bug
-                      usePortalTheme docs explicitly call out). */}
-                  {(() => {
-                    const theme = getPortalTheme(userType);
-                    const meta =
-                      userType === 'production' ? { Icon: Building2, label: 'Production' } :
-                      userType === 'investor'   ? { Icon: Wallet,    label: 'Investor'   } :
-                      userType === 'creator'    ? { Icon: User,      label: 'Creator'    } :
-                      userType === 'watcher'    ? { Icon: Eye,       label: 'Watcher'    } :
-                      null;
-                    if (!meta) return null;
-                    const displayName =
-                      userType === 'production' && user.companyName
-                        ? user.companyName
-                        : user.firstName
-                          ? `${user.firstName} ${user.lastName || ''}`.trim()
-                          : user.username;
-                    return (
-                      <div className={`flex items-center gap-2 px-3 py-1.5 ${theme.bgMuted} border border-gray-200 rounded-lg`}>
-                        <meta.Icon className={`w-4 h-4 ${theme.textAccent}`} />
-                        <span className={`text-sm font-medium ${theme.textAccent}`}>{meta.label}</span>
-                        <span className="text-xs text-gray-400">•</span>
-                        <span className="text-sm text-gray-900">{displayName}</span>
-                      </div>
-                    );
-                  })()}
-
-                  {/* Dashboard Button */}
-                  <button
-                    onClick={() => navigate(userType ? `/${getPortalPath(userType)}/dashboard` : '/login')}
-                    className="text-button px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition"
-                  >
-                    Dashboard
-                  </button>
-
-                  {/* Sign Out Button */}
-                  <button
-                    onClick={async () => { await logout(); navigate('/'); }}
-                    className={`text-button px-3 py-2 transition ${scrolled ? 'text-gray-500 hover:text-red-600' : 'text-white/70 hover:text-white'}`}
-                    title="Sign Out"
-                  >
-                    <LogOut className="w-4 h-4" />
-                  </button>
-                </>
-              ) : (
-                <>
-                  <button
-                    onClick={() => navigate('/login')}
-                    className={`text-button px-4 py-2 transition ${scrolled ? 'text-purple-600 hover:text-purple-700' : 'text-white hover:text-white/80'}`}
-                  >
-                    Sign In
-                  </button>
-                  <button
-                    onClick={() => navigate('/register')}
-                    className="text-button px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition"
-                  >
-                    Get Started
-                  </button>
-                </>
-              )}
-            </div>
-
-            {/* Mobile hamburger — the desktop nav links are hidden < md, so narrow viewports
-                need a way to reach Browse / How It Works / About + the auth actions. */}
-            <button
-              onClick={() => setMobileMenuOpen((o) => !o)}
-              aria-label="Toggle navigation menu"
-              aria-expanded={mobileMenuOpen}
-              className={`md:hidden inline-flex items-center justify-center p-2 rounded-lg transition ${scrolled ? 'text-gray-700 hover:bg-gray-100' : 'text-white hover:bg-white/10'}`}
-            >
-              {mobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
-            </button>
-          </div>
-        </div>
-
-        {/* Mobile dropdown menu */}
-        {mobileMenuOpen && (
-          <div className={`md:hidden border-t ${scrolled ? 'bg-white border-gray-200' : 'bg-[#1f1934] border-white/10'}`}>
-            <div className="max-w-7xl mx-auto px-4 py-3 flex flex-col gap-1">
-              {[
-                { label: 'Browse Pitches', to: '/marketplace' },
-                { label: 'Opportunities', to: '/opportunities' },
-                { label: 'How It Works', to: '/how-it-works' },
-                { label: 'About', to: '/about' },
-              ].map((item) => (
-                <button
-                  key={item.to}
-                  onClick={() => { setMobileMenuOpen(false); navigate(item.to); }}
-                  className={`text-left px-3 py-2.5 rounded-lg text-sm font-medium transition ${scrolled ? 'text-gray-700 hover:bg-gray-100' : 'text-white/90 hover:bg-white/10'}`}
-                >
-                  {item.label}
-                </button>
-              ))}
-              <div className={`my-2 border-t ${scrolled ? 'border-gray-200' : 'border-white/10'}`} />
-              {isAuthenticated && user ? (
-                <>
-                  <button
-                    onClick={() => { setMobileMenuOpen(false); navigate(userType ? `/${getPortalPath(userType)}/dashboard` : '/login'); }}
-                    className="px-3 py-2.5 rounded-lg bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-sm font-semibold text-center shadow-lg shadow-purple-500/30 hover:from-purple-500 hover:to-indigo-500 transition"
-                  >
-                    Dashboard
-                  </button>
-                  <button
-                    onClick={async () => { setMobileMenuOpen(false); await logout(); navigate('/'); }}
-                    className={`text-left px-3 py-2.5 rounded-lg text-sm font-medium transition ${scrolled ? 'text-gray-600 hover:bg-gray-100' : 'text-white/80 hover:bg-white/10'}`}
-                  >
-                    Sign Out
-                  </button>
-                </>
-              ) : (
-                <>
-                  <button
-                    onClick={() => { setMobileMenuOpen(false); navigate('/login'); }}
-                    className={`text-left px-3 py-2.5 rounded-lg text-sm font-medium transition ${scrolled ? 'text-purple-600 hover:bg-purple-50' : 'text-white hover:bg-white/10'}`}
-                  >
-                    Sign In
-                  </button>
-                  <button
-                    onClick={() => { setMobileMenuOpen(false); navigate('/register'); }}
-                    className="px-3 py-2.5 rounded-lg bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-sm font-semibold text-center shadow-lg shadow-purple-500/30 hover:from-purple-500 hover:to-indigo-500 transition"
-                  >
-                    Get Started
-                  </button>
-                </>
-              )}
-            </div>
-          </div>
-        )}
-      </header>
+      <PublicTopNav variant="overlay" heroRef={heroRef} showIdentityBadge />
 
       {/* Hero — "Premiere Night": dark, cinematic, editorial display type. The bright content
           rails below it intentionally read as the marquee turning the lights up.

--- a/frontend/src/pages/HowItWorks.tsx
+++ b/frontend/src/pages/HowItWorks.tsx
@@ -1,427 +1,550 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, Film, Users, DollarSign, Rocket, Shield, TrendingUp, CheckCircle, Star, Zap, Target, Award, Loader } from 'lucide-react';
+import {
+  ArrowRight, Film, Users, DollarSign, Shield, TrendingUp, Star, Zap, Target, Award,
+  Sparkles, Play, Menu, X, ChevronDown, Search, MessageSquare, Eye, Lock, BadgeCheck,
+  Clapperboard, Handshake, Flame, LogOut,
+} from 'lucide-react';
+import { useBetterAuthStore } from '../store/betterAuthStore';
+import { getPortalPath } from '@/utils/navigation';
 import { contentService } from '../services/content.service';
 
+// ---------------------------------------------------------------------------
+// Icon registry — keeps API/CMS-driven `icon` string keys rendering, and lets
+// the local defaults reference the same map.
+// ---------------------------------------------------------------------------
+const ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
+  film: Film, clapperboard: Clapperboard, shield: Shield, lock: Lock, users: Users,
+  'dollar-sign': DollarSign, target: Target, search: Search, 'trending-up': TrendingUp,
+  eye: Eye, award: Award, handshake: Handshake, message: MessageSquare, 'badge-check': BadgeCheck,
+  zap: Zap, star: Star, flame: Flame,
+};
+const Icon = ({ name, className }: { name?: string; className?: string }) => {
+  const C = ICONS[name || 'star'] || Star;
+  return <C className={className} />;
+};
 
-interface ContentData {
-  hero?: {
-    title?: string;
-    subtitle?: string;
-  };
-  creatorSteps?: Array<{
-    title: string;
-    description: string;
-    icon?: string;
-  }>;
-  investorSteps?: Array<{
-    title: string;
-    description: string;
-    icon?: string;
-  }>;
-  productionSteps?: Array<{
-    title: string;
-    description: string;
-    icon?: string;
-  }>;
-  features?: Array<{
-    title: string;
-    description: string;
-    icon?: string;
-  }>;
-  stats?: Array<{
-    value: string;
-    label: string;
-    color?: string;
-  }>;
-  metrics?: Array<{
-    value: string;
-    label: string;
-    color?: string;
-    description?: string;
-  }>;
+// ---------------------------------------------------------------------------
+// Default role tracks (CMS step arrays merge over these by index).
+// Accents pull from the canonical portal tokens in tailwind.config.js.
+// ---------------------------------------------------------------------------
+type Step = { title: string; description: string; icon: string };
+type Track = { id: string; label: string; accent: string; glow: string; tagline: string; outcome: string; steps: Step[] };
+
+const ROLE_TRACKS: Track[] = [
+  {
+    id: 'creator',
+    label: 'Creators',
+    accent: '#7B3FBF',
+    glow: 'rgba(123,63,191,0.35)',
+    tagline: 'Turn a screenplay into your next production.',
+    outcome: 'From first draft to signed deal — you keep control of your IP the whole way.',
+    steps: [
+      { icon: 'clapperboard', title: 'Build your pitch', description: 'Craft a cinematic pitch page — logline, synopsis, treatment, lookbook and budget — with guided tools made for storytellers.' },
+      { icon: 'lock', title: 'Protect your IP', description: 'Gate full materials behind the Pitchey Standard NDA. You decide who unlocks the script, and every view is logged.' },
+      { icon: 'trending-up', title: 'Get discovered', description: 'Your Heat Score and verified profile surface your project to investors and studios actively searching your genre and budget.' },
+      { icon: 'handshake', title: 'Close the deal', description: 'Message interested partners directly, share extended materials, and move from inbox to greenlight — rights intact.' },
+    ],
+  },
+  {
+    id: 'investor',
+    label: 'Investors',
+    accent: '#5B4FC7',
+    glow: 'rgba(91,79,199,0.35)',
+    tagline: 'Discover the next blockbuster before anyone else.',
+    outcome: 'A vetted, transparent deal flow — with a clear record of everything you reviewed.',
+    steps: [
+      { icon: 'target', title: 'Browse curated pitches', description: 'Explore a vetted marketplace across every genre and format, sorted by traction, freshness and heat — not noise.' },
+      { icon: 'lock', title: 'Unlock under NDA', description: 'Sign digitally to access scripts, budgets and proprietary materials, with a clear record of exactly what you reviewed.' },
+      { icon: 'eye', title: 'Track what’s moving', description: 'Follow creators and projects, watch engagement and momentum in real time, and build a shortlist before the market catches on.' },
+      { icon: 'award', title: 'Back the winners', description: 'Connect directly with creators, open the conversation, and negotiate terms on the projects you believe in.' },
+    ],
+  },
+  {
+    id: 'production',
+    label: 'Production',
+    accent: '#4A5FD0',
+    glow: 'rgba(74,95,208,0.35)',
+    tagline: 'Find, secure and produce your next slate.',
+    outcome: 'A credible sourcing pipeline that moves promising projects toward production.',
+    steps: [
+      { icon: 'badge-check', title: 'Stand up your slate', description: 'Build a verified company profile so creators know they’re pitching a credible partner — and bring your team in with a join code.' },
+      { icon: 'shield', title: 'Request & sign NDAs', description: 'Review sensitive materials under NDA while keeping your own development pipeline confidential.' },
+      { icon: 'search', title: 'Source by fit', description: 'Search by genre, budget and Heat Score to surface projects that match your slate — then compare submissions side by side.' },
+      { icon: 'message', title: 'Develop together', description: 'Message creators, bring collaborators into a shared workspace, and shepherd projects toward production.' },
+    ],
+  },
+];
+
+const FEATURES: Step[] = [
+  { icon: 'zap', title: 'AI-assisted pitching', description: 'Auto-fill production assessments from your uploaded documents with Claude — less busywork, sharper pitches.' },
+  { icon: 'shield', title: 'NDA-grade protection', description: 'The lawyer-drafted Pitchey Standard NDA gates every sensitive file. Click-to-sign, fully logged.' },
+  { icon: 'flame', title: 'Heat Score discovery', description: 'A Bayesian, role-weighted score surfaces real traction — so strong projects rise on merit, not ad spend.' },
+  { icon: 'badge-check', title: 'Verified & trusted', description: 'Region-adaptive company verification and gold / silver trust badges keep the marketplace credible.' },
+  { icon: 'message', title: 'Direct connections', description: 'Built-in messaging, shared workspaces and team join codes connect the right people fast.' },
+  { icon: 'star', title: 'Built for the industry', description: 'Slates, comparisons, opportunity boards and structured feedback — designed around how film actually gets made.' },
+];
+
+const FAQS = [
+  { q: 'Who can join Pitchey?', a: 'Creators pitching original work, investors hunting deal flow, and production companies sourcing their next slate. Anyone can also browse as a Watcher — our audience tier — to like, save and follow projects.' },
+  { q: 'How is my idea protected?', a: 'Your public summary is open, but full materials — script, budget, treatment — stay gated behind the Pitchey Standard NDA. You choose who unlocks them, and every access is logged so you always know who has seen what.' },
+  { q: 'What does it cost?', a: 'Browsing and building a profile is free. Creators and production companies choose a subscription tier (€19.99 / €29.99 / €39.99 per month) for advanced tools and reach. Investors browse curated deal flow at no charge.' },
+  { q: 'How do investors and producers find my pitch?', a: 'Your Heat Score — a Bayesian, role-weighted measure of real engagement — plus genre, budget and format search surface your project to the right people. Verified profiles and trust badges help you stand out.' },
+  { q: 'Do I have to sign an NDA to view a pitch?', a: 'Not to browse. The public-facing summary is always visible. Investors and production companies sign a digital NDA only when they want to unlock the full, sensitive materials behind a project.' },
+  { q: 'How do deals actually happen?', a: 'Pitchey is the discovery and protection layer. Once both sides are interested, you connect through built-in messaging and shared workspaces, then negotiate terms directly — your rights and relationships stay yours.' },
+];
+
+// ---------------------------------------------------------------------------
+// Scroll-reveal helper — opacity + translate as elements enter the viewport.
+// ---------------------------------------------------------------------------
+function Reveal({ children, delay = 0, className = '' }: { children: React.ReactNode; delay?: number; className?: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [shown, setShown] = useState(false);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    // Fall back to immediately visible if IntersectionObserver is unavailable
+    // (SSR, older browsers, or test environments).
+    if (typeof IntersectionObserver !== 'function') { setShown(true); return; }
+    let io: IntersectionObserver;
+    try {
+      io = new IntersectionObserver(([e]) => {
+        if (e.isIntersecting) { setShown(true); io.disconnect(); }
+      }, { threshold: 0.15 });
+      io.observe(el);
+    } catch {
+      setShown(true);
+      return;
+    }
+    return () => io.disconnect();
+  }, []);
+  return (
+    <div
+      ref={ref}
+      style={{ transitionDelay: `${delay}ms` }}
+      className={`transition-all duration-700 ease-out ${shown ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-6'} ${className}`}
+    >
+      {children}
+    </div>
+  );
 }
+
+const fmtMoney = (n: number) => {
+  if (n >= 1_000_000) { const m = n / 1_000_000; return `$${m % 1 === 0 ? m : m.toFixed(1)}M`; }
+  if (n >= 1_000) return `$${Math.round(n / 1_000)}K`;
+  return `$${n}`;
+};
+const fmtCount = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}K` : `${n}`);
 
 const HowItWorks: React.FC = () => {
   const navigate = useNavigate();
-  const [content, setContent] = useState<ContentData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { isAuthenticated, user, logout } = useBetterAuthStore();
+  const userType = user?.userType;
 
-  // Fallback content - hardcoded data
-  const fallbackContent: ContentData = {
-    hero: {
-      title: "Transform Your Ideas Into Reality",
-      subtitle: "Pitchey connects visionary creators with forward-thinking investors through a secure, transparent marketplace designed for the entertainment industry."
-    },
-    creatorSteps: [
-      {
-        title: "Create Your Pitch",
-        description: "Upload your screenplay, treatment, or concept with compelling visuals and detailed project information.",
-        icon: "film"
-      },
-      {
-        title: "Protect Your Work",
-        description: "Use our NDA system to protect your intellectual property while sharing with verified investors.",
-        icon: "shield"
-      },
-      {
-        title: "Connect with Investors",
-        description: "Get discovered by production companies and investors actively seeking new content.",
-        icon: "users"
-      },
-      {
-        title: "Secure Funding",
-        description: "Negotiate deals, receive funding, and bring your creative vision to life.",
-        icon: "dollar-sign"
-      }
-    ],
-    investorSteps: [
-      {
-        title: "Browse Curated Content",
-        description: "Access a diverse marketplace of pre-vetted pitches across all genres and formats.",
-        icon: "target"
-      },
-      {
-        title: "Review Under NDA",
-        description: "Sign NDAs digitally to access detailed materials and proprietary content securely.",
-        icon: "shield"
-      },
-      {
-        title: "Track Performance",
-        description: "Monitor pitch engagement, market trends, and investment opportunities in real-time.",
-        icon: "trending-up"
-      },
-      {
-        title: "Close Deals",
-        description: "Connect directly with creators, negotiate terms, and finalize investments.",
-        icon: "award"
-      }
-    ],
-    productionSteps: [
-      {
-        title: "Create",
-        description: "Build your verified production company profile and slate so creators know they're pitching to a credible partner.",
-        icon: "film"
-      },
-      {
-        title: "Protect",
-        description: "Request and sign NDAs to review sensitive materials while keeping your own development pipeline confidential.",
-        icon: "shield"
-      },
-      {
-        title: "Explore",
-        description: "Search the marketplace by genre, budget, and heat score to surface projects that fit your slate.",
-        icon: "target"
-      },
-      {
-        title: "Connect",
-        description: "Message creators directly, bring on collaborators, and move promising projects into production.",
-        icon: "users"
-      }
-    ],
-    features: [
-      {
-        title: "AI-Powered Recommendations",
-        description: "Our algorithm recommends the right projects to the right investors based on genre, budget, and track record.",
-        icon: "zap"
-      },
-      {
-        title: "Secure Platform",
-        description: "Bank-level encryption and comprehensive NDA protection for all shared materials.",
-        icon: "shield"
-      },
-      {
-        title: "Quality Control",
-        description: "All pitches are reviewed to ensure professional standards and market readiness.",
-        icon: "star"
-      },
-      {
-        title: "Direct Communication",
-        description: "Built-in messaging and video conferencing for seamless collaboration.",
-        icon: "users"
-      }
-    ],
-    stats: [
-      { value: "500+", label: "Active Projects", color: "purple" },
-      { value: "$50M+", label: "Funded to Date", color: "green" },
-      { value: "200+", label: "Success Stories", color: "yellow" },
-      { value: "95%", label: "Satisfaction Rate", color: "pink" }
-    ]
-  };
+  const [tracks, setTracks] = useState<Track[]>(ROLE_TRACKS);
+  const [features, setFeatures] = useState<Step[]>(FEATURES);
+  const [stats, setStats] = useState<Array<{ value: string; label: string }>>([]);
+  const [activeRole, setActiveRole] = useState(0);
+  const [openFaq, setOpenFaq] = useState<number | null>(0);
 
-  // Load content from API with fallback
+  const heroRef = useRef<HTMLElement>(null);
+  const [scrolled, setScrolled] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
   useEffect(() => {
-    const loadContent = async () => {
-      setLoading(true);
-      setError(null);
-      
-      try {
-        const [howItWorksResult, statsResult] = await Promise.all([
-          contentService.getHowItWorks(),
-          contentService.getStats()
-        ]);
-        
-        let mergedContent = { ...fallbackContent };
-        
-        if (howItWorksResult.success && howItWorksResult.data) {
-          mergedContent = { ...mergedContent, ...howItWorksResult.data };
-        }
-        
-        if (statsResult.success && statsResult.data) {
-          // Convert API format to component format
-          if (statsResult.data.metrics) {
-            mergedContent.stats = statsResult.data.metrics.map((metric: any) => ({
-              value: metric.value,
-              label: metric.label,
-              color: metric.color
-            }));
-          } else {
-            mergedContent.stats = statsResult.data;
-          }
-        }
-        
-        setContent(mergedContent);
-      } catch (err) {
-        console.warn('Error loading content:', err);
-        setContent(fallbackContent);
-        setError('Failed to load latest content. Showing cached version.');
-      } finally {
-        setLoading(false);
-      }
+    const onScroll = () => {
+      const bottom = heroRef.current?.getBoundingClientRect().bottom ?? 0;
+      setScrolled(bottom <= 64);
     };
-    
-    loadContent();
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
   }, []);
-  
-  // Helper function to render icons
-  const renderIcon = (iconName: string = 'star', className: string = 'w-8 h-8') => {
-    const iconMap: { [key: string]: React.ReactElement } = {
-      'film': <Film className={className} />,
-      'shield': <Shield className={className} />,
-      'users': <Users className={className} />,
-      'dollar-sign': <DollarSign className={className} />,
-      'target': <Target className={className} />,
-      'trending-up': <TrendingUp className={className} />,
-      'award': <Award className={className} />,
-      'zap': <Zap className={className} />,
-      'star': <Star className={className} />
-    };
-    return iconMap[iconName] || <Star className={className} />;
-  };
 
-  // Show loading state
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-gradient-to-b from-gray-50 via-purple-50 to-white flex items-center justify-center">
-        <div className="text-center">
-          <Loader className="w-12 h-12 text-purple-600 animate-spin mx-auto mb-4" />
-          <p className="text-gray-500">Loading content...</p>
-        </div>
-      </div>
-    );
-  }
-  
-  // Use loaded content or fallback
-  const currentContent = content || fallbackContent;
-  const creatorSteps = currentContent.creatorSteps || [];
-  const investorSteps = currentContent.investorSteps || [];
-  const productionSteps = currentContent.productionSteps || [];
-  const features = currentContent.features || [];
-  const stats = currentContent.stats || [];
+  // Merge optional CMS content over the local defaults; pull real platform stats.
+  useEffect(() => {
+    (async () => {
+      try {
+        const [hiw, statsRes] = await Promise.all([
+          contentService.getHowItWorks(),
+          contentService.getStats(),
+        ]);
+
+        if (hiw.success && hiw.data) {
+          const d: any = hiw.data;
+          const mergeSteps = (base: Step[], incoming?: Step[]) =>
+            Array.isArray(incoming) && incoming.length
+              ? base.map((s, i) => ({ ...s, ...(incoming[i] || {}) }))
+              : base;
+          setTracks((prev) => prev.map((t) => {
+            const key = t.id === 'creator' ? d.creatorSteps : t.id === 'investor' ? d.investorSteps : d.productionSteps;
+            return { ...t, steps: mergeSteps(t.steps, key) };
+          }));
+          if (Array.isArray(d.features) && d.features.length) setFeatures(d.features);
+        }
+
+        if (statsRes.success && statsRes.data) {
+          const s: any = statsRes.data;
+          const tiles = [
+            { value: fmtCount(Number(s.total_users) || 0), label: 'Members' },
+            { value: fmtCount(Number(s.published_pitches) || 0), label: 'Live pitches' },
+            { value: fmtCount(Number(s.total_pitches) || 0), label: 'Pitches created' },
+            { value: fmtMoney(Number(s.total_invested) || 0), label: 'Capital tracked' },
+          ];
+          // Only surface the strip if the platform actually has data — never fake numbers.
+          if (tiles.some((t) => t.value !== '0' && t.value !== '$0')) setStats(tiles);
+        }
+      } catch {
+        /* defaults already in state */
+      }
+    })();
+  }, []);
+
+  const navLinks = [
+    { label: 'Browse Pitches', to: '/marketplace' },
+    { label: 'Opportunities', to: '/opportunities' },
+    { label: 'How It Works', to: '/how-it-works' },
+    { label: 'About', to: '/about' },
+  ];
+  const track = tracks[activeRole];
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-gray-50 via-purple-50 to-white">
-      {/* Header */}
-      <header className="bg-white/80 backdrop-blur-sm shadow-sm border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
-          <div className="flex items-center gap-4">
+    <div className="min-h-screen bg-[#0d0a18] text-white">
+      {/* ===================== Header (scroll-aware, matches Homepage) ===================== */}
+      <header className={`sticky top-0 z-50 transition-colors duration-300 ${
+        scrolled
+          ? 'bg-white/95 backdrop-blur-md border-b border-gray-200 shadow-sm'
+          : mobileMenuOpen ? 'bg-[#1f1934] border-b border-white/10' : 'bg-[#0a0a12]/70 backdrop-blur-md border-b border-white/5'
+      }`}>
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between h-16">
+            <div className="flex items-center gap-8">
+              <a href="/" className="flex items-center">
+                <img src={scrolled ? '/pitchey-logotype.png' : '/pitchey-logotype-white.png'} alt="Pitchey" className="h-8 w-auto" />
+              </a>
+              <nav className="hidden md:flex items-center gap-6">
+                {navLinks.map((l) => {
+                  const active = l.to === '/how-it-works';
+                  return (
+                    <button
+                      key={l.to}
+                      onClick={() => navigate(l.to)}
+                      className={`text-nav-link transition ${
+                        scrolled
+                          ? active ? 'text-purple-700 font-semibold' : 'hover:text-purple-600'
+                          : active ? 'text-white font-semibold' : 'text-white/90 hover:text-white'
+                      }`}
+                    >
+                      {l.label}
+                    </button>
+                  );
+                })}
+              </nav>
+            </div>
+            <div className="hidden md:flex items-center gap-4">
+              {isAuthenticated && user ? (
+                <>
+                  <button
+                    onClick={() => navigate(userType ? `/${getPortalPath(userType)}/dashboard` : '/login')}
+                    className="text-button px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition"
+                  >
+                    Dashboard
+                  </button>
+                  <button
+                    onClick={async () => { await logout(); navigate('/'); }}
+                    className={`text-button px-3 py-2 transition ${scrolled ? 'text-gray-500 hover:text-red-600' : 'text-white/70 hover:text-white'}`}
+                    title="Sign Out"
+                  >
+                    <LogOut className="w-4 h-4" />
+                  </button>
+                </>
+              ) : (
+                <>
+                  <button
+                    onClick={() => navigate('/login')}
+                    className={`text-button px-4 py-2 transition ${scrolled ? 'text-purple-600 hover:text-purple-700' : 'text-white hover:text-white/80'}`}
+                  >
+                    Sign In
+                  </button>
+                  <button
+                    onClick={() => navigate('/register')}
+                    className="text-button px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition"
+                  >
+                    Get Started
+                  </button>
+                </>
+              )}
+            </div>
             <button
-              onClick={() => navigate('/')}
-              className="p-2 hover:bg-gray-100 rounded-lg transition"
+              onClick={() => setMobileMenuOpen((o) => !o)}
+              aria-label="Toggle navigation menu"
+              aria-expanded={mobileMenuOpen}
+              className={`md:hidden inline-flex items-center justify-center p-2 rounded-lg transition ${scrolled ? 'text-gray-700 hover:bg-gray-100' : 'text-white hover:bg-white/10'}`}
             >
-              <ArrowLeft className="w-5 h-5 text-gray-700" />
+              {mobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
             </button>
-            <img src="/pitchey-logotype.png" alt="Pitchey" className="h-7 w-auto" />
-            <h1 className="text-2xl font-bold text-gray-900">How It Works</h1>
           </div>
-          <button
-            onClick={() => navigate('/register')}
-            className="px-6 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition"
-          >
-            Get Started
-          </button>
         </div>
+        {mobileMenuOpen && (
+          <div className={`md:hidden border-t ${scrolled ? 'bg-white border-gray-200' : 'bg-[#1f1934] border-white/10'}`}>
+            <div className="max-w-7xl mx-auto px-4 py-3 flex flex-col gap-1">
+              {navLinks.map((item) => (
+                <button
+                  key={item.to}
+                  onClick={() => { setMobileMenuOpen(false); navigate(item.to); }}
+                  className={`text-left px-3 py-2.5 rounded-lg text-sm font-medium transition ${scrolled ? 'text-gray-700 hover:bg-gray-100' : 'text-white/90 hover:bg-white/10'}`}
+                >
+                  {item.label}
+                </button>
+              ))}
+              <div className={`my-2 border-t ${scrolled ? 'border-gray-200' : 'border-white/10'}`} />
+              <button
+                onClick={() => { setMobileMenuOpen(false); navigate(isAuthenticated && userType ? `/${getPortalPath(userType)}/dashboard` : '/register'); }}
+                className="px-3 py-2.5 rounded-lg bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-sm font-semibold text-center shadow-lg shadow-purple-500/30 hover:from-purple-500 hover:to-indigo-500 transition"
+              >
+                {isAuthenticated ? 'Dashboard' : 'Get Started'}
+              </button>
+            </div>
+          </div>
+        )}
       </header>
 
-      {/* Hero Section */}
-      <section className="py-20 text-center">
-        <div className="max-w-4xl mx-auto px-4">
-          {error && (
-            <div className="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg text-yellow-800 text-sm">
-              {error}
+      {/* ===================== Hero — "Premiere Night" ===================== */}
+      <section ref={heroRef} className="relative -mt-16 overflow-hidden bg-gradient-to-b from-[#3a2f5c] via-[#2c2547] to-[#1f1934]">
+        <div aria-hidden className="absolute -top-48 left-1/2 -translate-x-1/2 w-[64rem] h-[44rem] rounded-full blur-[80px] bg-[radial-gradient(ellipse_at_center,rgba(132,45,168,0.45),transparent_62%)]" />
+        <div aria-hidden className="absolute top-1/4 -right-24 w-[34rem] h-[34rem] rounded-full blur-[90px] bg-[radial-gradient(circle,rgba(245,158,11,0.18),transparent_60%)]" />
+        <div aria-hidden className="absolute -bottom-32 -left-24 w-[34rem] h-[34rem] rounded-full blur-[90px] bg-[radial-gradient(circle,rgba(91,79,199,0.22),transparent_60%)]" />
+        <div
+          aria-hidden
+          className="absolute inset-0 opacity-[0.06] mix-blend-overlay pointer-events-none"
+          style={{ backgroundImage: "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")" }}
+        />
+        <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/15 to-transparent" />
+        <div aria-hidden className="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
+        <div aria-hidden className="floating-decoration absolute top-20 left-10 opacity-[0.10] animate-float"><Film className="w-24 h-24 text-white" /></div>
+        <div aria-hidden className="floating-decoration absolute bottom-16 right-12 opacity-[0.10] animate-float-delayed"><Clapperboard className="w-28 h-28 text-white" /></div>
+
+        <div className="relative max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-36 pb-24 lg:pt-44 lg:pb-32 text-center">
+          <div className="inline-flex items-center gap-2.5 px-3 py-1 mb-8 rounded-full border border-white/15 bg-white/5 backdrop-blur text-[11px] font-medium tracking-[0.2em] uppercase text-white/70">
+            <span className="w-1.5 h-1.5 rounded-full bg-violet-400" />
+            How Pitchey works
+          </div>
+          <h1 className="font-display font-black tracking-tight leading-[0.95] text-4xl sm:text-6xl lg:text-7xl mb-6">
+            From a single page
+            <br />
+            <span className="inline-block font-semibold bg-gradient-to-r from-violet-300 via-fuchsia-300 to-purple-300 bg-clip-text text-transparent">
+              to the big screen
+            </span>
+          </h1>
+          <p className="max-w-2xl mx-auto text-lg sm:text-xl leading-relaxed text-white/80 mb-10">
+            Pitchey connects creators, investors and production companies through a secure,
+            transparent marketplace — built so great stories get found, protected, and made.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <button
+              onClick={() => navigate('/register')}
+              className="inline-flex items-center justify-center gap-2 px-7 py-3.5 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white font-semibold shadow-lg shadow-purple-500/30 transition hover:from-purple-500 hover:to-indigo-500"
+            >
+              <Sparkles className="w-5 h-5" />
+              Start your journey
+            </button>
+            <button
+              onClick={() => navigate('/marketplace')}
+              className="inline-flex items-center justify-center gap-2 px-7 py-3.5 rounded-xl border border-white/20 text-white transition hover:bg-white/10"
+            >
+              <Play className="w-5 h-5" />
+              Browse pitches
+            </button>
+          </div>
+
+          {/* Real platform stats — only rendered when the API returns non-zero data. */}
+          {stats.length > 0 && (
+            <div className="mt-16 grid grid-cols-2 sm:grid-cols-4 gap-px rounded-2xl overflow-hidden border border-white/10 bg-white/[0.04] backdrop-blur">
+              {stats.map((s, i) => (
+                <div key={i} className="px-4 py-5 bg-white/[0.02]">
+                  <div className="font-display text-3xl sm:text-4xl font-bold text-white">{s.value}</div>
+                  <div className="mt-1 text-[11px] uppercase tracking-[0.16em] text-white/50">{s.label}</div>
+                </div>
+              ))}
             </div>
           )}
-          <h2 className="text-5xl font-bold text-gray-900 mb-6">
-            {currentContent.hero?.title || "Transform Your Ideas Into Reality"}
-          </h2>
-          <p className="text-xl text-gray-600 mb-8">
-            {currentContent.hero?.subtitle || "Pitchey connects visionary creators with forward-thinking investors through a secure, transparent marketplace designed for the entertainment industry."}
+        </div>
+      </section>
+
+      {/* ===================== Role tracks (tabbed) ===================== */}
+      <section className="relative bg-[#0d0a18] py-24 overflow-hidden">
+        <div aria-hidden className="absolute inset-0 opacity-[0.4]" style={{ background: `radial-gradient(60% 50% at 50% 0%, ${track.glow}, transparent 70%)` }} />
+        <div className="relative max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <Reveal className="text-center mb-12">
+            <p className="text-[11px] uppercase tracking-[0.22em] text-white/40 mb-3">Choose your path</p>
+            <h2 className="font-display text-4xl sm:text-5xl font-bold">Built for every side of the table</h2>
+          </Reveal>
+
+          {/* Tab switcher */}
+          <div className="flex justify-center mb-14">
+            <div className="inline-flex p-1 rounded-full border border-white/10 bg-white/[0.04] backdrop-blur">
+              {tracks.map((t, i) => {
+                const on = i === activeRole;
+                return (
+                  <button
+                    key={t.id}
+                    onClick={() => setActiveRole(i)}
+                    className={`relative px-5 sm:px-7 py-2.5 rounded-full text-sm font-semibold transition ${on ? 'text-white' : 'text-white/50 hover:text-white/80'}`}
+                    style={on ? { backgroundColor: t.accent, boxShadow: `0 8px 30px -8px ${t.glow}` } : undefined}
+                  >
+                    {t.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="grid lg:grid-cols-12 gap-10 lg:gap-14 items-start">
+            {/* Left: role framing */}
+            <Reveal key={`framing-${track.id}`} className="lg:col-span-4 lg:sticky lg:top-28">
+              <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-semibold mb-5" style={{ color: track.accent, backgroundColor: `${track.accent}1a` }}>
+                <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: track.accent }} />
+                For {track.label}
+              </div>
+              <h3 className="font-display text-3xl sm:text-4xl font-bold leading-tight mb-5">{track.tagline}</h3>
+              <p className="text-white/60 leading-relaxed mb-8">{track.outcome}</p>
+              <button
+                onClick={() => navigate('/register')}
+                className="inline-flex items-center gap-2 px-6 py-3 rounded-xl font-semibold text-white transition hover:brightness-110"
+                style={{ backgroundColor: track.accent, boxShadow: `0 10px 30px -10px ${track.glow}` }}
+              >
+                Join as {track.label.replace(/s$/, '')}
+                <ArrowRight className="w-4 h-4" />
+              </button>
+            </Reveal>
+
+            {/* Right: numbered timeline */}
+            <div className="lg:col-span-8 relative">
+              <div aria-hidden className="absolute left-[27px] top-4 bottom-4 w-px bg-gradient-to-b from-white/20 via-white/10 to-transparent" />
+              <div className="space-y-5">
+                {track.steps.map((step, i) => (
+                  <Reveal key={`${track.id}-${i}`} delay={i * 90}>
+                    <div className="group relative flex gap-5 rounded-2xl border border-white/10 bg-white/[0.03] p-5 sm:p-6 transition hover:border-white/20 hover:bg-white/[0.05]">
+                      <div className="relative flex-shrink-0">
+                        <div
+                          className="w-14 h-14 rounded-xl flex items-center justify-center text-white transition group-hover:scale-105"
+                          style={{ backgroundColor: `${track.accent}26`, color: track.accent }}
+                        >
+                          <Icon name={step.icon} className="w-7 h-7" />
+                        </div>
+                        <span
+                          className="absolute -top-2 -left-2 w-6 h-6 rounded-full flex items-center justify-center text-[11px] font-bold text-white"
+                          style={{ backgroundColor: track.accent }}
+                        >
+                          {i + 1}
+                        </span>
+                      </div>
+                      <div className="pt-1">
+                        <h4 className="text-lg font-semibold text-white mb-1.5">{step.title}</h4>
+                        <p className="text-sm text-white/55 leading-relaxed">{step.description}</p>
+                      </div>
+                    </div>
+                  </Reveal>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ===================== Why Pitchey (features) ===================== */}
+      <section className="relative bg-gradient-to-b from-stone-50 via-white to-stone-50 text-gray-900 py-24 border-y border-black/5">
+        <div aria-hidden className="absolute inset-0 bg-[radial-gradient(55%_45%_at_50%_0%,rgba(132,45,168,0.06),transparent_60%)]" />
+        <div className="relative max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <Reveal className="text-center mb-14">
+            <p className="text-[11px] uppercase tracking-[0.22em] text-purple-700/70 mb-3">Why Pitchey</p>
+            <h2 className="font-display text-4xl sm:text-5xl font-bold text-gray-900">The infrastructure behind the deal</h2>
+            <p className="mt-4 text-gray-500 max-w-2xl mx-auto">Everything that makes discovery fair, materials safe, and conversations land with the right people.</p>
+          </Reveal>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
+            {features.map((f, i) => (
+              <Reveal key={i} delay={(i % 3) * 80}>
+                <div className="h-full rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition hover:shadow-md hover:-translate-y-0.5">
+                  <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-purple-600 to-indigo-600 text-white flex items-center justify-center mb-4 shadow-lg shadow-purple-500/20">
+                    <Icon name={f.icon} className="w-6 h-6" />
+                  </div>
+                  <h4 className="text-lg font-semibold text-gray-900 mb-2">{f.title}</h4>
+                  <p className="text-sm text-gray-500 leading-relaxed">{f.description}</p>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ===================== FAQ ===================== */}
+      <section className="bg-[#0d0a18] py-24">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <Reveal className="text-center mb-12">
+            <p className="text-[11px] uppercase tracking-[0.22em] text-white/40 mb-3">Questions</p>
+            <h2 className="font-display text-4xl sm:text-5xl font-bold">Good to know</h2>
+          </Reveal>
+          <div className="space-y-3">
+            {FAQS.map((item, i) => {
+              const open = openFaq === i;
+              return (
+                <Reveal key={i} delay={i * 50}>
+                  <div className={`rounded-2xl border transition ${open ? 'border-white/20 bg-white/[0.05]' : 'border-white/10 bg-white/[0.03]'}`}>
+                    <button
+                      onClick={() => setOpenFaq(open ? null : i)}
+                      aria-expanded={open}
+                      className="w-full flex items-center justify-between gap-4 text-left px-5 sm:px-6 py-5"
+                    >
+                      <span className="font-semibold text-white">{item.q}</span>
+                      <ChevronDown className={`w-5 h-5 flex-shrink-0 text-white/50 transition-transform duration-300 ${open ? 'rotate-180' : ''}`} />
+                    </button>
+                    <div className={`grid transition-all duration-300 ease-out ${open ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'}`}>
+                      <div className="overflow-hidden">
+                        <p className="px-5 sm:px-6 pb-5 text-sm text-white/55 leading-relaxed">{item.a}</p>
+                      </div>
+                    </div>
+                  </div>
+                </Reveal>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* ===================== CTA ===================== */}
+      <section className="relative overflow-hidden bg-gradient-to-br from-[#3a2f5c] via-[#2c2547] to-[#1f1934] py-24">
+        <div aria-hidden className="absolute -top-40 left-1/2 -translate-x-1/2 w-[60rem] h-[40rem] rounded-full blur-[90px] bg-[radial-gradient(ellipse_at_center,rgba(132,45,168,0.45),transparent_62%)]" />
+        <div className="relative max-w-4xl mx-auto px-4 text-center">
+          <h2 className="font-display text-4xl sm:text-5xl font-bold mb-5">Ready when you are</h2>
+          <p className="text-lg text-white/70 mb-10 max-w-2xl mx-auto">
+            Join the creators, investors and studios shaping what gets made next.
           </p>
-          <div className="flex justify-center gap-4">
+          <div className="flex flex-col sm:flex-row justify-center gap-3">
             <button
               onClick={() => navigate('/register')}
-              className="px-8 py-3 bg-purple-600 text-white rounded-lg hover:bg-purple-700 hover:shadow-lg transition"
+              className="inline-flex items-center justify-center gap-2 px-8 py-3.5 rounded-xl bg-white text-purple-800 font-semibold transition hover:bg-purple-50"
             >
-              Start Your Journey
+              <Users className="w-5 h-5" />
+              Create your account
             </button>
             <button
               onClick={() => navigate('/marketplace')}
-              className="px-8 py-3 bg-white border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition"
+              className="inline-flex items-center justify-center gap-2 px-8 py-3.5 rounded-xl border border-white/25 text-white transition hover:bg-white/10"
             >
-              Browse Marketplace
+              <Film className="w-5 h-5" />
+              Explore the marketplace
             </button>
           </div>
         </div>
       </section>
 
-      {/* For Creators Section */}
-      <section className="py-16 px-4">
-        <div className="max-w-6xl mx-auto">
-          <div className="text-center mb-12">
-            <h3 className="text-3xl font-bold text-gray-900 mb-4">For Creators</h3>
-            <p className="text-gray-600">Turn your screenplay into your next production</p>
-          </div>
-          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {creatorSteps.map((step, index) => (
-              <div key={index} className="relative">
-                {index < creatorSteps.length - 1 && (
-                  <div className="hidden lg:block absolute top-12 left-full w-full h-0.5 bg-gradient-to-r from-purple-300 to-transparent z-0" />
-                )}
-                <div className="bg-white rounded-xl p-6 border border-purple-200 shadow-sm hover:shadow-md hover:border-purple-300 transition relative z-10">
-                  <div className="text-purple-600 mb-4">{renderIcon(step.icon, 'w-8 h-8')}</div>
-                  <h4 className="text-xl font-semibold text-gray-900 mb-2">{step.title}</h4>
-                  <p className="text-gray-500 text-sm">{step.description}</p>
-                  <div className="absolute -top-3 -right-3 w-8 h-8 bg-purple-600 rounded-full flex items-center justify-center text-white font-bold">
-                    {index + 1}
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* For Investors Section */}
-      <section className="py-16 px-4 bg-gray-50">
-        <div className="max-w-6xl mx-auto">
-          <div className="text-center mb-12">
-            <h3 className="text-3xl font-bold text-gray-900 mb-4">For Investors</h3>
-            <p className="text-gray-600">Discover the next blockbuster before anyone else</p>
-          </div>
-          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {investorSteps.map((step, index) => (
-              <div key={index} className="relative">
-                {index < investorSteps.length - 1 && (
-                  <div className="hidden lg:block absolute top-12 left-full w-full h-0.5 bg-gradient-to-r from-green-300 to-transparent z-0" />
-                )}
-                <div className="bg-white rounded-xl p-6 border border-green-200 shadow-sm hover:shadow-md hover:border-green-300 transition relative z-10">
-                  <div className="text-green-600 mb-4">{renderIcon(step.icon, 'w-8 h-8')}</div>
-                  <h4 className="text-xl font-semibold text-gray-900 mb-2">{step.title}</h4>
-                  <p className="text-gray-500 text-sm">{step.description}</p>
-                  <div className="absolute -top-3 -right-3 w-8 h-8 bg-green-600 rounded-full flex items-center justify-center text-white font-bold">
-                    {index + 1}
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* For Production Companies Section */}
-      <section className="py-16 px-4">
-        <div className="max-w-6xl mx-auto">
-          <div className="text-center mb-12">
-            <h3 className="text-3xl font-bold text-gray-900 mb-4">For Production Companies</h3>
-            <p className="text-gray-600">Find, secure, and produce your next slate</p>
-          </div>
-          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {productionSteps.map((step, index) => (
-              <div key={index} className="relative">
-                {index < productionSteps.length - 1 && (
-                  <div className="hidden lg:block absolute top-12 left-full w-full h-0.5 bg-gradient-to-r from-blue-300 to-transparent z-0" />
-                )}
-                <div className="bg-white rounded-xl p-6 border border-blue-200 shadow-sm hover:shadow-md hover:border-blue-300 transition relative z-10">
-                  <div className="text-blue-600 mb-4">{renderIcon(step.icon, 'w-8 h-8')}</div>
-                  <h4 className="text-xl font-semibold text-gray-900 mb-2">{step.title}</h4>
-                  <p className="text-gray-500 text-sm">{step.description}</p>
-                  <div className="absolute -top-3 -right-3 w-8 h-8 bg-blue-600 rounded-full flex items-center justify-center text-white font-bold">
-                    {index + 1}
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Key Features */}
-      <section className="py-16 px-4 bg-gray-50">
-        <div className="max-w-6xl mx-auto">
-          <div className="text-center mb-12">
-            <h3 className="text-3xl font-bold text-gray-900 mb-4">Why Choose Pitchey?</h3>
-            <p className="text-gray-600">Industry-leading features for modern content creation</p>
-          </div>
-          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {features.map((feature, index) => (
-              <div key={index} className="bg-white rounded-xl p-6 border border-amber-200 shadow-sm hover:shadow-md hover:border-amber-300 transition">
-                <div className="text-amber-600 mb-4">{renderIcon(feature.icon, 'w-6 h-6')}</div>
-                <h4 className="text-lg font-semibold text-gray-900 mb-2">{feature.title}</h4>
-                <p className="text-gray-500 text-sm">{feature.description}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-
-      {/* CTA Section */}
-      <section className="py-20 text-center bg-gradient-to-br from-purple-700 via-purple-600 to-indigo-700 text-white">
-        <div className="max-w-4xl mx-auto px-4">
-          <h2 className="text-4xl font-bold mb-6">
-            Ready to Start Your Journey?
-          </h2>
-          <p className="text-xl text-purple-100 mb-8">
-            Join thousands of creators and investors transforming the entertainment industry
-          </p>
-          <div className="flex flex-col sm:flex-row justify-center gap-4">
-            <button
-              onClick={() => navigate('/register')}
-              className="px-8 py-3 bg-white text-purple-700 font-semibold rounded-lg hover:bg-purple-50 hover:shadow-lg transition"
-            >
-              <Users className="inline w-5 h-5 mr-2" />
-              Create Account
-            </button>
-            <button
-              onClick={() => navigate('/marketplace')}
-              className="px-8 py-3 bg-white/10 backdrop-blur-md border border-white/30 text-white rounded-lg hover:bg-white/20 transition"
-            >
-              <Film className="inline w-5 h-5 mr-2" />
-              Explore Marketplace
-            </button>
-          </div>
-        </div>
-      </section>
-
-      {/* Footer */}
-      <footer className="bg-white border-t border-gray-200 py-8">
-        <div className="max-w-6xl mx-auto px-4 text-center">
-          <p className="text-gray-500">
-            Have questions? Contact us at{' '}
-            <a href="mailto:support@pitchey.com" className="text-purple-600 hover:text-purple-700">
-              support@pitchey.com
-            </a>
+      {/* ===================== Footer ===================== */}
+      <footer className="bg-[#0a0a12] border-t border-white/10 py-10">
+        <div className="max-w-6xl mx-auto px-4 flex flex-col sm:flex-row items-center justify-between gap-4">
+          <img src="/pitchey-logotype-white.png" alt="Pitchey" className="h-6 w-auto opacity-80" />
+          <p className="text-sm text-white/40">
+            Have questions? Reach us at{' '}
+            <a href="mailto:support@pitchey.com" className="text-violet-300 hover:text-violet-200 transition">support@pitchey.com</a>
           </p>
         </div>
       </footer>

--- a/frontend/src/pages/HowItWorks.tsx
+++ b/frontend/src/pages/HowItWorks.tsx
@@ -2,11 +2,10 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   ArrowRight, Film, Users, DollarSign, Shield, TrendingUp, Star, Zap, Target, Award,
-  Sparkles, Play, Menu, X, ChevronDown, Search, MessageSquare, Eye, Lock, BadgeCheck,
-  Clapperboard, Handshake, Flame, LogOut,
+  Sparkles, Play, ChevronDown, Search, MessageSquare, Eye, Lock, BadgeCheck,
+  Clapperboard, Handshake, Flame,
 } from 'lucide-react';
-import { useBetterAuthStore } from '../store/betterAuthStore';
-import { getPortalPath } from '@/utils/navigation';
+import PublicTopNav from '@shared/components/layout/PublicTopNav';
 import { contentService } from '../services/content.service';
 
 // ---------------------------------------------------------------------------
@@ -138,9 +137,6 @@ const fmtCount = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}K` : `${n}
 
 const HowItWorks: React.FC = () => {
   const navigate = useNavigate();
-  const { isAuthenticated, user, logout } = useBetterAuthStore();
-  const userType = user?.userType;
-
   const [tracks, setTracks] = useState<Track[]>(ROLE_TRACKS);
   const [features, setFeatures] = useState<Step[]>(FEATURES);
   const [stats, setStats] = useState<Array<{ value: string; label: string }>>([]);
@@ -148,18 +144,6 @@ const HowItWorks: React.FC = () => {
   const [openFaq, setOpenFaq] = useState<number | null>(0);
 
   const heroRef = useRef<HTMLElement>(null);
-  const [scrolled, setScrolled] = useState(false);
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-
-  useEffect(() => {
-    const onScroll = () => {
-      const bottom = heroRef.current?.getBoundingClientRect().bottom ?? 0;
-      setScrolled(bottom <= 64);
-    };
-    onScroll();
-    window.addEventListener('scroll', onScroll, { passive: true });
-    return () => window.removeEventListener('scroll', onScroll);
-  }, []);
 
   // Merge optional CMS content over the local defaults; pull real platform stats.
   useEffect(() => {
@@ -200,114 +184,11 @@ const HowItWorks: React.FC = () => {
     })();
   }, []);
 
-  const navLinks = [
-    { label: 'Browse Pitches', to: '/marketplace' },
-    { label: 'Opportunities', to: '/opportunities' },
-    { label: 'How It Works', to: '/how-it-works' },
-    { label: 'About', to: '/about' },
-  ];
   const track = tracks[activeRole];
 
   return (
     <div className="min-h-screen bg-[#0d0a18] text-white">
-      {/* ===================== Header (scroll-aware, matches Homepage) ===================== */}
-      <header className={`sticky top-0 z-50 transition-colors duration-300 ${
-        scrolled
-          ? 'bg-white/95 backdrop-blur-md border-b border-gray-200 shadow-sm'
-          : mobileMenuOpen ? 'bg-[#1f1934] border-b border-white/10' : 'bg-[#0a0a12]/70 backdrop-blur-md border-b border-white/5'
-      }`}>
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-16">
-            <div className="flex items-center gap-8">
-              <a href="/" className="flex items-center">
-                <img src={scrolled ? '/pitchey-logotype.png' : '/pitchey-logotype-white.png'} alt="Pitchey" className="h-8 w-auto" />
-              </a>
-              <nav className="hidden md:flex items-center gap-6">
-                {navLinks.map((l) => {
-                  const active = l.to === '/how-it-works';
-                  return (
-                    <button
-                      key={l.to}
-                      onClick={() => navigate(l.to)}
-                      className={`text-nav-link transition ${
-                        scrolled
-                          ? active ? 'text-purple-700 font-semibold' : 'hover:text-purple-600'
-                          : active ? 'text-white font-semibold' : 'text-white/90 hover:text-white'
-                      }`}
-                    >
-                      {l.label}
-                    </button>
-                  );
-                })}
-              </nav>
-            </div>
-            <div className="hidden md:flex items-center gap-4">
-              {isAuthenticated && user ? (
-                <>
-                  <button
-                    onClick={() => navigate(userType ? `/${getPortalPath(userType)}/dashboard` : '/login')}
-                    className="text-button px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition"
-                  >
-                    Dashboard
-                  </button>
-                  <button
-                    onClick={async () => { await logout(); navigate('/'); }}
-                    className={`text-button px-3 py-2 transition ${scrolled ? 'text-gray-500 hover:text-red-600' : 'text-white/70 hover:text-white'}`}
-                    title="Sign Out"
-                  >
-                    <LogOut className="w-4 h-4" />
-                  </button>
-                </>
-              ) : (
-                <>
-                  <button
-                    onClick={() => navigate('/login')}
-                    className={`text-button px-4 py-2 transition ${scrolled ? 'text-purple-600 hover:text-purple-700' : 'text-white hover:text-white/80'}`}
-                  >
-                    Sign In
-                  </button>
-                  <button
-                    onClick={() => navigate('/register')}
-                    className="text-button px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition"
-                  >
-                    Get Started
-                  </button>
-                </>
-              )}
-            </div>
-            <button
-              onClick={() => setMobileMenuOpen((o) => !o)}
-              aria-label="Toggle navigation menu"
-              aria-expanded={mobileMenuOpen}
-              className={`md:hidden inline-flex items-center justify-center p-2 rounded-lg transition ${scrolled ? 'text-gray-700 hover:bg-gray-100' : 'text-white hover:bg-white/10'}`}
-            >
-              {mobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
-            </button>
-          </div>
-        </div>
-        {mobileMenuOpen && (
-          <div className={`md:hidden border-t ${scrolled ? 'bg-white border-gray-200' : 'bg-[#1f1934] border-white/10'}`}>
-            <div className="max-w-7xl mx-auto px-4 py-3 flex flex-col gap-1">
-              {navLinks.map((item) => (
-                <button
-                  key={item.to}
-                  onClick={() => { setMobileMenuOpen(false); navigate(item.to); }}
-                  className={`text-left px-3 py-2.5 rounded-lg text-sm font-medium transition ${scrolled ? 'text-gray-700 hover:bg-gray-100' : 'text-white/90 hover:bg-white/10'}`}
-                >
-                  {item.label}
-                </button>
-              ))}
-              <div className={`my-2 border-t ${scrolled ? 'border-gray-200' : 'border-white/10'}`} />
-              <button
-                onClick={() => { setMobileMenuOpen(false); navigate(isAuthenticated && userType ? `/${getPortalPath(userType)}/dashboard` : '/register'); }}
-                className="px-3 py-2.5 rounded-lg bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-sm font-semibold text-center shadow-lg shadow-purple-500/30 hover:from-purple-500 hover:to-indigo-500 transition"
-              >
-                {isAuthenticated ? 'Dashboard' : 'Get Started'}
-              </button>
-            </div>
-          </div>
-        )}
-      </header>
+      <PublicTopNav variant="overlay" heroRef={heroRef} />
 
       {/* ===================== Hero — "Premiere Night" ===================== */}
       <section ref={heroRef} className="relative -mt-16 overflow-hidden bg-gradient-to-b from-[#3a2f5c] via-[#2c2547] to-[#1f1934]">

--- a/frontend/src/pages/HowItWorks.tsx
+++ b/frontend/src/pages/HowItWorks.tsx
@@ -143,8 +143,6 @@ const HowItWorks: React.FC = () => {
   const [activeRole, setActiveRole] = useState(0);
   const [openFaq, setOpenFaq] = useState<number | null>(0);
 
-  const heroRef = useRef<HTMLElement>(null);
-
   // Merge optional CMS content over the local defaults; pull real platform stats.
   useEffect(() => {
     (async () => {
@@ -187,37 +185,32 @@ const HowItWorks: React.FC = () => {
   const track = tracks[activeRole];
 
   return (
-    <div className="min-h-screen bg-[#0d0a18] text-white">
-      <PublicTopNav variant="overlay" heroRef={heroRef} />
+    <div className="min-h-screen bg-white text-gray-900">
+      <PublicTopNav variant="solid" />
 
-      {/* ===================== Hero — "Premiere Night" ===================== */}
-      <section ref={heroRef} className="relative -mt-16 overflow-hidden bg-gradient-to-b from-[#3a2f5c] via-[#2c2547] to-[#1f1934]">
-        <div aria-hidden className="absolute -top-48 left-1/2 -translate-x-1/2 w-[64rem] h-[44rem] rounded-full blur-[80px] bg-[radial-gradient(ellipse_at_center,rgba(132,45,168,0.45),transparent_62%)]" />
-        <div aria-hidden className="absolute top-1/4 -right-24 w-[34rem] h-[34rem] rounded-full blur-[90px] bg-[radial-gradient(circle,rgba(245,158,11,0.18),transparent_60%)]" />
-        <div aria-hidden className="absolute -bottom-32 -left-24 w-[34rem] h-[34rem] rounded-full blur-[90px] bg-[radial-gradient(circle,rgba(91,79,199,0.22),transparent_60%)]" />
-        <div
-          aria-hidden
-          className="absolute inset-0 opacity-[0.06] mix-blend-overlay pointer-events-none"
-          style={{ backgroundImage: "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")" }}
-        />
-        <div aria-hidden className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/15 to-transparent" />
-        <div aria-hidden className="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
-        <div aria-hidden className="floating-decoration absolute top-20 left-10 opacity-[0.10] animate-float"><Film className="w-24 h-24 text-white" /></div>
-        <div aria-hidden className="floating-decoration absolute bottom-16 right-12 opacity-[0.10] animate-float-delayed"><Clapperboard className="w-28 h-28 text-white" /></div>
+      {/* ===================== Hero — light & airy ===================== */}
+      <section className="relative overflow-hidden bg-gradient-to-b from-[#faf7ff] via-[#fdf9fb] to-white">
+        {/* Soft brand glows */}
+        <div aria-hidden className="absolute -top-40 left-1/2 -translate-x-1/2 w-[64rem] h-[40rem] rounded-full blur-[90px] bg-[radial-gradient(ellipse_at_center,rgba(132,45,168,0.12),transparent_65%)]" />
+        <div aria-hidden className="absolute top-10 -right-24 w-[30rem] h-[30rem] rounded-full blur-[90px] bg-[radial-gradient(circle,rgba(91,79,199,0.10),transparent_60%)]" />
+        <div aria-hidden className="absolute -bottom-24 -left-24 w-[30rem] h-[30rem] rounded-full blur-[90px] bg-[radial-gradient(circle,rgba(168,45,99,0.07),transparent_60%)]" />
+        {/* Faint film-strip decorations */}
+        <div aria-hidden className="absolute top-24 left-10 opacity-[0.05] animate-float"><Film className="w-24 h-24 text-purple-900" /></div>
+        <div aria-hidden className="absolute bottom-16 right-12 opacity-[0.05] animate-float-delayed"><Clapperboard className="w-28 h-28 text-purple-900" /></div>
 
-        <div className="relative max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-36 pb-24 lg:pt-44 lg:pb-32 text-center">
-          <div className="inline-flex items-center gap-2.5 px-3 py-1 mb-8 rounded-full border border-white/15 bg-white/5 backdrop-blur text-[11px] font-medium tracking-[0.2em] uppercase text-white/70">
-            <span className="w-1.5 h-1.5 rounded-full bg-violet-400" />
+        <div className="relative max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-24 lg:pt-28 lg:pb-32 text-center">
+          <div className="inline-flex items-center gap-2.5 px-3 py-1 mb-8 rounded-full border border-purple-200 bg-purple-50 text-[11px] font-medium tracking-[0.2em] uppercase text-purple-700">
+            <span className="w-1.5 h-1.5 rounded-full bg-purple-500" />
             How Pitchey works
           </div>
-          <h1 className="font-display font-black tracking-tight leading-[0.95] text-4xl sm:text-6xl lg:text-7xl mb-6">
+          <h1 className="font-display font-black tracking-tight leading-[0.95] text-4xl sm:text-6xl lg:text-7xl mb-6 text-gray-900">
             From a single page
             <br />
-            <span className="inline-block font-semibold bg-gradient-to-r from-violet-300 via-fuchsia-300 to-purple-300 bg-clip-text text-transparent">
+            <span className="inline-block font-semibold bg-gradient-to-r from-purple-600 via-fuchsia-500 to-indigo-600 bg-clip-text text-transparent">
               to the big screen
             </span>
           </h1>
-          <p className="max-w-2xl mx-auto text-lg sm:text-xl leading-relaxed text-white/80 mb-10">
+          <p className="max-w-2xl mx-auto text-lg sm:text-xl leading-relaxed text-gray-600 mb-10">
             Pitchey connects creators, investors and production companies through a secure,
             transparent marketplace — built so great stories get found, protected, and made.
           </p>
@@ -231,7 +224,7 @@ const HowItWorks: React.FC = () => {
             </button>
             <button
               onClick={() => navigate('/marketplace')}
-              className="inline-flex items-center justify-center gap-2 px-7 py-3.5 rounded-xl border border-white/20 text-white transition hover:bg-white/10"
+              className="inline-flex items-center justify-center gap-2 px-7 py-3.5 rounded-xl border border-gray-300 text-gray-700 transition hover:border-purple-300 hover:text-purple-700 hover:bg-purple-50/50"
             >
               <Play className="w-5 h-5" />
               Browse pitches
@@ -240,11 +233,11 @@ const HowItWorks: React.FC = () => {
 
           {/* Real platform stats — only rendered when the API returns non-zero data. */}
           {stats.length > 0 && (
-            <div className="mt-16 grid grid-cols-2 sm:grid-cols-4 gap-px rounded-2xl overflow-hidden border border-white/10 bg-white/[0.04] backdrop-blur">
+            <div className="mt-16 grid grid-cols-2 sm:grid-cols-4 gap-px rounded-2xl overflow-hidden border border-gray-200 bg-gray-100 shadow-sm">
               {stats.map((s, i) => (
-                <div key={i} className="px-4 py-5 bg-white/[0.02]">
-                  <div className="font-display text-3xl sm:text-4xl font-bold text-white">{s.value}</div>
-                  <div className="mt-1 text-[11px] uppercase tracking-[0.16em] text-white/50">{s.label}</div>
+                <div key={i} className="px-4 py-5 bg-white">
+                  <div className="font-display text-3xl sm:text-4xl font-bold text-gray-900">{s.value}</div>
+                  <div className="mt-1 text-[11px] uppercase tracking-[0.16em] text-gray-400">{s.label}</div>
                 </div>
               ))}
             </div>
@@ -253,25 +246,25 @@ const HowItWorks: React.FC = () => {
       </section>
 
       {/* ===================== Role tracks (tabbed) ===================== */}
-      <section className="relative bg-[#0d0a18] py-24 overflow-hidden">
-        <div aria-hidden className="absolute inset-0 opacity-[0.4]" style={{ background: `radial-gradient(60% 50% at 50% 0%, ${track.glow}, transparent 70%)` }} />
+      <section className="relative bg-white py-24 overflow-hidden border-t border-gray-100">
+        <div aria-hidden className="absolute inset-0 opacity-90" style={{ background: `radial-gradient(55% 45% at 50% 0%, ${track.accent}12, transparent 70%)` }} />
         <div className="relative max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <Reveal className="text-center mb-12">
-            <p className="text-[11px] uppercase tracking-[0.22em] text-white/40 mb-3">Choose your path</p>
-            <h2 className="font-display text-4xl sm:text-5xl font-bold">Built for every side of the table</h2>
+            <p className="text-[11px] uppercase tracking-[0.22em] text-gray-400 mb-3">Choose your path</p>
+            <h2 className="font-display text-4xl sm:text-5xl font-bold text-gray-900">Built for every side of the table</h2>
           </Reveal>
 
           {/* Tab switcher */}
           <div className="flex justify-center mb-14">
-            <div className="inline-flex p-1 rounded-full border border-white/10 bg-white/[0.04] backdrop-blur">
+            <div className="inline-flex p-1 rounded-full border border-gray-200 bg-gray-100">
               {tracks.map((t, i) => {
                 const on = i === activeRole;
                 return (
                   <button
                     key={t.id}
                     onClick={() => setActiveRole(i)}
-                    className={`relative px-5 sm:px-7 py-2.5 rounded-full text-sm font-semibold transition ${on ? 'text-white' : 'text-white/50 hover:text-white/80'}`}
-                    style={on ? { backgroundColor: t.accent, boxShadow: `0 8px 30px -8px ${t.glow}` } : undefined}
+                    className={`relative px-5 sm:px-7 py-2.5 rounded-full text-sm font-semibold transition ${on ? 'text-white' : 'text-gray-500 hover:text-gray-800'}`}
+                    style={on ? { backgroundColor: t.accent, boxShadow: `0 8px 24px -10px ${t.accent}` } : undefined}
                   >
                     {t.label}
                   </button>
@@ -287,12 +280,12 @@ const HowItWorks: React.FC = () => {
                 <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: track.accent }} />
                 For {track.label}
               </div>
-              <h3 className="font-display text-3xl sm:text-4xl font-bold leading-tight mb-5">{track.tagline}</h3>
-              <p className="text-white/60 leading-relaxed mb-8">{track.outcome}</p>
+              <h3 className="font-display text-3xl sm:text-4xl font-bold leading-tight mb-5 text-gray-900">{track.tagline}</h3>
+              <p className="text-gray-600 leading-relaxed mb-8">{track.outcome}</p>
               <button
                 onClick={() => navigate('/register')}
                 className="inline-flex items-center gap-2 px-6 py-3 rounded-xl font-semibold text-white transition hover:brightness-110"
-                style={{ backgroundColor: track.accent, boxShadow: `0 10px 30px -10px ${track.glow}` }}
+                style={{ backgroundColor: track.accent, boxShadow: `0 10px 30px -12px ${track.accent}` }}
               >
                 Join as {track.label.replace(/s$/, '')}
                 <ArrowRight className="w-4 h-4" />
@@ -301,15 +294,15 @@ const HowItWorks: React.FC = () => {
 
             {/* Right: numbered timeline */}
             <div className="lg:col-span-8 relative">
-              <div aria-hidden className="absolute left-[27px] top-4 bottom-4 w-px bg-gradient-to-b from-white/20 via-white/10 to-transparent" />
+              <div aria-hidden className="absolute left-[27px] top-4 bottom-4 w-px bg-gradient-to-b from-gray-200 via-gray-200 to-transparent" />
               <div className="space-y-5">
                 {track.steps.map((step, i) => (
                   <Reveal key={`${track.id}-${i}`} delay={i * 90}>
-                    <div className="group relative flex gap-5 rounded-2xl border border-white/10 bg-white/[0.03] p-5 sm:p-6 transition hover:border-white/20 hover:bg-white/[0.05]">
+                    <div className="group relative flex gap-5 rounded-2xl border border-gray-200 bg-white p-5 sm:p-6 shadow-sm transition hover:border-gray-300 hover:shadow-md">
                       <div className="relative flex-shrink-0">
                         <div
-                          className="w-14 h-14 rounded-xl flex items-center justify-center text-white transition group-hover:scale-105"
-                          style={{ backgroundColor: `${track.accent}26`, color: track.accent }}
+                          className="w-14 h-14 rounded-xl flex items-center justify-center transition group-hover:scale-105"
+                          style={{ backgroundColor: `${track.accent}14`, color: track.accent }}
                         >
                           <Icon name={step.icon} className="w-7 h-7" />
                         </div>
@@ -321,8 +314,8 @@ const HowItWorks: React.FC = () => {
                         </span>
                       </div>
                       <div className="pt-1">
-                        <h4 className="text-lg font-semibold text-white mb-1.5">{step.title}</h4>
-                        <p className="text-sm text-white/55 leading-relaxed">{step.description}</p>
+                        <h4 className="text-lg font-semibold text-gray-900 mb-1.5">{step.title}</h4>
+                        <p className="text-sm text-gray-500 leading-relaxed">{step.description}</p>
                       </div>
                     </div>
                   </Reveal>
@@ -359,29 +352,29 @@ const HowItWorks: React.FC = () => {
       </section>
 
       {/* ===================== FAQ ===================== */}
-      <section className="bg-[#0d0a18] py-24">
+      <section className="bg-stone-50 py-24 border-t border-gray-100">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
           <Reveal className="text-center mb-12">
-            <p className="text-[11px] uppercase tracking-[0.22em] text-white/40 mb-3">Questions</p>
-            <h2 className="font-display text-4xl sm:text-5xl font-bold">Good to know</h2>
+            <p className="text-[11px] uppercase tracking-[0.22em] text-gray-400 mb-3">Questions</p>
+            <h2 className="font-display text-4xl sm:text-5xl font-bold text-gray-900">Good to know</h2>
           </Reveal>
           <div className="space-y-3">
             {FAQS.map((item, i) => {
               const open = openFaq === i;
               return (
                 <Reveal key={i} delay={i * 50}>
-                  <div className={`rounded-2xl border transition ${open ? 'border-white/20 bg-white/[0.05]' : 'border-white/10 bg-white/[0.03]'}`}>
+                  <div className={`rounded-2xl border bg-white transition ${open ? 'border-purple-200 shadow-sm' : 'border-gray-200'}`}>
                     <button
                       onClick={() => setOpenFaq(open ? null : i)}
                       aria-expanded={open}
                       className="w-full flex items-center justify-between gap-4 text-left px-5 sm:px-6 py-5"
                     >
-                      <span className="font-semibold text-white">{item.q}</span>
-                      <ChevronDown className={`w-5 h-5 flex-shrink-0 text-white/50 transition-transform duration-300 ${open ? 'rotate-180' : ''}`} />
+                      <span className="font-semibold text-gray-900">{item.q}</span>
+                      <ChevronDown className={`w-5 h-5 flex-shrink-0 transition-transform duration-300 ${open ? 'rotate-180 text-purple-600' : 'text-gray-400'}`} />
                     </button>
                     <div className={`grid transition-all duration-300 ease-out ${open ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'}`}>
                       <div className="overflow-hidden">
-                        <p className="px-5 sm:px-6 pb-5 text-sm text-white/55 leading-relaxed">{item.a}</p>
+                        <p className="px-5 sm:px-6 pb-5 text-sm text-gray-600 leading-relaxed">{item.a}</p>
                       </div>
                     </div>
                   </div>
@@ -393,24 +386,24 @@ const HowItWorks: React.FC = () => {
       </section>
 
       {/* ===================== CTA ===================== */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-[#3a2f5c] via-[#2c2547] to-[#1f1934] py-24">
-        <div aria-hidden className="absolute -top-40 left-1/2 -translate-x-1/2 w-[60rem] h-[40rem] rounded-full blur-[90px] bg-[radial-gradient(ellipse_at_center,rgba(132,45,168,0.45),transparent_62%)]" />
+      <section className="relative overflow-hidden bg-gradient-to-br from-purple-100 via-purple-50 to-indigo-100 py-24 border-t border-purple-100">
+        <div aria-hidden className="absolute -top-40 left-1/2 -translate-x-1/2 w-[60rem] h-[40rem] rounded-full blur-[90px] bg-[radial-gradient(ellipse_at_center,rgba(132,45,168,0.14),transparent_62%)]" />
         <div className="relative max-w-4xl mx-auto px-4 text-center">
-          <h2 className="font-display text-4xl sm:text-5xl font-bold mb-5">Ready when you are</h2>
-          <p className="text-lg text-white/70 mb-10 max-w-2xl mx-auto">
+          <h2 className="font-display text-4xl sm:text-5xl font-bold mb-5 text-gray-900">Ready when you are</h2>
+          <p className="text-lg text-gray-600 mb-10 max-w-2xl mx-auto">
             Join the creators, investors and studios shaping what gets made next.
           </p>
           <div className="flex flex-col sm:flex-row justify-center gap-3">
             <button
               onClick={() => navigate('/register')}
-              className="inline-flex items-center justify-center gap-2 px-8 py-3.5 rounded-xl bg-white text-purple-800 font-semibold transition hover:bg-purple-50"
+              className="inline-flex items-center justify-center gap-2 px-8 py-3.5 rounded-xl bg-purple-600 text-white font-semibold shadow-lg shadow-purple-500/30 transition hover:bg-purple-700"
             >
               <Users className="w-5 h-5" />
               Create your account
             </button>
             <button
               onClick={() => navigate('/marketplace')}
-              className="inline-flex items-center justify-center gap-2 px-8 py-3.5 rounded-xl border border-white/25 text-white transition hover:bg-white/10"
+              className="inline-flex items-center justify-center gap-2 px-8 py-3.5 rounded-xl border border-purple-300 text-purple-700 bg-white/60 transition hover:bg-white"
             >
               <Film className="w-5 h-5" />
               Explore the marketplace
@@ -420,12 +413,12 @@ const HowItWorks: React.FC = () => {
       </section>
 
       {/* ===================== Footer ===================== */}
-      <footer className="bg-[#0a0a12] border-t border-white/10 py-10">
+      <footer className="bg-white border-t border-gray-200 py-10">
         <div className="max-w-6xl mx-auto px-4 flex flex-col sm:flex-row items-center justify-between gap-4">
-          <img src="/pitchey-logotype-white.png" alt="Pitchey" className="h-6 w-auto opacity-80" />
-          <p className="text-sm text-white/40">
+          <img src="/pitchey-logotype.png" alt="Pitchey" className="h-6 w-auto opacity-80" />
+          <p className="text-sm text-gray-500">
             Have questions? Reach us at{' '}
-            <a href="mailto:support@pitchey.com" className="text-violet-300 hover:text-violet-200 transition">support@pitchey.com</a>
+            <a href="mailto:support@pitchey.com" className="text-purple-600 hover:text-purple-700 transition">support@pitchey.com</a>
           </p>
         </div>
       </footer>

--- a/frontend/src/pages/__tests__/About.test.tsx
+++ b/frontend/src/pages/__tests__/About.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import React from 'react'
 
@@ -26,13 +26,10 @@ vi.mock('../../services/content.service', () => ({
   },
 }))
 
-// ─── Logo component ─────────────────────────────────────────────────────
-vi.mock('../../components/Logo', () => ({
-  default: ({ onClick }: any) => (
-    <div data-testid="logo" onClick={onClick} role="button">
-      Pitchey
-    </div>
-  ),
+// ─── Auth store (used by the shared PublicTopNav) ───────────────────────
+const mockAuthState: any = { user: null, isAuthenticated: false, logout: vi.fn() }
+vi.mock('../../store/betterAuthStore', () => ({
+  useBetterAuthStore: () => mockAuthState,
 }))
 
 // ─── Component ─────────────────────────────────────────────────────────
@@ -107,24 +104,21 @@ describe('About', () => {
     })
   })
 
-  it('renders How It Works button', async () => {
+  it('exposes How It Works under the Learn dropdown', async () => {
     renderAbout()
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'How It Works' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Learn' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Learn' }))
+    await waitFor(() => {
+      expect(screen.getByRole('menuitem', { name: 'How It Works' })).toBeInTheDocument()
     })
   })
 
-  it('renders Back button in header', async () => {
+  it('renders the Pitchey logo in the nav', async () => {
     renderAbout()
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument()
-    })
-  })
-
-  it('renders logo', async () => {
-    renderAbout()
-    await waitFor(() => {
-      expect(screen.getByTestId('logo')).toBeInTheDocument()
+      expect(screen.getByAltText('Pitchey')).toBeInTheDocument()
     })
   })
 
@@ -177,21 +171,25 @@ describe('About', () => {
     expect(screen.getByText('About Pitchey')).toBeInTheDocument()
   })
 
-  it('navigates home when Get Started is clicked', async () => {
+  it('navigates to register when nav Get Started is clicked', async () => {
     renderAbout()
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Get Started' })).toBeInTheDocument()
     })
     screen.getByRole('button', { name: 'Get Started' }).click()
-    expect(mockNavigate).toHaveBeenCalledWith('/login')
+    expect(mockNavigate).toHaveBeenCalledWith('/register')
   })
 
-  it('navigates to how-it-works when How It Works is clicked', async () => {
+  it('navigates to how-it-works from the Learn dropdown', async () => {
     renderAbout()
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'How It Works' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Learn' })).toBeInTheDocument()
     })
-    screen.getByRole('button', { name: 'How It Works' }).click()
+    fireEvent.click(screen.getByRole('button', { name: 'Learn' }))
+    await waitFor(() => {
+      expect(screen.getByRole('menuitem', { name: 'How It Works' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('menuitem', { name: 'How It Works' }))
     expect(mockNavigate).toHaveBeenCalledWith('/how-it-works')
   })
 })

--- a/frontend/src/pages/__tests__/Homepage.test.tsx
+++ b/frontend/src/pages/__tests__/Homepage.test.tsx
@@ -138,8 +138,10 @@ describe('Homepage', () => {
   it('renders navigation links', () => {
     renderHomepage()
     expect(screen.getAllByRole('button', { name: 'Browse Pitches' }).length).toBeGreaterThan(0)
-    expect(screen.getByRole('button', { name: 'How It Works' })).toBeInTheDocument()
-    // "About" appears in both nav and footer
+    expect(screen.getAllByRole('button', { name: 'Opportunities' }).length).toBeGreaterThan(0)
+    // How It Works + About now live under the "Learn" dropdown
+    expect(screen.getByRole('button', { name: 'Learn' })).toBeInTheDocument()
+    // "About" still appears in the footer
     expect(screen.getAllByRole('button', { name: 'About' }).length).toBeGreaterThan(0)
   })
 

--- a/frontend/src/pages/__tests__/HowItWorks.test.tsx
+++ b/frontend/src/pages/__tests__/HowItWorks.test.tsx
@@ -64,10 +64,12 @@ describe('HowItWorks', () => {
     expect(screen.getByText('to the big screen')).toBeInTheDocument()
   })
 
-  it('renders the "How It Works" nav link and Get Started CTA in header', () => {
+  it('renders the shared public nav (Browse, Learn, Get Started)', () => {
     renderComponent()
-    expect(screen.getByText('How It Works')).toBeInTheDocument()
-    expect(screen.getByText('Get Started')).toBeInTheDocument()
+    // How It Works + About now live under the "Learn" dropdown (closed by default)
+    expect(screen.getByRole('button', { name: 'Browse Pitches' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Learn' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Get Started' })).toBeInTheDocument()
   })
 
   it('defaults to the Creators track and shows its tagline + first step', () => {

--- a/frontend/src/pages/__tests__/HowItWorks.test.tsx
+++ b/frontend/src/pages/__tests__/HowItWorks.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import React from 'react'
 
@@ -15,6 +15,13 @@ vi.mock('react-router-dom', async () => {
     Link: ({ to, children, ...props }: any) => <a href={to} {...props}>{children}</a>,
   }
 })
+
+// ─── Auth store ─────────────────────────────────────────────────────
+const mockUser = { id: 1, email: 'test@test.com', userType: 'creator', username: 'testuser' }
+const mockAuthState: any = { user: mockUser, isAuthenticated: false, logout: vi.fn() }
+vi.mock('../../store/betterAuthStore', () => ({
+  useBetterAuthStore: () => mockAuthState,
+}))
 
 // ─── Content service ─────────────────────────────────────────────────
 const mockGetHowItWorks = vi.fn()
@@ -37,7 +44,9 @@ beforeAll(async () => {
 describe('HowItWorks', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // Default: API fails gracefully, fallback content is used
+    mockAuthState.isAuthenticated = false
+    mockAuthState.user = mockUser
+    // Default: API fails gracefully, local default content is used
     mockGetHowItWorks.mockResolvedValue({ success: false, error: 'API unavailable' })
     mockGetStats.mockResolvedValue({ success: false, error: 'API unavailable' })
   })
@@ -49,157 +58,124 @@ describe('HowItWorks', () => {
       </MemoryRouter>
     )
 
-  it('shows loading state initially', () => {
-    let resolve: any
-    mockGetHowItWorks.mockReturnValue(new Promise(r => { resolve = r }))
+  it('renders the cinematic hero heading', async () => {
     renderComponent()
-    expect(screen.getByText('Loading content...')).toBeInTheDocument()
-    resolve({ success: false })
+    expect(screen.getByText('From a single page')).toBeInTheDocument()
+    expect(screen.getByText('to the big screen')).toBeInTheDocument()
   })
 
-  it('renders "How It Works" heading after loading', async () => {
+  it('renders the "How It Works" nav link and Get Started CTA in header', () => {
     renderComponent()
+    expect(screen.getByText('How It Works')).toBeInTheDocument()
+    expect(screen.getByText('Get Started')).toBeInTheDocument()
+  })
+
+  it('defaults to the Creators track and shows its tagline + first step', () => {
+    renderComponent()
+    expect(screen.getByText('Turn a screenplay into your next production.')).toBeInTheDocument()
+    expect(screen.getByText('Build your pitch')).toBeInTheDocument()
+  })
+
+  it('switches to the Investors track when its tab is clicked', async () => {
+    renderComponent()
+    // Investor content is not rendered until the tab is active
+    expect(screen.queryByText('Browse curated pitches')).not.toBeInTheDocument()
+    // The tab pill in the switcher (button, not the nav)
+    fireEvent.click(screen.getByRole('button', { name: 'Investors' }))
     await waitFor(() => {
-      expect(screen.getByText('How It Works')).toBeInTheDocument()
+      expect(screen.getByText('Browse curated pitches')).toBeInTheDocument()
     })
   })
 
-  it('renders hero title from fallback content', async () => {
+  it('switches to the Production track when its tab is clicked', async () => {
     renderComponent()
+    fireEvent.click(screen.getByRole('button', { name: 'Production' }))
     await waitFor(() => {
-      expect(screen.getByText('Transform Your Ideas Into Reality')).toBeInTheDocument()
+      expect(screen.getByText('Stand up your slate')).toBeInTheDocument()
     })
   })
 
-  it('renders "For Creators" section heading', async () => {
+  it('renders the features section with default features', () => {
     renderComponent()
+    expect(screen.getByText('The infrastructure behind the deal')).toBeInTheDocument()
+    expect(screen.getByText('AI-assisted pitching')).toBeInTheDocument()
+    expect(screen.getByText('Heat Score discovery')).toBeInTheDocument()
+  })
+
+  it('renders the FAQ section with the first item open by default', () => {
+    renderComponent()
+    expect(screen.getByText('Good to know')).toBeInTheDocument()
+    expect(screen.getByText('Who can join Pitchey?')).toBeInTheDocument()
+    // First answer is expanded by default
+    expect(screen.getByText(/Creators pitching original work/)).toBeInTheDocument()
+  })
+
+  it('toggles a FAQ item open on click', async () => {
+    renderComponent()
+    fireEvent.click(screen.getByText('What does it cost?'))
     await waitFor(() => {
-      expect(screen.getByText('For Creators')).toBeInTheDocument()
+      expect(screen.getByText(/Browsing and building a profile is free/)).toBeInTheDocument()
     })
   })
 
-  it('renders "For Investors" section heading', async () => {
+  it('renders the CTA section', () => {
     renderComponent()
-    await waitFor(() => {
-      expect(screen.getByText('For Investors')).toBeInTheDocument()
-    })
+    expect(screen.getByText('Ready when you are')).toBeInTheDocument()
+    expect(screen.getByText('Create your account')).toBeInTheDocument()
   })
 
-  it('renders "Why Choose Pitchey?" section', async () => {
+  it('renders footer with contact email', () => {
     renderComponent()
-    await waitFor(() => {
-      expect(screen.getByText('Why Choose Pitchey?')).toBeInTheDocument()
-    })
+    expect(screen.getByText(/support@pitchey.com/)).toBeInTheDocument()
   })
 
-  it('renders creator steps from fallback content', async () => {
+  it('renders the Pitchey brand logo', () => {
     renderComponent()
-    await waitFor(() => {
-      expect(screen.getByText('Create Your Pitch')).toBeInTheDocument()
-      expect(screen.getByText('Protect Your Work')).toBeInTheDocument()
-      expect(screen.getByText('Connect with Investors')).toBeInTheDocument()
-      expect(screen.getByText('Secure Funding')).toBeInTheDocument()
-    })
+    // Logotype image(s) (alt="Pitchey") — header + footer
+    expect(screen.getAllByAltText('Pitchey').length).toBeGreaterThan(0)
   })
 
-  it('renders investor steps from fallback content', async () => {
-    renderComponent()
-    await waitFor(() => {
-      expect(screen.getByText('Browse Curated Content')).toBeInTheDocument()
-      expect(screen.getByText('Review Under NDA')).toBeInTheDocument()
-      expect(screen.getByText('Track Performance')).toBeInTheDocument()
-      expect(screen.getByText('Close Deals')).toBeInTheDocument()
-    })
-  })
-
-  it('renders key features from fallback content', async () => {
-    renderComponent()
-    await waitFor(() => {
-      expect(screen.getByText('AI-Powered Recommendations')).toBeInTheDocument()
-      expect(screen.getByText('Secure Platform')).toBeInTheDocument()
-      expect(screen.getByText('Quality Control')).toBeInTheDocument()
-      expect(screen.getByText('Direct Communication')).toBeInTheDocument()
-    })
-  })
-
-  it('renders Get Started button in header', async () => {
-    renderComponent()
-    await waitFor(() => {
-      expect(screen.getByText('Get Started')).toBeInTheDocument()
-    })
-  })
-
-  it('renders CTA section', async () => {
-    renderComponent()
-    await waitFor(() => {
-      expect(screen.getByText("Ready to Start Your Journey?")).toBeInTheDocument()
-    })
-  })
-
-  it('renders Create Account and Explore Marketplace buttons', async () => {
-    renderComponent()
-    await waitFor(() => {
-      expect(screen.getByText('Create Account')).toBeInTheDocument()
-      expect(screen.getByText('Explore Marketplace')).toBeInTheDocument()
-    })
-  })
-
-  it('renders Start Your Journey button', async () => {
-    renderComponent()
-    await waitFor(() => {
-      expect(screen.getByText('Start Your Journey')).toBeInTheDocument()
-    })
-  })
-
-  it('renders Browse Marketplace button in hero', async () => {
-    renderComponent()
-    await waitFor(() => {
-      expect(screen.getAllByText('Browse Marketplace').length).toBeGreaterThan(0)
-    })
-  })
-
-  it('renders footer with contact email', async () => {
-    renderComponent()
-    await waitFor(() => {
-      expect(screen.getByText(/support@pitchey.com/)).toBeInTheDocument()
-    })
-  })
-
-  it('shows error banner when API fails but still shows fallback content', async () => {
-    mockGetHowItWorks.mockRejectedValue(new Error('Network error'))
-    mockGetStats.mockRejectedValue(new Error('Network error'))
-
-    renderComponent()
-    await waitFor(() => {
-      expect(screen.getByText('Transform Your Ideas Into Reality')).toBeInTheDocument()
-    })
-    // Should still show the error warning
-    expect(screen.getByText(/Failed to load latest content/)).toBeInTheDocument()
-  })
-
-  it('uses API content when API call succeeds', async () => {
+  it('merges API step content over the local defaults', async () => {
     mockGetHowItWorks.mockResolvedValue({
       success: true,
       data: {
-        hero: { title: 'API Hero Title', subtitle: 'API subtitle' },
-        creatorSteps: [],
-        investorSteps: [],
-        features: [],
-      }
+        creatorSteps: [{ title: 'Custom Creator Step', description: 'From the CMS', icon: 'film' }],
+      },
     })
-    mockGetStats.mockResolvedValue({ success: false })
-
     renderComponent()
     await waitFor(() => {
-      expect(screen.getByText('API Hero Title')).toBeInTheDocument()
+      expect(screen.getByText('Custom Creator Step')).toBeInTheDocument()
     })
   })
 
-  it('renders Pitchey brand in header', async () => {
-    renderComponent()
-    // Brand mark is the logotype image (alt="Pitchey") after the 2026-05 logo rollout
-    await waitFor(() => {
-      expect(screen.getByAltText('Pitchey')).toBeInTheDocument()
+  it('renders real platform stats when the API returns non-zero data', async () => {
+    mockGetStats.mockResolvedValue({
+      success: true,
+      data: { total_users: 1200, published_pitches: 340, total_pitches: 980, total_invested: 5_000_000 },
     })
+    renderComponent()
+    await waitFor(() => {
+      expect(screen.getByText('Members')).toBeInTheDocument()
+      expect(screen.getByText('1.2K')).toBeInTheDocument()
+      expect(screen.getByText('$5M')).toBeInTheDocument()
+    })
+  })
+
+  it('hides the stats strip when the API returns all-zero data', async () => {
+    mockGetStats.mockResolvedValue({
+      success: true,
+      data: { total_users: 0, published_pitches: 0, total_pitches: 0, total_invested: 0 },
+    })
+    renderComponent()
+    // Give the effect a tick to resolve
+    await waitFor(() => expect(mockGetStats).toHaveBeenCalled())
+    expect(screen.queryByText('Members')).not.toBeInTheDocument()
+  })
+
+  it('shows Dashboard instead of Sign In when authenticated', () => {
+    mockAuthState.isAuthenticated = true
+    renderComponent()
+    const header = screen.getByRole('banner')
+    expect(within(header).getByText('Dashboard')).toBeInTheDocument()
   })
 })

--- a/frontend/src/shared/components/layout/PublicTopNav.tsx
+++ b/frontend/src/shared/components/layout/PublicTopNav.tsx
@@ -1,0 +1,290 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { Menu, X, ChevronDown, LogOut, User, Building2, Wallet, Eye } from 'lucide-react';
+import { useBetterAuthStore } from '../../../store/betterAuthStore';
+import { getPortalPath } from '@/utils/navigation';
+import { getPortalTheme } from '@shared/hooks/usePortalTheme';
+
+/**
+ * Single source of truth for the public (marketing) top navigation.
+ *
+ * Information architecture — "Lean + Learn":
+ *   Explore (do)   → Browse Pitches · Opportunities          (top level)
+ *   Learn          → How It Works · About                    (dropdown)
+ *   Account        → Sign In · Get Started  (or Dashboard)   (right side)
+ *
+ * Keeping the marketing pages on ONE nav stops the three public pages from
+ * drifting apart (the inconsistency that prompted this). Use `variant="overlay"`
+ * on pages with a dark cinematic hero (Homepage, HowItWorks) and pass the hero
+ * ref so the bar flips from transparent → solid-white once the hero clears the
+ * nav. Use `variant="solid"` on light content pages (About).
+ */
+
+type Props = {
+  variant?: 'overlay' | 'solid';
+  heroRef?: React.RefObject<HTMLElement | null>;
+  /** Homepage shows a portal-themed identity strip when signed in. */
+  showIdentityBadge?: boolean;
+};
+
+const PRIMARY_LINKS = [
+  { label: 'Browse Pitches', to: '/marketplace' },
+  { label: 'Opportunities', to: '/opportunities' },
+];
+const LEARN_LINKS = [
+  { label: 'How It Works', to: '/how-it-works' },
+  { label: 'About', to: '/about' },
+];
+
+export default function PublicTopNav({ variant = 'overlay', heroRef, showIdentityBadge = false }: Props) {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const { isAuthenticated, user, logout } = useBetterAuthStore();
+  const userType = user?.userType;
+
+  // Solid pages are always in the "scrolled" (white) state.
+  const [scrolled, setScrolled] = useState(variant === 'solid');
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const [learnOpen, setLearnOpen] = useState(false);
+  const learnRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (variant === 'solid') return;
+    const onScroll = () => {
+      const el = heroRef?.current;
+      // Switch when the hero clears the 64px nav; fall back to a small scroll
+      // threshold if no hero ref was supplied.
+      setScrolled(el ? el.getBoundingClientRect().bottom <= 64 : window.scrollY > 8);
+    };
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [variant, heroRef]);
+
+  useEffect(() => {
+    if (!learnOpen) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (learnRef.current && !learnRef.current.contains(e.target as Node)) setLearnOpen(false);
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [learnOpen]);
+
+  const onDark = !scrolled; // dark hero behind the bar → use light text
+  const go = (to: string) => { setMobileOpen(false); setLearnOpen(false); navigate(to); };
+
+  const linkCls = (active: boolean) =>
+    `text-nav-link transition ${
+      onDark
+        ? active ? 'text-white font-semibold' : 'text-white/90 hover:text-white'
+        : active ? 'text-purple-700 font-semibold' : 'text-gray-700 hover:text-purple-600'
+    }`;
+
+  const learnActive = LEARN_LINKS.some((l) => l.to === pathname);
+
+  const dashboardHref = isAuthenticated && userType ? `/${getPortalPath(userType)}/dashboard` : '/login';
+
+  return (
+    <header
+      className={`sticky top-0 z-50 transition-colors duration-300 ${
+        scrolled
+          ? 'bg-white/95 backdrop-blur-md border-b border-gray-200 shadow-sm'
+          : mobileOpen
+            ? 'bg-[#1f1934] border-b border-white/10'
+            : 'bg-[#0a0a12]/70 backdrop-blur-md border-b border-white/5'
+      }`}
+    >
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between h-16">
+          {/* Left: logo + primary links */}
+          <div className="flex items-center gap-8">
+            <a href="/" className="flex items-center" aria-label="Pitchey home">
+              <img
+                src={onDark ? '/pitchey-logotype-white.png' : '/pitchey-logotype.png'}
+                alt="Pitchey"
+                className="h-8 w-auto"
+              />
+            </a>
+            <nav className="hidden md:flex items-center gap-6">
+              {PRIMARY_LINKS.map((l) => (
+                <button key={l.to} onClick={() => go(l.to)} className={linkCls(l.to === pathname)}>
+                  {l.label}
+                </button>
+              ))}
+
+              {/* Learn dropdown */}
+              <div
+                ref={learnRef}
+                className="relative"
+                onMouseEnter={() => setLearnOpen(true)}
+                onMouseLeave={() => setLearnOpen(false)}
+              >
+                <button
+                  onClick={() => setLearnOpen((o) => !o)}
+                  aria-haspopup="menu"
+                  aria-expanded={learnOpen}
+                  className={`inline-flex items-center gap-1 ${linkCls(learnActive)}`}
+                >
+                  Learn
+                  <ChevronDown className={`w-4 h-4 transition-transform ${learnOpen ? 'rotate-180' : ''}`} />
+                </button>
+                {learnOpen && (
+                  <div role="menu" className="absolute left-0 top-full pt-2 w-52">
+                    <div className="rounded-xl border border-gray-200 bg-white shadow-lg shadow-black/5 py-1 overflow-hidden">
+                      {LEARN_LINKS.map((l) => (
+                        <button
+                          key={l.to}
+                          role="menuitem"
+                          onClick={() => go(l.to)}
+                          className={`block w-full text-left px-4 py-2.5 text-sm transition ${
+                            l.to === pathname
+                              ? 'text-purple-700 font-semibold bg-purple-50'
+                              : 'text-gray-700 hover:bg-gray-50 hover:text-purple-600'
+                          }`}
+                        >
+                          {l.label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </nav>
+          </div>
+
+          {/* Right: account actions */}
+          <div className="hidden md:flex items-center gap-4">
+            {isAuthenticated && user ? (
+              <>
+                {showIdentityBadge && (() => {
+                  const theme = getPortalTheme(userType);
+                  const meta =
+                    userType === 'production' ? { Icon: Building2, label: 'Production' } :
+                    userType === 'investor'   ? { Icon: Wallet,    label: 'Investor'   } :
+                    userType === 'creator'    ? { Icon: User,      label: 'Creator'    } :
+                    userType === 'watcher'    ? { Icon: Eye,       label: 'Watcher'    } : null;
+                  if (!meta) return null;
+                  const displayName =
+                    userType === 'production' && user.companyName
+                      ? user.companyName
+                      : user.firstName
+                        ? `${user.firstName} ${user.lastName || ''}`.trim()
+                        : user.username;
+                  return (
+                    <div className={`flex items-center gap-2 px-3 py-1.5 ${theme.bgMuted} border border-gray-200 rounded-lg`}>
+                      <meta.Icon className={`w-4 h-4 ${theme.textAccent}`} />
+                      <span className={`text-sm font-medium ${theme.textAccent}`}>{meta.label}</span>
+                      <span className="text-xs text-gray-400">•</span>
+                      <span className="text-sm text-gray-900">{displayName}</span>
+                    </div>
+                  );
+                })()}
+                <button
+                  onClick={() => navigate(dashboardHref)}
+                  className="text-button px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition"
+                >
+                  Dashboard
+                </button>
+                <button
+                  onClick={async () => { await logout(); navigate('/'); }}
+                  className={`text-button px-3 py-2 transition ${onDark ? 'text-white/70 hover:text-white' : 'text-gray-500 hover:text-red-600'}`}
+                  title="Sign Out"
+                >
+                  <LogOut className="w-4 h-4" />
+                </button>
+              </>
+            ) : (
+              <>
+                <button
+                  onClick={() => navigate('/login')}
+                  className={`text-button px-4 py-2 transition ${onDark ? 'text-white hover:text-white/80' : 'text-purple-600 hover:text-purple-700'}`}
+                >
+                  Sign In
+                </button>
+                <button
+                  onClick={() => navigate('/register')}
+                  className="text-button px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition"
+                >
+                  Get Started
+                </button>
+              </>
+            )}
+          </div>
+
+          {/* Mobile hamburger */}
+          <button
+            onClick={() => setMobileOpen((o) => !o)}
+            aria-label="Toggle navigation menu"
+            aria-expanded={mobileOpen}
+            className={`md:hidden inline-flex items-center justify-center p-2 rounded-lg transition ${
+              scrolled ? 'text-gray-700 hover:bg-gray-100' : 'text-white hover:bg-white/10'
+            }`}
+          >
+            {mobileOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+          </button>
+        </div>
+      </div>
+
+      {/* Mobile menu */}
+      {mobileOpen && (
+        <div className={`md:hidden border-t ${scrolled ? 'bg-white border-gray-200' : 'bg-[#1f1934] border-white/10'}`}>
+          <div className="max-w-7xl mx-auto px-4 py-3 flex flex-col gap-1">
+            {PRIMARY_LINKS.map((item) => (
+              <button
+                key={item.to}
+                onClick={() => go(item.to)}
+                className={`text-left px-3 py-2.5 rounded-lg text-sm font-medium transition ${scrolled ? 'text-gray-700 hover:bg-gray-100' : 'text-white/90 hover:bg-white/10'}`}
+              >
+                {item.label}
+              </button>
+            ))}
+            <p className={`px-3 pt-3 pb-1 text-[11px] font-semibold uppercase tracking-[0.16em] ${scrolled ? 'text-gray-400' : 'text-white/40'}`}>
+              Learn
+            </p>
+            {LEARN_LINKS.map((item) => (
+              <button
+                key={item.to}
+                onClick={() => go(item.to)}
+                className={`text-left px-3 py-2.5 rounded-lg text-sm font-medium transition ${scrolled ? 'text-gray-700 hover:bg-gray-100' : 'text-white/90 hover:bg-white/10'}`}
+              >
+                {item.label}
+              </button>
+            ))}
+            <div className={`my-2 border-t ${scrolled ? 'border-gray-200' : 'border-white/10'}`} />
+            {isAuthenticated && user ? (
+              <>
+                <button
+                  onClick={() => go(dashboardHref)}
+                  className="px-3 py-2.5 rounded-lg bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-sm font-semibold text-center shadow-lg shadow-purple-500/30 hover:from-purple-500 hover:to-indigo-500 transition"
+                >
+                  Dashboard
+                </button>
+                <button
+                  onClick={async () => { setMobileOpen(false); await logout(); navigate('/'); }}
+                  className={`text-left px-3 py-2.5 rounded-lg text-sm font-medium transition ${scrolled ? 'text-gray-600 hover:bg-gray-100' : 'text-white/80 hover:bg-white/10'}`}
+                >
+                  Sign Out
+                </button>
+              </>
+            ) : (
+              <>
+                <button
+                  onClick={() => go('/login')}
+                  className={`text-left px-3 py-2.5 rounded-lg text-sm font-medium transition ${scrolled ? 'text-purple-600 hover:bg-purple-50' : 'text-white hover:bg-white/10'}`}
+                >
+                  Sign In
+                </button>
+                <button
+                  onClick={() => go('/register')}
+                  className="px-3 py-2.5 rounded-lg bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-sm font-semibold text-center shadow-lg shadow-purple-500/30 hover:from-purple-500 hover:to-indigo-500 transition"
+                >
+                  Get Started
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </header>
+  );
+}


### PR DESCRIPTION
## What

Redesigns and restructures the `/how-it-works` page. The old page was the generic "purple gradient on white + color-coded cards" look, visually disconnected from the rest of the platform. This rebuilds it in the homepage's "Premiere Night" cinematic brand language and reorganizes the content around an interactive role switcher.

**Already deployed to production** (`pitchey-5o8.pages.dev`, bundle `index-h733usUF.js`) ahead of merge — this PR brings git in sync.

## Changes
- **Cinematic dark hero** — spotlight gradient, film grain, letterbox lines, Fraunces display headline; **shared scroll-aware header** matching the Homepage nav (auth-aware, mobile hamburger).
- **Tabbed role switcher** — Creators / Investors / Production replace the three stacked sections; each recolors to its canonical portal accent (`#7B3FBF` / `#5B4FC7` / `#4A5FD0`) and renders a numbered timeline of steps.
- **Reworked copy** accurate to the live platform (Pitchey Standard NDA, Heat Score, team join codes, compare submissions, shared workspaces, trust badges).
- **Real platform stats** from `/api/content/stats` — strip only renders when the API returns non-zero data, so it never fabricates numbers (old page hardcoded "500+ / \$50M+").
- **"Why Pitchey" feature grid** + **animated FAQ accordion**.
- **Scroll-reveal** via IntersectionObserver, with a guarded fallback for SSR / older browsers / test envs.

## Testing
- `HowItWorks.test.tsx` rewritten against the new structure — **15/15 pass**
- `tsc --noEmit -p tsconfig.app.json` clean · `vite build` clean
- Verified in-browser: hero, tab switching with accent recolor, features, FAQ, scroll-reveal all render; only console noise is the expected content-API fallback in local dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)