### PR TITLE
fix(feedback): comment/review author shows @username, never company name

### DIFF
--- a/src/handlers/pitch-feedback.ts
+++ b/src/handlers/pitch-feedback.ts
@@ -449,14 +449,19 @@ export async function getPitchFeedbackPublic(request: Request, env: Env): Promis
         pf.id, pf.reviewer_type, pf.rating, pf.strengths, pf.weaknesses,
         pf.suggestions, pf.overall_feedback, pf.is_interested, pf.is_anonymous, pf.created_at,
         CASE WHEN pf.is_anonymous THEN NULL ELSE u.id END as reviewer_id,
-        -- Names are public to all viewers now (P5). If a user's display name is
-        -- actually an email (no real name set), show only the local part so we
-        -- don't leak their full email address to anonymous callers.
+        -- Canonical author rule (matches getPitchComments): chosen @username first,
+        -- then real name, then the email local-part. Email-shaped usernames are
+        -- skipped (no '@handle' that's really an address; no email leak). company_name
+        -- is never the author identity — it leaked in as "Slycloth/Sky Cloth" before.
         CASE
           WHEN pf.is_anonymous THEN 'Anonymous'
-          WHEN COALESCE(u.name, u.username, 'User') LIKE '%@%.%'
-            THEN split_part(COALESCE(u.name, u.username, 'User'), '@', 1)
-          ELSE COALESCE(u.name, u.username, 'User')
+          ELSE COALESCE(
+            CASE WHEN u.username IS NOT NULL AND TRIM(u.username) <> '' AND u.username NOT LIKE '%@%'
+                 THEN '@' || u.username END,
+            NULLIF(TRIM(CONCAT(u.first_name, ' ', u.last_name)), ''),
+            split_part(u.email, '@', 1),
+            'User'
+          )
         END as reviewer_name,
         CASE WHEN pf.is_anonymous THEN NULL ELSE u.company_name END as reviewer_company
       FROM pitch_feedback pf
@@ -751,7 +756,16 @@ export async function getPitchComments(request: Request, env: Env): Promise<Resp
       SELECT
         pc.id, pc.content, pc.created_at, pc.user_id,
         pc.user_type,
-        u.name as user_name, u.username
+        -- Canonical author rule (matches getPitchFeedbackPublic): chosen @username
+        -- first, then real name, then the email local-part. Email-shaped usernames are
+        -- skipped (no email leak). Never company_name — that surfaced Karl as "Sky Cloth".
+        COALESCE(
+          CASE WHEN u.username IS NOT NULL AND TRIM(u.username) <> '' AND u.username NOT LIKE '%@%'
+               THEN '@' || u.username END,
+          NULLIF(TRIM(CONCAT(u.first_name, ' ', u.last_name)), ''),
+          split_part(u.email, '@', 1),
+          'User'
+        ) as author_name
       FROM pitch_comments pc
       LEFT JOIN users u ON u.id = pc.user_id
       WHERE pc.pitch_id = ${pitchId}
@@ -766,7 +780,7 @@ export async function getPitchComments(request: Request, env: Env): Promise<Resp
           id: c.id,
           content: c.content,
           created_at: c.created_at,
-          display_name: c.user_name || c.username || 'User',
+          display_name: c.author_name || 'User',
           user_type: c.user_type,
         };
       }


### PR DESCRIPTION
## Problem
Karl's production account showed up on his own comments/reviews as **"Sky Cloth"** (his `company_name`), and under a *different* name on other surfaces — because each handler orders the `users` name columns differently, and the comment/review queries led with company-derived values. `origin/main` still has the old `u.name`-based logic, so this bug is **live in production** today.

## Fix
Both author surfaces — `getPitchComments` and `getPitchFeedbackPublic` — now resolve one canonical identity:

`@username` → real name (`first + last`) → email local-part → `'User'`

- Email-shaped usernames are skipped (no `@handle` that's actually an address; no email leak).
- `company_name` is **never** used as a person's author name.
- The NDA-gated pseudonym branch for non-NDA viewers is untouched.

Verified against live data: Karl (prod, id 1049) → `@Tester` (becomes `@skycloth` once he sets his username in Settings → Profile); email-shaped usernames fall through to the real name; demo accounts → `@handle`.

## Scope
Touches **only** `src/handlers/pitch-feedback.ts` — file-disjoint from #260/#261/#262 and the dashboard-tabs / nav-consolidation branches. Extracted from the `wip/profile-feedback-roster` decomposition.

Tracking: #263 (slice "Feedback / author-name identity").

🤖 Generated with [Claude Code](https://claude.com/claude-code)