### PR TITLE
chore(crons): drop the 3 no-op container/metrics cron stubs (#103, partial)

### DIFF
--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -21632,19 +21632,13 @@ const websocketSafeHandler = {
         case "*/5 * * * *": // Every 5 minutes
           await Promise.all([
             checkNDAExpirations(env, ctx),
-            checkContainerHealth(env, ctx),
             keepDatabaseWarm(env, ctx) // P3: closes the Neon 5-min autosuspend gap (gated off by default)
           ]);
-          break;
-
-        case "*/10 * * * *": // Every 10 minutes
-          await monitorJobQueues(env, ctx);
           break;
 
         case "0 * * * *": // Hourly
           await Promise.all([
             sendDigestEmails(env, ctx),
-            aggregateMetrics(env, ctx),
             checkMoneyPathSLOs(env, ctx)
           ]);
           break;
@@ -21713,10 +21707,6 @@ export { WebSocketRoom } from './durable-objects/websocket-room';
 // Placeholder scheduled task functions (used by scheduled handler in websocketSafeHandler)
 async function checkNDAExpirations(env: any, ctx: ExecutionContext): Promise<void> {
   console.log("Checking NDA expirations...");
-}
-
-async function checkContainerHealth(env: any, ctx: ExecutionContext): Promise<void> {
-  console.log("Checking container health...");
 }
 
 // P3 (connectivity-map): Neon compute autosuspends after 5 min idle
@@ -21953,16 +21943,8 @@ async function checkMoneyPathSLOs(env: any, _ctx: ExecutionContext): Promise<voi
   }));
 }
 
-async function monitorJobQueues(env: any, ctx: ExecutionContext): Promise<void> {
-  console.log("Monitoring job queues...");
-}
-
 async function sendDigestEmails(env: any, ctx: ExecutionContext): Promise<void> {
   console.log("Sending digest emails...");
-}
-
-async function aggregateMetrics(env: any, ctx: ExecutionContext): Promise<void> {
-  console.log("Aggregating metrics...");
 }
 
 async function exportAuditLogs(env: any, ctx: ExecutionContext): Promise<void> {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -145,9 +145,8 @@ bucket_name = "pitchey-trace-logs"
 # ===== CRON TRIGGERS =====
 [triggers]
 crons = [
-  "*/5 * * * *",    # Every 5 min: Check NDA expirations and container health
-  "*/10 * * * *",   # Every 10 min: Job queue monitoring
-  "0 * * * *",      # Hourly: Send digest emails and metrics aggregation
+  "*/5 * * * *",    # Every 5 min: Check NDA expirations (+ optional Neon keep-warm)
+  "0 * * * *",      # Hourly: Send digest emails + money-path SLO check
   "0 0 * * *",      # Daily: Export audit logs and archive jobs
   "0 2 * * 1",      # Weekly: Database cleanup (Mondays at 2 AM)
   "0 3 * * *",      # Daily 3 AM: Stripe<->DB subscription reconciliation (drift detection)


### PR DESCRIPTION
Partial progress on #103.

`checkContainerHealth`, `monitorJobQueues`, and `aggregateMetrics` were placeholder cron handlers whose **entire body was a single `console.log`** — pure no-ops firing every 5 / 10 / 60 minutes. Removed:
- their calls in the `scheduled()` switch,
- the now-empty `*/10 * * * *` case (`monitorJobQueues` was its only content) + the matching `*/10` trigger in `wrangler.toml`,
- the three function definitions,
- two stale cron comments.

**Zero behavior change** (they did nothing) and slightly fewer scheduled invocations. The `*/5` and hourly crons retain their real work (NDA expirations, Neon keep-warm, digest emails, money-path SLO check).

### Left for a product decision (so #103 stays open)
`sendDigestEmails`, `exportAuditLogs`, `archiveOldJobs` are also stubs but need a call on **implement vs. delete** — not touched here.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)