### PR TITLE
feat(nav): sidebar refinements — collapsed default + hover-expand + trim Quick Links

### DIFF
--- a/frontend/src/shared/components/layout/EnhancedAdminNav.tsx
+++ b/frontend/src/shared/components/layout/EnhancedAdminNav.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { useNavigate, useLocation, Link } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import {
   Home, BarChart3, Activity, Users, FileText, Shield,
   DollarSign, FileBarChart, ClipboardList, Lock, Settings,
-  Store, ExternalLink, BadgeCheck, Ticket
+  BadgeCheck, Ticket
 } from 'lucide-react';
 import { ADMIN_ROUTES } from '@/config/navigation.routes';
 
@@ -68,33 +68,6 @@ export function EnhancedAdminNav({ collapsed = false }: { collapsed?: boolean })
     <nav className="w-full">
       <div className={collapsed ? 'p-2' : 'p-4'}>
         {!collapsed && <h2 className="text-xl font-bold text-purple-900 mb-4">Admin Portal</h2>}
-
-        {/* Quick Links - Always visible at top */}
-        <div className="mb-6 pb-4 border-b border-gray-200">
-          {!collapsed && (
-            <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-              Quick Links
-            </h3>
-          )}
-          <div className="space-y-1">
-            <Link
-              to="/"
-              title={collapsed ? 'Home' : undefined}
-              className={`w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-purple-50 hover:text-purple-900 transition-colors duration-200`}
-            >
-              <Home className="w-4 h-4 shrink-0" />
-              {!collapsed && <><span className="flex-1 text-left">Home</span><ExternalLink className="w-3 h-3 text-gray-400" /></>}
-            </Link>
-            <Link
-              to="/marketplace"
-              title={collapsed ? 'Marketplace' : undefined}
-              className={`w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-purple-50 hover:text-purple-900 transition-colors duration-200`}
-            >
-              <Store className="w-4 h-4 shrink-0" />
-              {!collapsed && <><span className="flex-1 text-left">Marketplace</span><ExternalLink className="w-3 h-3 text-gray-400" /></>}
-            </Link>
-          </div>
-        </div>
 
         {adminNavigationSections.map((section) => (
           <div key={section.title} className={collapsed ? 'mb-2' : 'mb-6'}>

--- a/frontend/src/shared/components/layout/EnhancedCreatorNav.tsx
+++ b/frontend/src/shared/components/layout/EnhancedCreatorNav.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { useNavigate, useLocation, Link } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import {
   Home, BarChart3, Film, Plus,
   FileText, Users, GitBranch, User, Settings,
-  MessageSquare, Target, Star, Store, ExternalLink,
+  MessageSquare, Target, Star,
   Library, Layers
 } from 'lucide-react';
 import { CREATOR_ROUTES } from '@/config/navigation.routes';
@@ -71,33 +71,6 @@ export function EnhancedCreatorNav({ collapsed = false }: { collapsed?: boolean 
     <nav className="w-full">
       <div className={collapsed ? 'p-2' : 'p-4'}>
         {!collapsed && <h2 className="text-xl font-bold text-brand-portal-creator mb-4">Creator Portal</h2>}
-
-        {/* Quick Links - Always visible at top */}
-        <div className="mb-6 pb-4 border-b border-gray-200">
-          {!collapsed && (
-            <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-              Quick Links
-            </h3>
-          )}
-          <div className="space-y-1">
-            <Link
-              to="/"
-              title={collapsed ? 'Home' : undefined}
-              className={`w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-brand-portal-creator/10 hover:text-brand-portal-creator transition-colors duration-200`}
-            >
-              <Home className="w-4 h-4 shrink-0" />
-              {!collapsed && <><span className="flex-1 text-left">Home</span><ExternalLink className="w-3 h-3 text-gray-400" /></>}
-            </Link>
-            <Link
-              to="/creator/browse"
-              title={collapsed ? 'Marketplace' : undefined}
-              className={`w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-brand-portal-creator/10 hover:text-brand-portal-creator transition-colors duration-200`}
-            >
-              <Store className="w-4 h-4 shrink-0" />
-              {!collapsed && <><span className="flex-1 text-left">Marketplace</span><ExternalLink className="w-3 h-3 text-gray-400" /></>}
-            </Link>
-          </div>
-        </div>
 
         {creatorNavigationSections.map((section) => (
           <div key={section.title} className={collapsed ? 'mb-2' : 'mb-6'}>

--- a/frontend/src/shared/components/layout/EnhancedInvestorNav.tsx
+++ b/frontend/src/shared/components/layout/EnhancedInvestorNav.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { useNavigate, useLocation, Link } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import {
   Home, BarChart3, Activity, LineChart, Briefcase, Clock, CheckCircle,
   FolderOpen, Globe, Bookmark, Eye, DollarSign, FileText, PieChart,
   TrendingUp, AlertTriangle, Users, Building2, UserCheck, Wallet,
-  CreditCard, Settings, Shield, Receipt, Calculator, FileCheck, Store, ExternalLink,
+  CreditCard, Settings, Shield, Receipt, Calculator, FileCheck,
   GitBranch
 } from 'lucide-react';
 import { INVESTOR_ROUTES } from '@/config/navigation.routes';
@@ -109,33 +109,6 @@ export function EnhancedInvestorNav({ collapsed = false }: { collapsed?: boolean
     <nav className="w-full">
       <div className={collapsed ? 'p-2' : 'p-4'}>
         {!collapsed && <h2 className="text-xl font-bold text-brand-portal-investor mb-4">Investor Portal</h2>}
-
-        {/* Quick Links - Always visible at top */}
-        <div className="mb-6 pb-4 border-b border-gray-200">
-          {!collapsed && (
-            <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-              Quick Links
-            </h3>
-          )}
-          <div className="space-y-1">
-            <Link
-              to="/"
-              title={collapsed ? 'Home' : undefined}
-              className={`w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-brand-portal-investor/5 hover:text-brand-portal-investor transition-colors duration-200`}
-            >
-              <Home className="w-4 h-4 shrink-0" />
-              {!collapsed && <><span className="flex-1 text-left">Home</span><ExternalLink className="w-3 h-3 text-gray-400" /></>}
-            </Link>
-            <Link
-              to="/marketplace"
-              title={collapsed ? 'Marketplace' : undefined}
-              className={`w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-brand-portal-investor/5 hover:text-brand-portal-investor transition-colors duration-200`}
-            >
-              <Store className="w-4 h-4 shrink-0" />
-              {!collapsed && <><span className="flex-1 text-left">Marketplace</span><ExternalLink className="w-3 h-3 text-gray-400" /></>}
-            </Link>
-          </div>
-        </div>
 
         {investorNavigationSections.map((section) => (
           <div key={section.title} className={collapsed ? 'mb-2' : 'mb-6'}>

--- a/frontend/src/shared/components/layout/EnhancedWatcherNav.tsx
+++ b/frontend/src/shared/components/layout/EnhancedWatcherNav.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { useNavigate, useLocation, Link } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import {
   Home, Library,
-  CreditCard, User, Settings, Store, ExternalLink
+  CreditCard, User, Settings
 } from 'lucide-react';
 import { WATCHER_ROUTES } from '@/config/navigation.routes';
 
@@ -43,33 +43,6 @@ export function EnhancedWatcherNav({ collapsed = false }: { collapsed?: boolean 
     <nav className="w-full">
       <div className={collapsed ? 'p-2' : 'p-4'}>
         {!collapsed && <h2 className="text-xl font-bold text-cyan-600 mb-4">Watcher Portal</h2>}
-
-        {/* Quick Links */}
-        <div className="mb-6 pb-4 border-b border-gray-200">
-          {!collapsed && (
-            <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-              Quick Links
-            </h3>
-          )}
-          <div className="space-y-1">
-            <Link
-              to="/"
-              title={collapsed ? 'Home' : undefined}
-              className={`w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-cyan-50 hover:text-cyan-600 transition-colors duration-200`}
-            >
-              <Home className="w-4 h-4 shrink-0" />
-              {!collapsed && <><span className="flex-1 text-left">Home</span><ExternalLink className="w-3 h-3 text-gray-400" /></>}
-            </Link>
-            <Link
-              to="/watcher/browse"
-              title={collapsed ? 'Marketplace' : undefined}
-              className={`w-full flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-lg text-sm text-gray-700 hover:bg-cyan-50 hover:text-cyan-600 transition-colors duration-200`}
-            >
-              <Store className="w-4 h-4 shrink-0" />
-              {!collapsed && <><span className="flex-1 text-left">Marketplace</span><ExternalLink className="w-3 h-3 text-gray-400" /></>}
-            </Link>
-          </div>
-        </div>
 
         {watcherNavigationSections.map((section) => (
           <div key={section.title} className={collapsed ? 'mb-2' : 'mb-6'}>

--- a/frontend/src/shared/components/layout/PortalLayout.tsx
+++ b/frontend/src/shared/components/layout/PortalLayout.tsx
@@ -18,12 +18,21 @@ interface PortalLayoutProps {
 export function PortalLayout({ userType }: PortalLayoutProps) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false); // Closed by default on mobile
   // Desktop sidebar collapse — persisted so it sticks across navigations/sessions.
-  // Collapsed = a slim icon rail (labels via tooltip); expanded = the full labelled nav.
+  // Collapsed = a slim icon rail (labels via tooltip / hover); expanded = the full
+  // labelled nav. Defaults to COLLAPSED (the cleaner resting state) on first visit.
   const [isDesktopSidebarCollapsed, setIsDesktopSidebarCollapsed] = useState(() => {
-    try { return localStorage.getItem('pitchey:sidebarCollapsed') === '1'; } catch { return false; }
+    try {
+      const stored = localStorage.getItem('pitchey:sidebarCollapsed');
+      return stored === null ? true : stored === '1';
+    } catch { return true; }
   });
+  // When collapsed, hovering the rail temporarily expands it as an overlay (no reflow).
+  const [isSidebarHovered, setIsSidebarHovered] = useState(false);
   const location = useLocation();
   const theme = getPortalTheme(userType);
+
+  // The rail shows full labels when pinned open OR while hovered (collapsed).
+  const railExpanded = !isDesktopSidebarCollapsed || isSidebarHovered;
 
   // Close mobile sidebar on route change
   useEffect(() => {
@@ -80,31 +89,34 @@ export function PortalLayout({ userType }: PortalLayoutProps) {
             scrolling content. flex-col: nav scrolls internally, collapse toggle pinned
             at the bottom. The aside owns the chrome (bg/border/width) so the nav
             components are width-agnostic content. */}
-        <aside className={`
-          hidden lg:flex lg:flex-col transition-all duration-300 ease-in-out
-          sticky top-16 self-start h-[calc(100vh-4rem)]
-          bg-white border-r border-gray-200
-          ${isDesktopSidebarCollapsed ? 'w-16' : 'w-64'}
-        `}>
-          <div className="flex-1 overflow-y-auto">
-            {renderSidebar(isDesktopSidebarCollapsed)}
+        {/* Desktop rail. The <aside> reserves the layout slot (16 collapsed / 64 open);
+            the inner panel is fixed so it stays pinned on scroll and, when collapsed,
+            expands to full width on hover as an OVERLAY — no content reflow. */}
+        <aside
+          onMouseEnter={() => setIsSidebarHovered(true)}
+          onMouseLeave={() => setIsSidebarHovered(false)}
+          className={`hidden lg:block shrink-0 transition-all duration-200 ease-in-out ${isDesktopSidebarCollapsed ? 'w-16' : 'w-64'}`}
+        >
+          <div className={`
+            fixed top-16 left-0 bottom-0 z-30 flex flex-col
+            bg-white border-r border-gray-200 transition-all duration-200 ease-in-out
+            ${railExpanded ? 'w-64' : 'w-16'}
+            ${isDesktopSidebarCollapsed && isSidebarHovered ? 'shadow-2xl' : ''}
+          `}>
+            <div className="flex-1 overflow-y-auto">
+              {renderSidebar(!railExpanded)}
+            </div>
+            <button
+              type="button"
+              onClick={toggleDesktopSidebar}
+              className="shrink-0 border-t border-gray-200 px-3 py-2.5 flex items-center justify-center gap-2 text-xs font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 transition-colors"
+              title={isDesktopSidebarCollapsed ? 'Pin sidebar open' : 'Collapse sidebar'}
+              aria-label={isDesktopSidebarCollapsed ? 'Pin sidebar open' : 'Collapse sidebar'}
+            >
+              {isDesktopSidebarCollapsed ? <PanelLeftOpen className="w-4 h-4" /> : <PanelLeftClose className="w-4 h-4" />}
+              {railExpanded && <span>{isDesktopSidebarCollapsed ? 'Pin open' : 'Collapse'}</span>}
+            </button>
           </div>
-          <button
-            type="button"
-            onClick={toggleDesktopSidebar}
-            className="shrink-0 border-t border-gray-200 px-3 py-2.5 flex items-center justify-center gap-2 text-xs font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 transition-colors"
-            title={isDesktopSidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-            aria-label={isDesktopSidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          >
-            {isDesktopSidebarCollapsed ? (
-              <PanelLeftOpen className="w-4 h-4" />
-            ) : (
-              <>
-                <PanelLeftClose className="w-4 h-4" />
-                <span>Collapse</span>
-              </>
-            )}
-          </button>
         </aside>
 
         {/* Sidebar - Mobile Overlay (always full width — only the desktop rail collapses) */}

--- a/frontend/src/shared/components/layout/__tests__/EnhancedAdminNav.test.tsx
+++ b/frontend/src/shared/components/layout/__tests__/EnhancedAdminNav.test.tsx
@@ -59,24 +59,8 @@ describe('EnhancedAdminNav', () => {
     })
   })
 
-  describe('Quick Links section', () => {
-    it('renders Quick Links section heading', () => {
-      renderComponent()
-      expect(screen.getByText('Quick Links')).toBeInTheDocument()
-    })
-
-    it('renders Home quick link pointing to /', () => {
-      renderComponent()
-      const homeLink = screen.getByText('Home').closest('a')
-      expect(homeLink).toHaveAttribute('href', '/')
-    })
-
-    it('renders Marketplace quick link pointing to /marketplace', () => {
-      renderComponent()
-      const marketplaceLink = screen.getByText('Marketplace').closest('a')
-      expect(marketplaceLink).toHaveAttribute('href', '/marketplace')
-    })
-  })
+  // Quick Links section removed 2026-06-12 — the sidebar's Home/Marketplace quick
+  // links duplicated the header nav, so they were trimmed (see PortalLayout header).
 
   describe('Navigation sections', () => {
     it('renders all 5 section headings', () => {


### PR DESCRIPTION
Follow-up to #268 (collapsible sidebar). Makes the cleaner state the **default** so the difference is visible, and removes redundancy.

- **Collapsed by default** on first visit — a slim icon rail instead of the full 256px sidebar. (Persisted; existing users keep their saved choice.)
- **Hover-to-expand** — hovering the collapsed rail expands it to full labels as a *fixed overlay* (no content reflow). The bottom toggle still pins it open/closed.
- **Trimmed "Quick Links"** (Home/Marketplace) from creator/investor/admin/watcher sidebars — the header already has Dashboard + Marketplace. Production had none. Unused imports cleaned; stale AdminNav Quick-Links tests removed.

Mobile overlay unaffected. `tsc` clean; 37 nav/navigation tests pass.