### PR TITLE
feat(pitch-form): fixed-role creative roster on create/edit

### DIFF
--- a/frontend/src/components/__tests__/PitchForm.test.tsx
+++ b/frontend/src/components/__tests__/PitchForm.test.tsx
@@ -286,7 +286,7 @@ vi.mock('@features/pitches/components/PitchForm/EnhancedPitchFormSections', () =
   WhyNowSection: vi.fn(() => <div data-testid="why-now-section">Why Now</div>),
   ProductionLocationSection: vi.fn(() => <div data-testid="production-location-section">Production Location</div>),
   DevelopmentStageSelect: vi.fn(() => <div data-testid="development-stage-select">Development Stage</div>),
-  CreativeAttachmentsManager: vi.fn(() => <div data-testid="creative-attachments-manager">Creative Attachments</div>),
+  CreativeRosterManager: vi.fn(() => <div data-testid="creative-attachments-manager">Creative Attachments</div>),
   VideoUrlSection: vi.fn(() => <div data-testid="video-url-section">Video URL</div>),
 }))
 

--- a/frontend/src/features/pitches/components/PitchForm/EnhancedPitchFormSections.tsx
+++ b/frontend/src/features/pitches/components/PitchForm/EnhancedPitchFormSections.tsx
@@ -364,6 +364,140 @@ export const CreativeAttachmentsManager: React.FC<CreativeAttachmentsManagerProp
   );
 };
 
+// ============ CREATIVE ROSTER (production-pitch "Attached Creatives" look) ============
+// The create/edit forms previously used CreativeAttachmentsManager (plain cards with
+// bio/IMDb/website). The production pitch view renders a tighter "Attached Creatives"
+// roster — seeded role cards with avatar initials and a single name field per role.
+// This component mirrors that exact look for the create/edit flow (role + name only,
+// bio/links intentionally dropped per the 2026-06-11 decision). Bound to the same
+// CreativeAttachment[] shape so the existing create/update persistence path is unchanged.
+export const STANDARD_CREATIVE_ROLES = [
+  'Director',
+  'Producer',
+  'Cinematographer',
+  'Production Designer',
+  'Editor',
+  'Composer',
+];
+
+const creativeInitials = (name: string): string =>
+  name.trim().split(/\s+/).map((w) => w[0]).slice(0, 2).join('').toUpperCase();
+
+export const CreativeRosterManager: React.FC<CreativeAttachmentsManagerProps> = ({
+  attachments,
+  onChange,
+}) => {
+  // Always present the six standard roles (merging in any saved name by role), then
+  // append any custom-role rows the user added on top.
+  const rows: CreativeAttachment[] = React.useMemo(() => {
+    const standard = STANDARD_CREATIVE_ROLES.map((role, i) => {
+      const existing = attachments.find((a) => a.role === role);
+      return existing ?? { id: `role-${i}-${role}`, role, name: '', bio: '' };
+    });
+    const custom = attachments.filter((a) => !STANDARD_CREATIVE_ROLES.includes(a.role));
+    return [...standard, ...custom];
+  }, [attachments]);
+
+  const upsert = (row: CreativeAttachment, patch: Partial<CreativeAttachment>) => {
+    const idx = attachments.findIndex((a) => a.id === row.id);
+    if (idx >= 0) {
+      const next = attachments.slice();
+      next[idx] = { ...next[idx], ...patch };
+      onChange(next);
+    } else {
+      onChange([...attachments, { ...row, ...patch }]);
+    }
+  };
+
+  const removeRow = (row: CreativeAttachment) => {
+    onChange(attachments.filter((a) => a.id !== row.id));
+  };
+
+  const addCustom = () => {
+    onChange([...attachments, { id: Date.now().toString(), role: '', name: '', bio: '' }]);
+  };
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center gap-2.5">
+        <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 ring-1 ring-inset ring-indigo-100">
+          <Users className="h-5 w-5" />
+        </span>
+        <h3 className="text-xl font-bold tracking-tight text-gray-900">Attached Creatives</h3>
+      </div>
+      <p className="mb-5 pl-[3.05rem] text-sm text-gray-500">
+        Attach key creative names — pitches with attached talent read as more bankable.
+      </p>
+
+      <p className="mb-2 pl-0.5 text-[0.68rem] font-semibold uppercase tracking-wide text-gray-400">
+        Creative roster
+      </p>
+      <div className="space-y-2.5">
+        {rows.map((row) => {
+          const isStandard = STANDARD_CREATIVE_ROLES.includes(row.role);
+          const initials = creativeInitials(row.name);
+          return (
+            <div
+              key={row.id}
+              className={`flex items-center gap-4 rounded-xl border p-3.5 transition ${
+                row.name ? 'border-indigo-200 bg-indigo-50/40' : 'border-gray-100 bg-gray-50/60'
+              }`}
+            >
+              <span
+                className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-semibold ${
+                  initials ? 'bg-indigo-600 text-white' : 'bg-gray-200 text-gray-400'
+                }`}
+              >
+                {initials || <Users className="h-4 w-4" />}
+              </span>
+              <div className="min-w-0 flex-1">
+                {isStandard ? (
+                  <p className="text-[0.7rem] font-semibold uppercase tracking-wide text-gray-400">
+                    {row.role}
+                  </p>
+                ) : (
+                  <input
+                    type="text"
+                    value={row.role}
+                    onChange={(e) => upsert(row, { role: e.target.value })}
+                    placeholder="Role (e.g. Writer)"
+                    className="w-full bg-transparent text-[0.7rem] font-semibold uppercase tracking-wide text-gray-500 placeholder:font-normal placeholder:normal-case placeholder:text-gray-300 focus:outline-none"
+                  />
+                )}
+                <input
+                  type="text"
+                  value={row.name}
+                  onChange={(e) => upsert(row, { name: e.target.value })}
+                  placeholder="Add a name…"
+                  className="mt-0.5 w-full bg-transparent text-sm font-medium text-gray-900 placeholder:font-normal placeholder:text-gray-400 focus:outline-none"
+                />
+              </div>
+              {!isStandard && (
+                <button
+                  type="button"
+                  onClick={() => removeRow(row)}
+                  className="shrink-0 text-gray-300 transition hover:text-red-500"
+                  aria-label="Remove creative"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <button
+        type="button"
+        onClick={addCustom}
+        className="mt-3 inline-flex w-full items-center justify-center gap-1.5 rounded-xl border-2 border-dashed border-gray-200 px-4 py-2.5 text-sm font-medium text-gray-500 transition hover:border-indigo-300 hover:text-indigo-600"
+      >
+        <Plus className="h-4 w-4" /> Add another creative
+      </button>
+    </div>
+  );
+};
+
 // ============ VIDEO URL WITH PASSWORD SECTION ============
 interface VideoUrlSectionProps {
   videoUrl: string;

--- a/frontend/src/pages/CreatePitch.tsx
+++ b/frontend/src/pages/CreatePitch.tsx
@@ -29,7 +29,7 @@ import {
   WhyNowSection,
   ProductionLocationSection,
   DevelopmentStageSelect,
-  CreativeAttachmentsManager,
+  CreativeRosterManager,
   VideoUrlSection,
   type CreativeAttachment
 } from '@features/pitches/components/PitchForm/EnhancedPitchFormSections';
@@ -412,7 +412,12 @@ export default function CreatePitch() {
           videoPassword: validatedData.videoPassword,
           videoPlatform: validatedData.videoPlatform,
           // Documents will be uploaded separately
-          documents: validatedData.documents || []
+          documents: validatedData.documents || [],
+          // Attached creatives roster — only persist rows with a name (the seeded
+          // standard roles render empty until filled). Was previously dropped on create.
+          creativeAttachments: (formData.creativeAttachments || []).filter(
+            (a: CreativeAttachment) => a.name?.trim()
+          )
         };
 
         // Add custom NDA URL if available
@@ -1185,11 +1190,9 @@ export default function CreatePitch() {
             </div>
           </div>
 
-          {/* Creative Team Section */}
+          {/* Creative Team Section — mirrors the production pitch "Attached Creatives" roster */}
           <div className="bg-white rounded-xl shadow-sm p-6">
-            <h2 className="text-lg font-semibold text-gray-900 mb-6">Creative Team</h2>
-            
-            <CreativeAttachmentsManager
+            <CreativeRosterManager
               attachments={formData.creativeAttachments || []}
               onChange={(attachments) => setValue('creativeAttachments', attachments)}
             />

--- a/frontend/src/pages/PitchEdit.tsx
+++ b/frontend/src/pages/PitchEdit.tsx
@@ -13,7 +13,7 @@ import type { Character } from '@shared/types/character';
 import { normalizeCharacters, serializeCharacters } from '@features/pitches/utils/characterUtils';
 import { DocumentUpload } from '@features/uploads/components/DocumentUpload';
 import type { DocumentFile } from '@features/uploads/components/DocumentUpload';
-import { CreativeAttachmentsManager, type CreativeAttachment } from '@features/pitches/components/PitchForm/EnhancedPitchFormSections';
+import { CreativeRosterManager, type CreativeAttachment } from '@features/pitches/components/PitchForm/EnhancedPitchFormSections';
 
 interface PitchFormData {
   title: string;
@@ -413,8 +413,11 @@ export default function PitchEdit() {
         characters: serializeCharacters(formData.characters),
         // Send the full creative-team list. The update handler deletes + re-inserts
         // pitch_creative_attachments, so the array must always reflect the current
-        // desired state (empty array clears them).
-        creativeAttachments: formData.creativeAttachments,
+        // desired state (empty array clears them). Drop seeded-but-unfilled roster
+        // rows (the standard roles render empty until a name is typed).
+        creativeAttachments: (formData.creativeAttachments || []).filter(
+          (a: CreativeAttachment) => a.name?.trim()
+        ),
       };
 
       // Collects names of any media/documents that failed to upload during this
@@ -875,10 +878,9 @@ export default function PitchEdit() {
             />
           </div>
 
-          {/* Creative Team Section */}
+          {/* Creative Team Section — mirrors the production pitch "Attached Creatives" roster */}
           <div className="bg-white rounded-xl shadow-sm p-6">
-            <h2 className="text-lg font-semibold text-gray-900 mb-6">Creative Team</h2>
-            <CreativeAttachmentsManager
+            <CreativeRosterManager
               attachments={formData.creativeAttachments || []}
               onChange={(creativeAttachments) => setFormData(prev => ({ ...prev, creativeAttachments }))}
             />

--- a/frontend/src/pages/__tests__/CreatePitch.test.tsx
+++ b/frontend/src/pages/__tests__/CreatePitch.test.tsx
@@ -234,7 +234,7 @@ vi.mock('@features/pitches/components/PitchForm/EnhancedPitchFormSections', () =
   DevelopmentStageSelect: ({ value, onChange }: any) => (
     <div data-testid="development-stage">Development Stage</div>
   ),
-  CreativeAttachmentsManager: ({ attachments, onChange }: any) => (
+  CreativeRosterManager: ({ attachments, onChange }: any) => (
     <div data-testid="creative-attachments">Creative Attachments</div>
   ),
   VideoUrlSection: ({ value, onChange }: any) => (
@@ -462,7 +462,9 @@ describe('CreatePitch', () => {
         <CreatePitch />
       </MemoryRouter>
     )
-    expect(screen.getByText('Creative Team')).toBeInTheDocument()
+    // The section now renders the production-style "Attached Creatives" roster
+    // (CreativeRosterManager), mocked here as the creative-attachments testid.
+    expect(screen.getByTestId('creative-attachments')).toBeInTheDocument()
   })
 
   it('renders Document Upload Hub', () => {


### PR DESCRIPTION
Makes the **create/edit pitch form** render the fixed-role **CreativeRosterManager** (Director / Producer / Cinematographer / Production Designer / Editor / Composer, with inline "Add a name…") instead of the old free-form "Add Creative Team Member" list.

### Why
The roster UI was built on the parallel `wip/profile-feedback-roster` branch but never shipped; `main` still showed the old `CreativeAttachmentsManager`. This extracts **just the roster-form piece** so it ships independently of that branch's in-flight dashboard/settings/identity work.

### Changes
- `EnhancedPitchFormSections.tsx` — add `CreativeRosterManager` (old `CreativeAttachmentsManager` kept).
- `CreatePitch.tsx` / `PitchEdit.tsx` — swap to the roster; submit filters out seeded-but-unnamed rows.
- Test mocks + assertions updated.

### Safety
- No backend change — persists via the existing `creativeAttachments` → `pitch_creative_attachments` path.
- Combines cleanly with the Optional Extras section already on `main` (different regions of the same files).
- `tsc` clean; 53 tests pass (`CreatePitch.test`, `PitchForm.test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)