### PR TITLE
fix(nav): de-glitch sidebar hover + film-strip LogoLoader

### DIFF
--- a/frontend/src/components/LogoLoader.tsx
+++ b/frontend/src/components/LogoLoader.tsx
@@ -1,0 +1,67 @@
+/**
+ * LogoLoader — Pitchey "running film" loading animation.
+ *
+ * A crisp SVG film-strip (sprocket holes + translucent frame windows) that scrolls
+ * vertically in a seamless loop, evoking film running through a projector gate.
+ * Reusable anywhere a loading state is needed: route Suspense fallbacks, button
+ * spinners, full-page splash, etc.
+ *
+ * Implementation: the element repeats a single film tile (`background-repeat: repeat-y`)
+ * and the `.pitchey-film-anim` class (see index.css) scrolls the background by exactly
+ * one tile height (`--film-tile`), so the loop is seamless at any size. Honors
+ * `prefers-reduced-motion`.
+ */
+
+interface LogoLoaderProps {
+  size?: 'sm' | 'md' | 'lg';
+  /** Optional caption rendered under the strip (also improves a11y). */
+  label?: string;
+  className?: string;
+}
+
+const DIMS = {
+  sm: { w: 26, h: 32, tile: 17 },
+  md: { w: 40, h: 50, tile: 25 },
+  lg: { w: 58, h: 72, tile: 36 },
+} as const;
+
+// One film tile: brand-violet body, a darker frame divider, white sprocket holes down
+// both edges, and a translucent frame window. preserveAspectRatio='none' lets it stretch
+// to the tile box; it repeats vertically to form a continuous strip.
+const TILE_SVG = encodeURIComponent(
+  `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 26' preserveAspectRatio='none'>` +
+    `<rect width='48' height='26' fill='#5B4FC7'/>` +
+    `<rect width='48' height='2' fill='#3F2F99'/>` +
+    `<rect x='4' y='8' width='7' height='10' rx='2' fill='#ffffff'/>` +
+    `<rect x='37' y='8' width='7' height='10' rx='2' fill='#ffffff'/>` +
+    `<rect x='15' y='4' width='18' height='18' rx='2' fill='#ffffff' opacity='0.18'/>` +
+  `</svg>`
+);
+
+export default function LogoLoader({ size = 'md', label, className = '' }: LogoLoaderProps) {
+  const d = DIMS[size];
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`inline-flex flex-col items-center gap-2 ${className}`}
+    >
+      <div
+        className="pitchey-film-anim rounded-md ring-1 ring-black/10 shadow-sm"
+        style={{
+          width: d.w,
+          height: d.h,
+          // consumed by the @keyframes scroll distance
+          ['--film-tile' as string]: `${d.tile}px`,
+          backgroundImage: `url("data:image/svg+xml,${TILE_SVG}")`,
+          backgroundRepeat: 'repeat-y',
+          backgroundSize: `${d.w}px ${d.tile}px`,
+        } as React.CSSProperties}
+        aria-hidden="true"
+      />
+      {label && <span className="text-xs font-medium text-gray-500">{label}</span>}
+      <span className="sr-only">{label || 'Loading…'}</span>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -423,3 +423,16 @@
     }
   }
 }
+/* ── Pitchey film-strip loader ──────────────────────────────────────────────
+   Reusable "running film" load animation (see components/LogoLoader.tsx).
+   The element paints a vertically-repeating film tile and scrolls the
+   background by exactly one tile height, so the loop is seamless. */
+@keyframes pitchey-film-run {
+  to { background-position-y: var(--film-tile, 25px); }
+}
+.pitchey-film-anim {
+  animation: pitchey-film-run 0.8s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .pitchey-film-anim { animation: none; }
+}

--- a/frontend/src/shared/components/layout/PortalLayout.tsx
+++ b/frontend/src/shared/components/layout/PortalLayout.tsx
@@ -4,6 +4,7 @@ import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
 import { MinimalHeader } from './MinimalHeader';
 import { PageErrorBoundary } from '@shared/components/feedback/ConsoleErrorBoundary';
 import { getPortalTheme } from '@shared/hooks/usePortalTheme';
+import LogoLoader from '@/components/LogoLoader';
 
 import { EnhancedCreatorNav } from './EnhancedCreatorNav';
 import { EnhancedInvestorNav } from './EnhancedInvestorNav';
@@ -92,14 +93,17 @@ export function PortalLayout({ userType }: PortalLayoutProps) {
         {/* Desktop rail. The <aside> reserves the layout slot (16 collapsed / 64 open);
             the inner panel is fixed so it stays pinned on scroll and, when collapsed,
             expands to full width on hover as an OVERLAY — no content reflow. */}
-        <aside
-          onMouseEnter={() => setIsSidebarHovered(true)}
-          onMouseLeave={() => setIsSidebarHovered(false)}
-          className={`hidden lg:block shrink-0 transition-all duration-200 ease-in-out ${isDesktopSidebarCollapsed ? 'w-16' : 'w-64'}`}
-        >
-          <div className={`
+        <aside className={`hidden lg:block shrink-0 transition-[width] duration-200 ease-in-out ${isDesktopSidebarCollapsed ? 'w-16' : 'w-64'}`}>
+          {/* Hover handlers live on the FIXED panel (the element that actually grows to
+              w-64), NOT the w-16 placeholder above — otherwise the cursor leaves the
+              listening element the instant the panel expands, causing expand/collapse
+              flicker. */}
+          <div
+            onMouseEnter={() => setIsSidebarHovered(true)}
+            onMouseLeave={() => setIsSidebarHovered(false)}
+            className={`
             fixed top-16 left-0 bottom-0 z-30 flex flex-col
-            bg-white border-r border-gray-200 transition-all duration-200 ease-in-out
+            bg-white border-r border-gray-200 transition-[width] duration-200 ease-in-out
             ${railExpanded ? 'w-64' : 'w-16'}
             ${isDesktopSidebarCollapsed && isSidebarHovered ? 'shadow-2xl' : ''}
           `}>
@@ -150,7 +154,7 @@ export function PortalLayout({ userType }: PortalLayoutProps) {
           <div className="container mx-auto px-4 py-6 max-w-7xl">
             {/* Page Content - key forces re-render on route change and resets error boundary */}
             <PageErrorBoundary key={location.pathname}>
-              <Suspense fallback={<div className="flex items-center justify-center h-64"><div className={`animate-spin rounded-full h-8 w-8 border-b-2 ${theme.spinnerBorder}`}></div></div>}>
+              <Suspense fallback={<div className="flex items-center justify-center h-64"><LogoLoader size="md" /></div>}>
                 <Outlet />
               </Suspense>
             </PageErrorBoundary>


### PR DESCRIPTION
## 1. Sidebar hover flicker (bug fix)
The `onMouseEnter/Leave` handlers were on the `w-16` placeholder `<aside>`, but the panel that expands to `w-64` is its `fixed` child. The moment it expanded, the cursor was *outside* the listening element → `mouseleave` → collapse → re-trigger → **flicker**. Moved the handlers onto the fixed panel; narrowed the transition to `width` only for smoother motion.

## 2. Film-strip LogoLoader (new, reusable)
A "running film" loading animation: a crisp **SVG film-strip** (sprocket holes + frame windows, brand violet `#5B4FC7`) that scrolls vertically in a **seamless loop** (`repeat-y` + one-tile background scroll). Sizes sm/md/lg, honors `prefers-reduced-motion`. Wired into the PortalLayout route Suspense fallback (replacing the generic ring spinner) — reusable for button states, splash screens, etc.

`tsc` clean; nav tests pass. No Higgsfield needed — pure CSS/SVG, tiny + crisp.