### PR TITLE
chore(crons): remove the last 3 no-op stub crons — closes #103

### DIFF
--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -21637,16 +21637,11 @@ const websocketSafeHandler = {
           break;
 
         case "0 * * * *": // Hourly
-          await Promise.all([
-            sendDigestEmails(env, ctx),
-            checkMoneyPathSLOs(env, ctx)
-          ]);
+          await checkMoneyPathSLOs(env, ctx);
           break;
 
         case "0 0 * * *": // Daily
           await Promise.all([
-            exportAuditLogs(env, ctx),
-            archiveOldJobs(env, ctx),
             sweepExpiredSubscriptionGrants(env, ctx),
             topUpDemoAccountCredits(env, ctx),
           ]);
@@ -21941,18 +21936,6 @@ async function checkMoneyPathSLOs(env: any, _ctx: ExecutionContext): Promise<voi
     category: 'slo', action: 'check_complete',
     breaches, results: summary, duration_ms: Date.now() - startedAt,
   }));
-}
-
-async function sendDigestEmails(env: any, ctx: ExecutionContext): Promise<void> {
-  console.log("Sending digest emails...");
-}
-
-async function exportAuditLogs(env: any, ctx: ExecutionContext): Promise<void> {
-  console.log("Exporting audit logs...");
-}
-
-async function archiveOldJobs(env: any, ctx: ExecutionContext): Promise<void> {
-  console.log("Archiving old jobs...");
 }
 
 async function cleanupDatabase(env: any, _ctx: ExecutionContext): Promise<void> {


### PR DESCRIPTION
Closes #103.

`sendDigestEmails`, `exportAuditLogs`, and `archiveOldJobs` were placeholder cron handlers whose entire body was a single `console.log`. Removed their scheduled calls + the function definitions:

- **`exportAuditLogs` (cron)** → redundant: a real on-demand export already exists (`GET /api/audit/logs/export` → `auditService.exportAuditLogs`). The live method + route are untouched.
- **`archiveOldJobs`** → the job infra (`JobScheduler` DO) was removed in #73; nothing to archive.
- **`sendDigestEmails`** → a no-op hourly cron added zero value and implied a feature that doesn't exist. If digest emails are wanted, that's a proper feature build (doc estimate: M–L), not a resurrected stub — deleting the stub burns no bridge.

Both cron triggers remain — each case keeps its real work (`checkMoneyPathSLOs` hourly; `sweepExpiredSubscriptionGrants` + `topUpDemoAccountCredits` daily). Together with the 3 container stubs removed in #255, this clears the last placeholder crons.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)