### PR TITLE
chore(do): remove orphan ContainerOrchestrator + JobScheduler exports (#73)

### DIFF
--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -21709,8 +21709,6 @@ export const NotificationRoom = WebSocketDurableObject;
 // Durable Object Exports (Premium Feature)
 export { NotificationHub } from './durable-objects/notification-hub';
 export { WebSocketRoom } from './durable-objects/websocket-room';
-export { ContainerOrchestrator } from './durable-objects/container-orchestrator-do';
-export { JobScheduler } from './durable-objects/job-scheduler-do';
 
 // Placeholder scheduled task functions (used by scheduled handler in websocketSafeHandler)
 async function checkNDAExpirations(env: any, ctx: ExecutionContext): Promise<void> {


### PR DESCRIPTION
Closes #73.

`ContainerOrchestrator` and `JobScheduler` were re-exported from `worker-integrated.ts` but **never bound** — `wrangler.toml` binds only `NotificationHub` + `WebSocketRoom`, and `[[migrations]] new_classes = ["NotificationHub", "WebSocketRoom"]`. The exports only cluttered `wrangler types`.

Removed the two export lines. **No DO migration needed** (the classes were never registered, so there are no instances to delete). The source files under `src/durable-objects/` stay parked.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)