### PR TITLE
fix(test): green the Settings notifications-tab tests (stale after #262 Profile-tab default)

### DIFF
--- a/frontend/src/pages/__tests__/Settings.test.tsx
+++ b/frontend/src/pages/__tests__/Settings.test.tsx
@@ -125,12 +125,17 @@ describe('Settings', () => {
     })
   })
 
-  it('shows notifications tab content by default', async () => {
+  it('shows notifications tab content when the Notifications tab is selected', async () => {
     render(
       <MemoryRouter>
         <Settings />
       </MemoryRouter>
     )
+
+    await waitFor(() => {
+      expect(screen.getByText('Notifications')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Notifications'))
 
     await waitFor(() => {
       expect(screen.getByText('Notification Preferences')).toBeInTheDocument()
@@ -145,6 +150,11 @@ describe('Settings', () => {
     )
 
     await waitFor(() => {
+      expect(screen.getByText('Notifications')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Notifications'))
+
+    await waitFor(() => {
       expect(screen.getByText('Email Notifications')).toBeInTheDocument()
     })
   })
@@ -157,6 +167,11 @@ describe('Settings', () => {
     )
 
     await waitFor(() => {
+      expect(screen.getByText('Notifications')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Notifications'))
+
+    await waitFor(() => {
       expect(screen.getByText('Push Notifications')).toBeInTheDocument()
     })
   })
@@ -167,6 +182,11 @@ describe('Settings', () => {
         <Settings />
       </MemoryRouter>
     )
+
+    await waitFor(() => {
+      expect(screen.getByText('Notifications')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Notifications'))
 
     await waitFor(() => {
       expect(screen.getByText('Pitch Views')).toBeInTheDocument()


### PR DESCRIPTION
## What
4 `Settings.test.tsx` tests were failing the **Frontend Tests** gate on `main` — the #260–#265 cluster was merged past this (mislabeled "flaky/UNSTABLE").

## Root cause
#262 added a **Profile** tab to Settings and made it the default `activeTab`. The notifications content no longer renders by default, but these 4 tests still asserted notification text (`Notification Preferences`, `Email`/`Push Notifications`, sub-options) without selecting the Notifications tab.

**The Settings UI is correct — the tests were stale.** Each now clicks the Notifications tab first (same pattern as the existing Privacy-tab test).

## Result
- `Settings.test.tsx`: **20/20 pass** (was 16/20).
- Test-only change — no app/runtime code touched, no deploy needed.
- Greens `main`'s Frontend Tests gate so subsequent PRs (e.g. #266) don't inherit a red gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)