### PR TITLE
feat(creator): tabbed dashboard — Overview · My Pitches · NDAs · Network

### DIFF
--- a/frontend/src/components/__tests__/CreatorDashboard.test.tsx
+++ b/frontend/src/components/__tests__/CreatorDashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import React from 'react'
@@ -162,6 +162,15 @@ function renderDashboard() {
   )
 }
 
+// Dashboard is now tabbed (Overview · My Pitches · NDAs · Network). Click a tab —
+// scoped to the tab nav so we never collide with QuickActions buttons that share
+// labels like "NDAs". Waits past the loading skeleton for the nav to render.
+async function gotoTab(name: RegExp) {
+  const user = userEvent.setup()
+  const nav = await screen.findByRole('navigation', { name: /Dashboard sections/i })
+  await user.click(within(nav).getByRole('button', { name }))
+}
+
 const mockDashboardData = (overrides = {}) => ({
   success: true,
   data: {
@@ -285,6 +294,7 @@ describe('CreatorDashboard', () => {
 
     it('displays KPI stat cards', async () => {
       renderDashboard()
+      await gotoTab(/My Pitches/i)
       await waitFor(() => {
         expect(screen.getByText('Total Pitches')).toBeInTheDocument()
         expect(screen.getAllByText('Active Pitches').length).toBeGreaterThan(0)
@@ -305,7 +315,8 @@ describe('CreatorDashboard', () => {
         expect(screen.getByText('Quick Actions')).toBeInTheDocument()
         expect(screen.getByText('Create Pitch')).toBeInTheDocument()
         expect(screen.getByText('Manage Pitches')).toBeInTheDocument()
-        expect(screen.getByText('NDAs')).toBeInTheDocument()
+        // "NDAs" now also appears as a tab label — quick-action + tab = 2 matches.
+        expect(screen.getAllByText('NDAs').length).toBeGreaterThan(0)
         expect(screen.getAllByText('Messages').length).toBeGreaterThan(0)
         expect(screen.getAllByText('Analytics').length).toBeGreaterThan(0)
         expect(screen.getByText('Billing')).toBeInTheDocument()
@@ -349,6 +360,7 @@ describe('CreatorDashboard', () => {
 
     it('displays pitch cards with titles', async () => {
       renderDashboard()
+      await gotoTab(/My Pitches/i)
       await waitFor(() => {
         expect(screen.getByText('My First Pitch')).toBeInTheDocument()
         expect(screen.getByText('Second Pitch')).toBeInTheDocument()
@@ -357,6 +369,7 @@ describe('CreatorDashboard', () => {
 
     it('shows pitch status badges', async () => {
       renderDashboard()
+      await gotoTab(/My Pitches/i)
       await waitFor(() => {
         expect(screen.getByText('published')).toBeInTheDocument()
         expect(screen.getByText('draft')).toBeInTheDocument()
@@ -372,6 +385,7 @@ describe('CreatorDashboard', () => {
       })
 
       renderDashboard()
+      await gotoTab(/My Pitches/i)
       await waitFor(() => {
         expect(screen.getByText(/haven't published any pitches/)).toBeInTheDocument()
         expect(screen.getByText('Create Your First Pitch')).toBeInTheDocument()
@@ -380,6 +394,7 @@ describe('CreatorDashboard', () => {
 
     it('shows View All link', async () => {
       renderDashboard()
+      await gotoTab(/My Pitches/i)
       await waitFor(() => {
         expect(screen.getByText('View All')).toBeInTheDocument()
       })
@@ -424,6 +439,7 @@ describe('CreatorDashboard', () => {
   describe('Creator Milestones', () => {
     it('displays milestone section', async () => {
       renderDashboard()
+      await gotoTab(/My Pitches/i)
       await waitFor(() => {
         expect(screen.getByText('Creator Milestones')).toBeInTheDocument()
       })
@@ -431,6 +447,7 @@ describe('CreatorDashboard', () => {
 
     it('shows milestone cards', async () => {
       renderDashboard()
+      await gotoTab(/My Pitches/i)
       await waitFor(() => {
         expect(screen.getByText('First Pitch')).toBeInTheDocument()
         expect(screen.getByText('100 Views')).toBeInTheDocument()
@@ -441,6 +458,7 @@ describe('CreatorDashboard', () => {
 
     it('shows next goals section', async () => {
       renderDashboard()
+      await gotoTab(/My Pitches/i)
       await waitFor(() => {
         expect(screen.getByText('Your Next Goals')).toBeInTheDocument()
       })
@@ -552,6 +570,7 @@ describe('CreatorDashboard', () => {
   describe('NDA Integration', () => {
     it('renders NDA panel', async () => {
       renderDashboard()
+      await gotoTab(/NDAs/i)
       await waitFor(() => {
         expect(screen.getByTestId('nda-panel')).toBeInTheDocument()
       })

--- a/frontend/src/pages/CreatorDashboard.tsx
+++ b/frontend/src/pages/CreatorDashboard.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useOnlineStatus } from '@/shared/hooks/useOnlineStatus';
 import { useNavigate } from 'react-router-dom';
-import { TrendingUp, Eye, MessageSquare, Upload, BarChart3, Calendar, Plus, Shield, CreditCard, Wifi, WifiOff, AlertTriangle, RefreshCw, Sparkles, ArrowRight, Share2 } from 'lucide-react';
+import { TrendingUp, Eye, MessageSquare, Upload, BarChart3, Calendar, Plus, Shield, CreditCard, Wifi, WifiOff, AlertTriangle, RefreshCw, Sparkles, ArrowRight, Share2, Activity, Users } from 'lucide-react';
 import QuickActionsPanel, { type QuickAction } from '../components/dashboard/QuickActionsPanel';
 import ShareLinksModal from '../components/portfolio/ShareLinksModal';
 import { useBetterAuthStore } from '../store/betterAuthStore';
@@ -51,6 +51,7 @@ function CreatorDashboard() {
   const [totalViews, setTotalViews] = useState<number>(0);
   const [followers, setFollowers] = useState<number>(0);
   const [showShareModal, setShowShareModal] = useState(false);
+  const [activeTab, setActiveTab] = useState<'overview' | 'pitches' | 'ndas' | 'network'>('overview');
 
   const quickActions: QuickAction[] = [
     { label: 'Create Pitch', icon: Plus, accent: 'purple', onClick: () => { void navigate('/creator/pitch/new'); } },
@@ -367,6 +368,12 @@ function CreatorDashboard() {
       <div className="w-full animate-pulse">
         {/* Skeleton hero zone */}
         <div className="mb-6 h-7 w-48 bg-gray-200 rounded" />
+        {/* Skeleton tab bar */}
+        <div className="inline-flex gap-1 p-1 bg-gray-100 rounded-xl mb-6">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-9 w-24 bg-gray-200 rounded-lg" />
+          ))}
+        </div>
         <div className="grid grid-cols-1 lg:grid-cols-5 gap-6 mb-8">
           <div className="lg:col-span-3 bg-gradient-to-br from-purple-300 to-indigo-300 rounded-xl h-56" />
           <div className="lg:col-span-2 bg-white rounded-xl shadow-sm h-56" />
@@ -441,6 +448,50 @@ function CreatorDashboard() {
         </div>
       )}
 
+      {/* Tab Navigation — segmented control (portal-purple active pill, live counts) */}
+      <div className="mb-6">
+        <nav
+          aria-label="Dashboard sections"
+          className="inline-flex w-full sm:w-auto items-center gap-1 p-1 bg-gray-100 rounded-xl overflow-x-auto"
+        >
+          {([
+            { id: 'overview', label: 'Overview', icon: Activity, count: null },
+            { id: 'pitches', label: 'My Pitches', icon: Upload, count: pitches?.length || 0 },
+            { id: 'ndas', label: 'NDAs', icon: Shield, count: safeNumber(stats?.totalInterest) || 0 },
+            { id: 'network', label: 'Network', icon: Users, count: followers || 0 },
+          ] as const).map(({ id, label, icon: Icon, count }) => {
+            const isActive = activeTab === id;
+            return (
+              <button
+                key={id}
+                onClick={() => setActiveTab(id)}
+                aria-current={isActive ? 'page' : undefined}
+                className={`relative flex-1 sm:flex-initial inline-flex items-center justify-center gap-2 px-3 sm:px-4 py-2 rounded-lg text-xs sm:text-sm font-medium whitespace-nowrap transition-all duration-200 ${
+                  isActive
+                    ? 'bg-white text-brand-portal-creator shadow-sm ring-1 ring-black/5'
+                    : 'text-gray-500 hover:text-gray-800 hover:bg-white/60'
+                }`}
+              >
+                <Icon className={`w-4 h-4 ${isActive ? 'text-brand-portal-creator' : 'text-gray-400'}`} />
+                <span>{label}</span>
+                {count !== null && count > 0 && (
+                  <span
+                    className={`ml-0.5 inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 rounded-full text-[11px] font-semibold tabular-nums ${
+                      isActive ? 'bg-brand-portal-creator/10 text-brand-portal-creator' : 'bg-gray-200 text-gray-500'
+                    }`}
+                  >
+                    {count}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </nav>
+      </div>
+
+      {/* ===== OVERVIEW TAB ===== */}
+      {activeTab === 'overview' && (
+      <>
       {/* ===== COMMAND CENTER HERO ZONE ===== */}
       <div className="grid grid-cols-1 lg:grid-cols-5 gap-6 mb-8">
         {/* Left: Key Metrics */}
@@ -491,10 +542,13 @@ function CreatorDashboard() {
         <CreatorCollaborations />
       </div>
 
-      {/* ===== MY PITCHES + NDA QUICK STATUS ===== */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
-        {/* My Pitches — left 2/3 */}
-        <div className="lg:col-span-2">
+      </>
+      )}
+
+      {/* ===== MY PITCHES (Pitches tab) ===== */}
+      {activeTab === 'pitches' && (
+      <div className="mb-8">
+        <div>
           <div className="bg-white rounded-xl shadow-sm">
             <div className="px-6 py-4 border-b flex items-center justify-between">
               <h2 className="text-lg font-semibold text-gray-900">My Pitches</h2>
@@ -571,8 +625,12 @@ function CreatorDashboard() {
             </div>
           </div>
         </div>
+      </div>
+      )}
 
-        {/* NDA Status + Subscription — right 1/3 */}
+      {/* ===== NDA STATUS + SUBSCRIPTION (Overview tab) ===== */}
+      {activeTab === 'overview' && (
+      <div className="max-w-2xl mb-8">
         <div className="space-y-6">
           <QuickNDAStatus userType="creator" />
 
@@ -640,11 +698,16 @@ function CreatorDashboard() {
           </div>
         </div>
       </div>
+      )}
 
-      {/* ===== NDA NOTIFICATION PANEL ===== */}
+      {/* ===== NDA NOTIFICATION PANEL (NDAs tab) ===== */}
+      {activeTab === 'ndas' && (
       <NDANotificationPanel className="mb-8" />
+      )}
 
-      {/* ===== STATS GRID — 6 KPI Cards (pushed down) ===== */}
+      {/* ===== STATS GRID — 6 KPI Cards (Pitches tab) ===== */}
+      {activeTab === 'pitches' && (
+      <>
       <div className="mb-4 px-1">
         <h2 className="text-sm font-semibold uppercase tracking-wider text-gray-500">Performance</h2>
       </div>
@@ -724,7 +787,12 @@ function CreatorDashboard() {
         </div>
       </div>
 
-      {/* ===== FUNDING OVERVIEW ===== */}
+      </>
+      )}
+
+      {/* ===== FUNDING OVERVIEW (Overview tab) ===== */}
+      {activeTab === 'overview' && (
+      <>
       {sectionStatus.funding.error ? (
         <div className="flex items-center gap-3 bg-red-50 border border-red-200 rounded-lg p-4 mb-8">
           <AlertTriangle className="w-5 h-5 text-red-600 shrink-0" />
@@ -768,7 +836,11 @@ function CreatorDashboard() {
         </div>
       </div>
 
-      {/* ===== CREATOR MILESTONES ===== */}
+      </>
+      )}
+
+      {/* ===== CREATOR MILESTONES (Pitches tab) ===== */}
+      {activeTab === 'pitches' && (
       <div className="bg-white rounded-xl shadow-sm mb-8">
         <div className="px-6 py-4 border-b">
           <h2 className="text-lg font-semibold text-gray-900">Creator Milestones</h2>
@@ -902,7 +974,10 @@ function CreatorDashboard() {
         </div>
       </div>
 
-      {/* ===== RECENT ACTIVITY (full-width) ===== */}
+      )}
+
+      {/* ===== RECENT ACTIVITY (Overview tab) ===== */}
+      {activeTab === 'overview' && (
       <div className="bg-white rounded-xl shadow-sm">
         <div className="px-6 py-4 border-b">
           <h2 className="text-lg font-semibold text-gray-900">Recent Activity</h2>
@@ -942,6 +1017,30 @@ function CreatorDashboard() {
           )}
         </div>
       </div>
+      )}
+
+      {/* ===== NETWORK TAB ===== */}
+      {activeTab === 'network' && (
+        <div className="bg-white rounded-xl shadow-sm p-8">
+          <div className="flex flex-col items-center text-center max-w-md mx-auto py-6">
+            <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-gradient-to-br from-purple-50 to-indigo-100 ring-1 ring-purple-100/60 mb-4">
+              <Users className="w-7 h-7 text-brand-portal-creator" />
+            </div>
+            <p className="text-4xl font-bold tracking-tight tabular-nums text-gray-900">{followers}</p>
+            <p className="text-sm font-medium text-gray-600 mt-1">Followers</p>
+            <p className="text-gray-500 text-sm mt-3 mb-6">
+              People who follow your work get notified when you publish new pitches.
+            </p>
+            <button
+              onClick={() => { void navigate('/creator/following'); }}
+              className="inline-flex items-center gap-2 px-5 py-2.5 bg-brand-action text-white rounded-lg hover:opacity-90 transition font-medium text-sm"
+            >
+              View followers &amp; following
+              <ArrowRight className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/__tests__/CreatorDashboard.test.tsx
+++ b/frontend/src/pages/__tests__/CreatorDashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, beforeAll, afterEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import React from 'react'
@@ -181,6 +181,15 @@ function renderDashboard() {
   )
 }
 
+// Dashboard is now tabbed (Overview · My Pitches · NDAs · Network). Click a tab —
+// scoped to the tab nav so we never collide with the QuickActions buttons that
+// share labels like "NDAs". Waits for the nav to appear (past the loading skeleton).
+async function gotoTab(name: RegExp) {
+  const user = userEvent.setup()
+  const nav = await screen.findByRole('navigation', { name: /Dashboard sections/i })
+  await user.click(within(nav).getByRole('button', { name }))
+}
+
 describe('CreatorDashboard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -297,6 +306,7 @@ describe('CreatorDashboard', () => {
 
     it('renders pitch cards from API response', async () => {
       renderDashboard()
+      await gotoTab(/My Pitches/i)
       await waitFor(() => {
         expect(screen.getByText('Pitch A')).toBeInTheDocument()
         expect(screen.getByText('Pitch B')).toBeInTheDocument()
@@ -325,6 +335,7 @@ describe('CreatorDashboard', () => {
         return Promise.resolve({ success: true, data: { followers: [], following: [] } })
       })
       renderDashboard()
+      await gotoTab(/My Pitches/i)
       await waitFor(() => {
         expect(screen.getByText(/haven't published any pitches/i)).toBeInTheDocument()
       })
@@ -395,6 +406,7 @@ describe('CreatorDashboard', () => {
         return Promise.resolve({ success: true, data: {} })
       })
       renderDashboard()
+      await gotoTab(/Network/i)
       await waitFor(() => {
         expect(screen.getByText('Followers')).toBeInTheDocument()
       })
@@ -440,7 +452,8 @@ describe('CreatorDashboard', () => {
       await waitFor(() => {
         expect(screen.getByText('Create Pitch')).toBeInTheDocument()
         expect(screen.getByText('Manage Pitches')).toBeInTheDocument()
-        expect(screen.getByText('NDAs')).toBeInTheDocument()
+        // "NDAs" now also appears as a tab label — quick-action + tab = 2 matches.
+        expect(screen.getAllByText('NDAs').length).toBeGreaterThan(0)
         expect(screen.getByText('Messages')).toBeInTheDocument()
         expect(screen.getByText('Analytics')).toBeInTheDocument()
         expect(screen.getByText('Billing')).toBeInTheDocument()
@@ -473,6 +486,7 @@ describe('CreatorDashboard', () => {
   describe('Milestones', () => {
     it('renders Creator Milestones section', async () => {
       renderDashboard()
+      await gotoTab(/My Pitches/i)
       await waitFor(() => {
         expect(screen.getByText('Creator Milestones')).toBeInTheDocument()
       })
@@ -480,6 +494,7 @@ describe('CreatorDashboard', () => {
 
     it('shows completed First Pitch milestone when pitches > 0', async () => {
       renderDashboard()
+      await gotoTab(/My Pitches/i)
       await waitFor(() => {
         expect(screen.getByText('First Pitch')).toBeInTheDocument()
         expect(screen.getByText('Completed')).toBeInTheDocument()


### PR DESCRIPTION
## What
Restructures the Creator dashboard into the **Production portal's tabbed information architecture** — a segmented-control nav with live count badges, keeping the creator's purple identity (Production is blue).

**Tabs**
- **Overview** — hero metrics + quick actions, company join/collaborations, NDA status, subscription, funding, recent activity
- **My Pitches** — pitch grid, 6-card performance KPIs, creator milestones
- **NDAs** — NDA notification panel
- **Network** — followers card + CTA

Plus a matching tab-bar loading skeleton.

## Tests
A `gotoTab()` helper scoped to the nav (so it never collides with same-named QuickActions buttons like "NDAs"); tab-gated assertions activate their tab first. **62/62 pass**, tsc clean.

> Note: corrects an incomplete earlier cut of the test file — the Milestones (×3) and NDA-panel tests were missing their `gotoTab` calls.

## Scope
Touches **only** `CreatorDashboard.tsx` + its two test files — disjoint from #260/#261/#262/#264 and the nav-consolidation branch. Extracted from the `wip/profile-feedback-roster` decomposition, rebased clean onto current `origin/main`.

Tracking: #263 (slice "Tabbed CreatorDashboard").

🤖 Generated with [Claude Code](https://claude.com/claude-code)