### PR TITLE
feat(nav): collapsible desktop sidebar (icon rail)

### DIFF
--- a/frontend/src/shared/components/layout/EnhancedAdminNav.tsx
+++ b/frontend/src/shared/components/layout/EnhancedAdminNav.tsx
@@ -60,45 +60,49 @@ export const adminNavigationSections: NavigationSection[] = [
   },
 ];
 
-export function EnhancedAdminNav() {
+export function EnhancedAdminNav({ collapsed = false }: { collapsed?: boolean }) {
   const navigate = useNavigate();
   const location = useLocation();
 
   return (
-    <nav className="w-64 bg-white border-r border-gray-200 h-full overflow-y-auto">
-      <div className="p-4">
-        <h2 className="text-xl font-bold text-purple-900 mb-4">Admin Portal</h2>
+    <nav className="w-full">
+      <div className={collapsed ? 'p-2' : 'p-4'}>
+        {!collapsed && <h2 className="text-xl font-bold text-purple-900 mb-4">Admin Portal</h2>}
 
         {/* Quick Links - Always visible at top */}
         <div className="mb-6 pb-4 border-b border-gray-200">
-          <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-            Quick Links
-          </h3>
+          {!collapsed && (
+            <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+              Quick Links
+            </h3>
+          )}
           <div className="space-y-1">
             <Link
               to="/"
-              className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-purple-50 hover:text-purple-900 transition-colors duration-200"
+              title={collapsed ? 'Home' : undefined}
+              className={`w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-purple-50 hover:text-purple-900 transition-colors duration-200`}
             >
-              <Home className="w-4 h-4" />
-              <span className="flex-1 text-left">Home</span>
-              <ExternalLink className="w-3 h-3 text-gray-400" />
+              <Home className="w-4 h-4 shrink-0" />
+              {!collapsed && <><span className="flex-1 text-left">Home</span><ExternalLink className="w-3 h-3 text-gray-400" /></>}
             </Link>
             <Link
               to="/marketplace"
-              className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-purple-50 hover:text-purple-900 transition-colors duration-200"
+              title={collapsed ? 'Marketplace' : undefined}
+              className={`w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-purple-50 hover:text-purple-900 transition-colors duration-200`}
             >
-              <Store className="w-4 h-4" />
-              <span className="flex-1 text-left">Marketplace</span>
-              <ExternalLink className="w-3 h-3 text-gray-400" />
+              <Store className="w-4 h-4 shrink-0" />
+              {!collapsed && <><span className="flex-1 text-left">Marketplace</span><ExternalLink className="w-3 h-3 text-gray-400" /></>}
             </Link>
           </div>
         </div>
 
         {adminNavigationSections.map((section) => (
-          <div key={section.title} className="mb-6">
-            <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-              {section.title}
-            </h3>
+          <div key={section.title} className={collapsed ? 'mb-2' : 'mb-6'}>
+            {!collapsed && (
+              <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+                {section.title}
+              </h3>
+            )}
             <div className="space-y-1">
               {section.items.map((item) => {
                 const Icon = item.icon;
@@ -108,8 +112,9 @@ export function EnhancedAdminNav() {
                   <button
                     key={item.path}
                     onClick={() => navigate(item.path)}
+                    title={collapsed ? item.label : undefined}
                     className={`
-                      w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm
+                      w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm
                       transition-colors duration-200
                       ${isActive
                         ? 'bg-purple-100 text-purple-900 font-medium'
@@ -117,9 +122,9 @@ export function EnhancedAdminNav() {
                       }
                     `}
                   >
-                    <Icon className="w-4 h-4" />
-                    <span className="flex-1 text-left">{item.label}</span>
-                    {item.badge && (
+                    <Icon className="w-4 h-4 shrink-0" />
+                    {!collapsed && <span className="flex-1 text-left">{item.label}</span>}
+                    {!collapsed && item.badge && (
                       <span className="px-1.5 py-0.5 text-xs font-medium bg-gray-100 text-gray-700 rounded">
                         {item.badge}
                       </span>

--- a/frontend/src/shared/components/layout/EnhancedCreatorNav.tsx
+++ b/frontend/src/shared/components/layout/EnhancedCreatorNav.tsx
@@ -63,45 +63,49 @@ export const creatorNavigationSections: NavigationSection[] = [
   },
 ];
 
-export function EnhancedCreatorNav() {
+export function EnhancedCreatorNav({ collapsed = false }: { collapsed?: boolean }) {
   const navigate = useNavigate();
   const location = useLocation();
 
   return (
-    <nav className="w-64 bg-white border-r border-gray-200 h-full overflow-y-auto">
-      <div className="p-4">
-        <h2 className="text-xl font-bold text-brand-portal-creator mb-4">Creator Portal</h2>
+    <nav className="w-full">
+      <div className={collapsed ? 'p-2' : 'p-4'}>
+        {!collapsed && <h2 className="text-xl font-bold text-brand-portal-creator mb-4">Creator Portal</h2>}
 
         {/* Quick Links - Always visible at top */}
         <div className="mb-6 pb-4 border-b border-gray-200">
-          <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-            Quick Links
-          </h3>
+          {!collapsed && (
+            <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+              Quick Links
+            </h3>
+          )}
           <div className="space-y-1">
             <Link
               to="/"
-              className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-brand-portal-creator/10 hover:text-brand-portal-creator transition-colors duration-200"
+              title={collapsed ? 'Home' : undefined}
+              className={`w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-brand-portal-creator/10 hover:text-brand-portal-creator transition-colors duration-200`}
             >
-              <Home className="w-4 h-4" />
-              <span className="flex-1 text-left">Home</span>
-              <ExternalLink className="w-3 h-3 text-gray-400" />
+              <Home className="w-4 h-4 shrink-0" />
+              {!collapsed && <><span className="flex-1 text-left">Home</span><ExternalLink className="w-3 h-3 text-gray-400" /></>}
             </Link>
             <Link
               to="/creator/browse"
-              className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-brand-portal-creator/10 hover:text-brand-portal-creator transition-colors duration-200"
+              title={collapsed ? 'Marketplace' : undefined}
+              className={`w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-brand-portal-creator/10 hover:text-brand-portal-creator transition-colors duration-200`}
             >
-              <Store className="w-4 h-4" />
-              <span className="flex-1 text-left">Marketplace</span>
-              <ExternalLink className="w-3 h-3 text-gray-400" />
+              <Store className="w-4 h-4 shrink-0" />
+              {!collapsed && <><span className="flex-1 text-left">Marketplace</span><ExternalLink className="w-3 h-3 text-gray-400" /></>}
             </Link>
           </div>
         </div>
 
         {creatorNavigationSections.map((section) => (
-          <div key={section.title} className="mb-6">
-            <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-              {section.title}
-            </h3>
+          <div key={section.title} className={collapsed ? 'mb-2' : 'mb-6'}>
+            {!collapsed && (
+              <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+                {section.title}
+              </h3>
+            )}
             <div className="space-y-1">
               {section.items.map((item) => {
                 const Icon = item.icon;
@@ -117,18 +121,19 @@ export function EnhancedCreatorNav() {
                   <button
                     key={item.path}
                     onClick={() => navigate(item.path)}
+                    title={collapsed ? item.label : undefined}
                     className={`
-                      w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm
+                      w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm
                       transition-colors duration-200
-                      ${isActive 
-                        ? 'bg-brand-portal-creator/10 text-brand-portal-creator font-medium' 
+                      ${isActive
+                        ? 'bg-brand-portal-creator/10 text-brand-portal-creator font-medium'
                         : 'text-gray-700 hover:bg-gray-50 hover:text-gray-900'
                       }
                     `}
                   >
-                    <Icon className="w-4 h-4" />
-                    <span className="flex-1 text-left">{item.label}</span>
-                    {item.badge && (
+                    <Icon className="w-4 h-4 shrink-0" />
+                    {!collapsed && <span className="flex-1 text-left">{item.label}</span>}
+                    {!collapsed && item.badge && (
                       <span className="px-1.5 py-0.5 text-xs font-medium bg-gray-100 text-gray-700 rounded">
                         {item.badge}
                       </span>

--- a/frontend/src/shared/components/layout/EnhancedInvestorNav.tsx
+++ b/frontend/src/shared/components/layout/EnhancedInvestorNav.tsx
@@ -90,7 +90,7 @@ export const investorNavigationSections: NavigationSection[] = [
   },
 ];
 
-export function EnhancedInvestorNav() {
+export function EnhancedInvestorNav({ collapsed = false }: { collapsed?: boolean }) {
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -106,40 +106,44 @@ export function EnhancedInvestorNav() {
   };
 
   return (
-    <nav className="w-64 bg-white border-r border-gray-200 h-full overflow-y-auto">
-      <div className="p-4">
-        <h2 className="text-xl font-bold text-brand-portal-investor mb-4">Investor Portal</h2>
+    <nav className="w-full">
+      <div className={collapsed ? 'p-2' : 'p-4'}>
+        {!collapsed && <h2 className="text-xl font-bold text-brand-portal-investor mb-4">Investor Portal</h2>}
 
         {/* Quick Links - Always visible at top */}
         <div className="mb-6 pb-4 border-b border-gray-200">
-          <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-            Quick Links
-          </h3>
+          {!collapsed && (
+            <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+              Quick Links
+            </h3>
+          )}
           <div className="space-y-1">
             <Link
               to="/"
-              className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-brand-portal-investor/5 hover:text-brand-portal-investor transition-colors duration-200"
+              title={collapsed ? 'Home' : undefined}
+              className={`w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-brand-portal-investor/5 hover:text-brand-portal-investor transition-colors duration-200`}
             >
-              <Home className="w-4 h-4" />
-              <span className="flex-1 text-left">Home</span>
-              <ExternalLink className="w-3 h-3 text-gray-400" />
+              <Home className="w-4 h-4 shrink-0" />
+              {!collapsed && <><span className="flex-1 text-left">Home</span><ExternalLink className="w-3 h-3 text-gray-400" /></>}
             </Link>
             <Link
               to="/marketplace"
-              className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-brand-portal-investor/5 hover:text-brand-portal-investor transition-colors duration-200"
+              title={collapsed ? 'Marketplace' : undefined}
+              className={`w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-brand-portal-investor/5 hover:text-brand-portal-investor transition-colors duration-200`}
             >
-              <Store className="w-4 h-4" />
-              <span className="flex-1 text-left">Marketplace</span>
-              <ExternalLink className="w-3 h-3 text-gray-400" />
+              <Store className="w-4 h-4 shrink-0" />
+              {!collapsed && <><span className="flex-1 text-left">Marketplace</span><ExternalLink className="w-3 h-3 text-gray-400" /></>}
             </Link>
           </div>
         </div>
 
         {investorNavigationSections.map((section) => (
-          <div key={section.title} className="mb-6">
-            <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-              {section.title}
-            </h3>
+          <div key={section.title} className={collapsed ? 'mb-2' : 'mb-6'}>
+            {!collapsed && (
+              <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+                {section.title}
+              </h3>
+            )}
             <div className="space-y-1">
               {section.items.map((item) => {
                 const Icon = item.icon;
@@ -150,18 +154,19 @@ export function EnhancedInvestorNav() {
                   <button
                     key={item.path}
                     onClick={() => { void navigate(item.path); }}
+                    title={collapsed ? item.label : undefined}
                     className={`
-                      w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm
+                      w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm
                       transition-all duration-200
-                      ${isActive 
+                      ${isActive
                         ? colorScheme.active
                         : `text-gray-700 ${colorScheme.hover}`
                       }
                     `}
                   >
-                    <Icon className={`w-4 h-4 transition-colors ${colorScheme.icon}`} />
-                    <span className="flex-1 text-left">{item.label}</span>
-                    {item.badge && (
+                    <Icon className={`w-4 h-4 shrink-0 transition-colors ${colorScheme.icon}`} />
+                    {!collapsed && <span className="flex-1 text-left">{item.label}</span>}
+                    {!collapsed && item.badge && (
                       <span className="px-1.5 py-0.5 text-xs font-medium bg-gray-100 text-gray-700 rounded">
                         {item.badge}
                       </span>

--- a/frontend/src/shared/components/layout/EnhancedProductionNav.tsx
+++ b/frontend/src/shared/components/layout/EnhancedProductionNav.tsx
@@ -61,18 +61,18 @@ export const productionNavigationSections: NavigationSection[] = [
   },
 ];
 
-export function EnhancedProductionNav() {
+export function EnhancedProductionNav({ collapsed = false }: { collapsed?: boolean }) {
   const navigate = useNavigate();
   const location = useLocation();
 
   return (
-    <nav className="w-64 bg-white border-r border-gray-200 h-full overflow-y-auto">
-      <div className="p-4">
-        <h2 className="text-xl font-bold text-brand-portal-production mb-4">Production Portal</h2>
+    <nav className="w-full">
+      <div className={collapsed ? 'p-2' : 'p-4'}>
+        {!collapsed && <h2 className="text-xl font-bold text-brand-portal-production mb-4">Production Portal</h2>}
 
         {productionNavigationSections.map((section, sectionIdx) => (
-          <div key={section.title || `section-${sectionIdx}`} className="mb-5">
-            {section.title && (
+          <div key={section.title || `section-${sectionIdx}`} className={collapsed ? 'mb-2' : 'mb-5'}>
+            {!collapsed && section.title && (
               <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
                 {section.title}
               </h3>
@@ -87,8 +87,9 @@ export function EnhancedProductionNav() {
                   <button
                     key={item.path + item.label}
                     onClick={() => navigate(item.path)}
+                    title={collapsed ? item.label : undefined}
                     className={`
-                      w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm
+                      w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm
                       transition-colors duration-200
                       ${isActive
                         ? 'bg-brand-portal-production/10 text-brand-portal-production font-medium'
@@ -96,9 +97,9 @@ export function EnhancedProductionNav() {
                       }
                     `}
                   >
-                    <Icon className="w-4 h-4" />
-                    <span className="flex-1 text-left">{item.label}</span>
-                    {item.badge && (
+                    <Icon className="w-4 h-4 shrink-0" />
+                    {!collapsed && <span className="flex-1 text-left">{item.label}</span>}
+                    {!collapsed && item.badge && (
                       <span className="px-1.5 py-0.5 text-xs font-medium bg-red-100 text-red-700 rounded">
                         {item.badge}
                       </span>

--- a/frontend/src/shared/components/layout/EnhancedWatcherNav.tsx
+++ b/frontend/src/shared/components/layout/EnhancedWatcherNav.tsx
@@ -35,45 +35,49 @@ export const watcherNavigationSections: NavigationSection[] = [
   },
 ];
 
-export function EnhancedWatcherNav() {
+export function EnhancedWatcherNav({ collapsed = false }: { collapsed?: boolean }) {
   const navigate = useNavigate();
   const location = useLocation();
 
   return (
-    <nav className="w-64 bg-white border-r border-gray-200 h-full overflow-y-auto">
-      <div className="p-4">
-        <h2 className="text-xl font-bold text-cyan-600 mb-4">Watcher Portal</h2>
+    <nav className="w-full">
+      <div className={collapsed ? 'p-2' : 'p-4'}>
+        {!collapsed && <h2 className="text-xl font-bold text-cyan-600 mb-4">Watcher Portal</h2>}
 
         {/* Quick Links */}
         <div className="mb-6 pb-4 border-b border-gray-200">
-          <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-            Quick Links
-          </h3>
+          {!collapsed && (
+            <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+              Quick Links
+            </h3>
+          )}
           <div className="space-y-1">
             <Link
               to="/"
-              className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-cyan-50 hover:text-cyan-600 transition-colors duration-200"
+              title={collapsed ? 'Home' : undefined}
+              className={`w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-cyan-50 hover:text-cyan-600 transition-colors duration-200`}
             >
-              <Home className="w-4 h-4" />
-              <span className="flex-1 text-left">Home</span>
-              <ExternalLink className="w-3 h-3 text-gray-400" />
+              <Home className="w-4 h-4 shrink-0" />
+              {!collapsed && <><span className="flex-1 text-left">Home</span><ExternalLink className="w-3 h-3 text-gray-400" /></>}
             </Link>
             <Link
               to="/watcher/browse"
-              className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-cyan-50 hover:text-cyan-600 transition-colors duration-200"
+              title={collapsed ? 'Marketplace' : undefined}
+              className={`w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-cyan-50 hover:text-cyan-600 transition-colors duration-200`}
             >
-              <Store className="w-4 h-4" />
-              <span className="flex-1 text-left">Marketplace</span>
-              <ExternalLink className="w-3 h-3 text-gray-400" />
+              <Store className="w-4 h-4 shrink-0" />
+              {!collapsed && <><span className="flex-1 text-left">Marketplace</span><ExternalLink className="w-3 h-3 text-gray-400" /></>}
             </Link>
           </div>
         </div>
 
         {watcherNavigationSections.map((section) => (
-          <div key={section.title} className="mb-6">
-            <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-              {section.title}
-            </h3>
+          <div key={section.title} className={collapsed ? 'mb-2' : 'mb-6'}>
+            {!collapsed && (
+              <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+                {section.title}
+              </h3>
+            )}
             <div className="space-y-1">
               {section.items.map((item) => {
                 const Icon = item.icon;
@@ -83,8 +87,9 @@ export function EnhancedWatcherNav() {
                   <button
                     key={item.path}
                     onClick={() => navigate(item.path)}
+                    title={collapsed ? item.label : undefined}
                     className={`
-                      w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm
+                      w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm
                       transition-colors duration-200
                       ${isActive
                         ? 'bg-cyan-50 text-cyan-600 font-medium'
@@ -92,8 +97,8 @@ export function EnhancedWatcherNav() {
                       }
                     `}
                   >
-                    <Icon className="w-4 h-4" />
-                    <span className="flex-1 text-left">{item.label}</span>
+                    <Icon className="w-4 h-4 shrink-0" />
+                    {!collapsed && <span className="flex-1 text-left">{item.label}</span>}
                   </button>
                 );
               })}

--- a/frontend/src/shared/components/layout/PortalLayout.tsx
+++ b/frontend/src/shared/components/layout/PortalLayout.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, Suspense } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
+import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
 import { MinimalHeader } from './MinimalHeader';
 import { PageErrorBoundary } from '@shared/components/feedback/ConsoleErrorBoundary';
 import { getPortalTheme } from '@shared/hooks/usePortalTheme';
@@ -16,7 +17,11 @@ interface PortalLayoutProps {
 
 export function PortalLayout({ userType }: PortalLayoutProps) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false); // Closed by default on mobile
-  const [isDesktopSidebarCollapsed, _setIsDesktopSidebarCollapsed] = useState(false);
+  // Desktop sidebar collapse — persisted so it sticks across navigations/sessions.
+  // Collapsed = a slim icon rail (labels via tooltip); expanded = the full labelled nav.
+  const [isDesktopSidebarCollapsed, setIsDesktopSidebarCollapsed] = useState(() => {
+    try { return localStorage.getItem('pitchey:sidebarCollapsed') === '1'; } catch { return false; }
+  });
   const location = useLocation();
   const theme = getPortalTheme(userType);
 
@@ -29,18 +34,27 @@ export function PortalLayout({ userType }: PortalLayoutProps) {
     setIsSidebarOpen(!isSidebarOpen);
   };
 
-  const renderSidebar = () => {
+  const toggleDesktopSidebar = () => {
+    setIsDesktopSidebarCollapsed((prev) => {
+      const next = !prev;
+      try { localStorage.setItem('pitchey:sidebarCollapsed', next ? '1' : '0'); } catch { /* ignore */ }
+      return next;
+    });
+  };
+
+  // Mobile overlay always renders expanded (full width); only the desktop rail collapses.
+  const renderSidebar = (collapsed = false) => {
     switch (userType) {
       case 'creator':
-        return <EnhancedCreatorNav />;
+        return <EnhancedCreatorNav collapsed={collapsed} />;
       case 'investor':
-        return <EnhancedInvestorNav />;
+        return <EnhancedInvestorNav collapsed={collapsed} />;
       case 'production':
-        return <EnhancedProductionNav />;
+        return <EnhancedProductionNav collapsed={collapsed} />;
       case 'admin':
-        return <EnhancedAdminNav />;
+        return <EnhancedAdminNav collapsed={collapsed} />;
       case 'watcher':
-        return <EnhancedWatcherNav />;
+        return <EnhancedWatcherNav collapsed={collapsed} />;
       default:
         return null;
     }
@@ -63,31 +77,53 @@ export function PortalLayout({ userType }: PortalLayoutProps) {
           (top-16) keep the chrome pinned during natural window scroll. */}
       <div className="flex min-h-[calc(100vh-4rem)]">
         {/* Sidebar - Desktop. sticky + self-start so it stays pinned beside the
-            scrolling content; own height + overflow so a long nav scrolls internally. */}
+            scrolling content. flex-col: nav scrolls internally, collapse toggle pinned
+            at the bottom. The aside owns the chrome (bg/border/width) so the nav
+            components are width-agnostic content. */}
         <aside className={`
-          hidden lg:block transition-all duration-300 ease-in-out
-          sticky top-16 self-start h-[calc(100vh-4rem)] overflow-y-auto
+          hidden lg:flex lg:flex-col transition-all duration-300 ease-in-out
+          sticky top-16 self-start h-[calc(100vh-4rem)]
+          bg-white border-r border-gray-200
           ${isDesktopSidebarCollapsed ? 'w-16' : 'w-64'}
         `}>
-          {renderSidebar()}
+          <div className="flex-1 overflow-y-auto">
+            {renderSidebar(isDesktopSidebarCollapsed)}
+          </div>
+          <button
+            type="button"
+            onClick={toggleDesktopSidebar}
+            className="shrink-0 border-t border-gray-200 px-3 py-2.5 flex items-center justify-center gap-2 text-xs font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 transition-colors"
+            title={isDesktopSidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            aria-label={isDesktopSidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          >
+            {isDesktopSidebarCollapsed ? (
+              <PanelLeftOpen className="w-4 h-4" />
+            ) : (
+              <>
+                <PanelLeftClose className="w-4 h-4" />
+                <span>Collapse</span>
+              </>
+            )}
+          </button>
         </aside>
 
-        {/* Sidebar - Mobile Overlay */}
+        {/* Sidebar - Mobile Overlay (always full width — only the desktop rail collapses) */}
         {isSidebarOpen && (
           <>
             {/* Backdrop */}
-            <div 
+            <div
               className="lg:hidden fixed inset-0 bg-black bg-opacity-50 z-30"
               onClick={toggleSidebar}
             />
-            
+
             {/* Sidebar */}
             <aside className={`
-              lg:hidden fixed left-0 top-16 bottom-0 z-40
+              lg:hidden fixed left-0 top-16 bottom-0 z-40 w-64
+              bg-white border-r border-gray-200 overflow-y-auto
               transform transition-transform duration-300 ease-in-out
               ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full'}
             `}>
-              {renderSidebar()}
+              {renderSidebar(false)}
             </aside>
           </>
         )}


### PR DESCRIPTION
Reduces the always-on sidebar density (esp. creator: ~16 items / 6 sections + Quick Links, which duplicate the header and overlap the new dashboard/pitch-library tabs).

## What
- Adds a **persisted collapse toggle** (pinned at the bottom of the desktop rail).
- **Collapsed** = slim `w-16` icon rail, labels via tooltip; **expanded** = full labelled nav.
- All five portal navs (creator/investor/production/admin/watcher) take a `collapsed` prop; the `aside` owns the chrome (bg/border/width) so navs are width-agnostic content.

## Safety
- **Default is EXPANDED — identical to today.** Collapse is opt-in, persisted in `localStorage` per browser. Nobody's experience changes unless they click "Collapse."
- Mobile overlay unaffected (always full).
- `tsc` clean; 40 nav/navigation tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)