### PR TITLE
fix(creator): direct dashboard nav + "Optional Extras" pitch section

### DIFF
--- a/frontend/src/pages/CreatePitch.tsx
+++ b/frontend/src/pages/CreatePitch.tsx
@@ -1347,13 +1347,23 @@ export default function CreatePitch() {
             </div>
 
 
-            {/* Video Upload */}
+          </div>
+
+          {/* Optional Extras — sizzle reel / trailer + lookbook are nice-to-have, not required (Karl feedback) */}
+          <div className="bg-white rounded-xl shadow-sm p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-1">Optional Extras</h2>
+            <p className="text-sm text-gray-500 mb-6">
+              Add-ons that make your pitch stand out — none of these are required. Upload a sizzle
+              reel or trailer here, and add a lookbook (visual pitch deck) under Project Documents below.
+            </p>
+
+            {/* Video Upload (sizzle reel / trailer) */}
             <div>
-              <label 
+              <label
                 id="video-label"
                 className="block text-sm font-medium text-gray-700 mb-2"
               >
-                Pitch Video (Optional)
+                Sizzle Reel or Trailer <span className="text-gray-400 font-normal">(optional)</span>
               </label>
               <div
                 {...a11y.fileUpload.getDropZoneAttributes({
@@ -1395,7 +1405,7 @@ export default function CreatePitch() {
                 ) : (
                   <div>
                     <Video className="w-8 h-8 text-gray-400 mx-auto mb-2" aria-hidden="true" />
-                    <p className="text-sm text-gray-600 mb-2">Upload a pitch video (MP4, MOV, AVI - Max 100MB)</p>
+                    <p className="text-sm text-gray-600 mb-2">Upload a sizzle reel or trailer (MP4, MOV, AVI - Max 100MB)</p>
                     <div className="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition">
                       <Upload className="w-4 h-4" aria-hidden="true" />
                       Choose Video
@@ -1492,7 +1502,11 @@ export default function CreatePitch() {
                 the Edit page. Files are held in formData.documents and uploaded after
                 the pitch is created (PHASE 2b in submit), so they attach with pitchId. */}
             <div className="border-t pt-6 mt-6">
-              <h4 className="text-base font-semibold text-gray-900 mb-4">Project Documents</h4>
+              <h4 className="text-base font-semibold text-gray-900 mb-1">Project Documents</h4>
+              <p className="text-sm text-gray-500 mb-4">
+                All optional. A lookbook (visual pitch deck) is a great add-on — choose the
+                "Lookbook" type after selecting your file.
+              </p>
               <DocumentUpload
                 documents={(formData.documents ?? []) as unknown as DocumentFile[]}
                 onChange={handleDocumentChange as unknown as (docs: DocumentFile[]) => void}

--- a/frontend/src/pages/PitchEdit.tsx
+++ b/frontend/src/pages/PitchEdit.tsx
@@ -886,8 +886,12 @@ export default function PitchEdit() {
 
           {/* Document Upload Section */}
           <div className="bg-white rounded-xl shadow-sm p-6">
-            <h2 className="text-lg font-semibold text-gray-900 mb-6">Project Documents</h2>
-            
+            <h2 className="text-lg font-semibold text-gray-900 mb-1">Project Documents</h2>
+            <p className="text-sm text-gray-500 mb-6">
+              All optional. A lookbook (visual pitch deck) is a great add-on — choose the
+              "Lookbook" type after selecting your file.
+            </p>
+
             <DocumentUpload
               documents={formData.documents}
               onChange={handleDocumentChange}
@@ -1021,10 +1025,20 @@ export default function PitchEdit() {
               </div>
             </div>
 
-            {/* Video Upload */}
+          </div>
+
+          {/* Optional Extras — sizzle reel / trailer + lookbook are nice-to-have, not required (Karl feedback) */}
+          <div className="bg-white rounded-xl shadow-sm p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-1">Optional Extras</h2>
+            <p className="text-sm text-gray-500 mb-6">
+              Add-ons that make your pitch stand out — none of these are required. Upload a sizzle
+              reel or trailer here, and add a lookbook (visual pitch deck) under Project Documents.
+            </p>
+
+            {/* Video Upload (sizzle reel / trailer) */}
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">
-                Pitch Video (Optional)
+                Sizzle Reel or Trailer <span className="text-gray-400 font-normal">(optional)</span>
               </label>
               <div className={`border-2 border-dashed border-gray-300 rounded-lg p-6 text-center transition ${theme.borderAccentHover}`}>
                 {formData.video ? (
@@ -1044,7 +1058,7 @@ export default function PitchEdit() {
                 ) : (
                   <div>
                     <Video className="w-8 h-8 text-gray-400 mx-auto mb-2" />
-                    <p className="text-sm text-gray-600 mb-2">Upload a new pitch video (optional)</p>
+                    <p className="text-sm text-gray-600 mb-2">Upload a sizzle reel or trailer (optional)</p>
                     <input
                       type="file"
                       accept="video/*"

--- a/frontend/src/shared/components/layout/MinimalHeader.tsx
+++ b/frontend/src/shared/components/layout/MinimalHeader.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { ChevronDown, CircleUser, Coins, Menu, X, LogOut, Home, Store } from 'lucide-react';
+import { ChevronDown, CircleUser, Coins, Menu, X, LogOut, LayoutDashboard, Store } from 'lucide-react';
 import { useBetterAuthStore } from '@/store/betterAuthStore';
 import { paymentsAPI } from '@/lib/apiServices';
 import { WebSocketStatusCompact } from '@/components/WebSocketStatus';
 import { NotificationBell } from '@features/notifications/components/NotificationBell';
 import Logo from '@/components/Logo';
-import { getPortalPath, getBrowsePath } from '@/utils/navigation';
+import { getPortalPath, getBrowsePath, getDashboardRoute } from '@/utils/navigation';
 import { getPortalTheme } from '@shared/hooks/usePortalTheme';
 
 
@@ -83,6 +83,10 @@ export function MinimalHeader({ onMenuToggle, isSidebarOpen = true, userType }: 
   // Route to the in-portal browse for this portal so the marketplace keeps the
   // portal chrome instead of swapping to the standalone /marketplace (old layout).
   const browsePath = getBrowsePath(userType);
+  // "Home" for a logged-in user means their portal dashboard, not the public
+  // landing page. Pointing the logo + quick-nav here removes the detour where
+  // users had to bounce through the marketing page to get back to the dashboard.
+  const homePath = userType ? getDashboardRoute(userType) : '/';
 
   return (
     <header className="bg-white border-b border-gray-200 h-16 flex items-center justify-between px-4 sticky top-0 z-40">
@@ -99,7 +103,7 @@ export function MinimalHeader({ onMenuToggle, isSidebarOpen = true, userType }: 
 
         {/* Logo — portal identity is carried by the role badge + main-content
             strip, not the logo color */}
-        <Link to="/" className="flex items-center" aria-label="Pitchey home">
+        <Link to={homePath} className="flex items-center" aria-label="Pitchey dashboard">
           <Logo size="md" />
         </Link>
 
@@ -120,12 +124,12 @@ export function MinimalHeader({ onMenuToggle, isSidebarOpen = true, userType }: 
         {/* Quick Navigation Links — hidden on mobile (sidebar hamburger covers this) */}
         <nav className="hidden sm:flex items-center gap-1">
           <Link
-            to="/"
+            to={homePath}
             className="flex items-center gap-1.5 px-2 sm:px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors"
-            title="Home"
+            title="Dashboard"
           >
-            <Home className="w-4 h-4" />
-            <span className="hidden md:inline">Home</span>
+            <LayoutDashboard className="w-4 h-4" />
+            <span className="hidden md:inline">Dashboard</span>
           </Link>
           <Link
             to={browsePath}
@@ -184,11 +188,11 @@ export function MinimalHeader({ onMenuToggle, isSidebarOpen = true, userType }: 
               {/* Quick Navigation - Mobile */}
               <div className="sm:hidden border-b border-gray-200 py-2">
                 <button
-                  onClick={() => { navigate('/'); setIsProfileOpen(false); }}
+                  onClick={() => { navigate(homePath); setIsProfileOpen(false); }}
                   className="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2"
                 >
-                  <Home className="w-4 h-4" />
-                  Home
+                  <LayoutDashboard className="w-4 h-4" />
+                  Dashboard
                 </button>
                 <button
                   onClick={() => { navigate(browsePath); setIsProfileOpen(false); }}


### PR DESCRIPTION
Two pieces of creator-portal feedback (Karl).

## 1. Navigation — no direct path back to the dashboard
From **My Pitches** (and anywhere in a portal) the header logo + quick-nav "Home" pointed at the public landing page (`/`), forcing a detour through the marketing page to get back to the dashboard.

- Logo + quick-nav now route to the **portal dashboard** (`getDashboardRoute(userType)`).
- The quick-nav link is relabeled **"Dashboard"** (with a dashboard icon) — header *and* mobile profile dropdown.

## 2. Trailer/sizzle reel + lookbook framed as optional add-ons
Split a dedicated **"Optional Extras"** card out of "Media & Assets" on both the create and edit forms:

- Cover Image stays as the core visual; the video moves into Optional Extras, relabeled **"Sizzle Reel or Trailer (optional)"**.
- Project Documents gets a note pointing at the **Lookbook** type.
- Applied to both `CreatePitch` and `PitchEdit` for parity.

## Scope / safety
- Frontend-only (3 files) — no worker/backend changes, no migration.
- `tsc --noEmit` clean (0 errors).
- Isolated from the parallel `wip/profile-feedback-roster` work (no `CreativeRoster` / dashboard / settings changes here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)