### PR TITLE
feat(ui): premium LogoSplash for app-boot / route loads

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,7 @@ import { sessionCache } from './store/sessionCache';
 import { GlobalErrorBoundary } from '@shared/components/feedback/ConsoleErrorBoundary';
 import ToastProvider from '@shared/components/feedback/ToastProvider';
 import { NotificationToastProvider } from '@shared/components/feedback/NotificationToastContainer';
-import LoadingSpinner from '@shared/components/feedback/LoadingSpinner';
+import LogoSplash from '@/components/LogoSplash';
 // Import safe context provider (without legacy AuthProvider)
 import { AppContextProviderSafe } from '@shared/contexts/AppContextProviderSafe';
 import { configService } from './services/config.service';
@@ -282,11 +282,7 @@ function PitchRouter() {
   // during the hydration race. Show the app's standard loading state and only
   // decide PitchDetail-vs-PublicPitchView once auth has settled.
   if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <LoadingSpinner size="lg" text="Loading..." />
-      </div>
-    );
+    return <LogoSplash message="Loading…" />;
   }
 
   // Also treat a valid cached session as authenticated for routing purposes, so
@@ -392,12 +388,7 @@ function App() {
   // Show loading state while initializing to prevent flicker and navigation loops
   if (initializing || !sessionChecked) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-50 to-gray-100">
-        <div className="text-center">
-          <LoadingSpinner size="lg" text="Loading..." />
-          <p className="mt-4 text-gray-600">Please wait...</p>
-        </div>
-      </div>
+      <LogoSplash message="Preparing your workspace…" />
     );
   }
 
@@ -409,14 +400,7 @@ function App() {
         <NotificationToastProvider>
           <ToastProvider>
             <Router>
-              <Suspense fallback={
-                <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-50 to-gray-100">
-                  <div className="text-center">
-                    <LoadingSpinner size="lg" text="Loading..." />
-                    <p className="mt-4 text-gray-600">Optimizing your experience...</p>
-                  </div>
-                </div>
-              }>
+              <Suspense fallback={<LogoSplash message="Optimizing your experience…" />}>
                 <Routes>
           {/* Homepage - Only render on exact path match */}
           <Route path="/" element={<Homepage />} />

--- a/frontend/src/components/LogoLoader.tsx
+++ b/frontend/src/components/LogoLoader.tsx
@@ -14,6 +14,8 @@
 
 interface LogoLoaderProps {
   size?: 'sm' | 'md' | 'lg';
+  /** Animation pace — snappy for buttons, calm for splash screens. */
+  speed?: 'fast' | 'normal' | 'slow';
   /** Optional caption rendered under the strip (also improves a11y). */
   label?: string;
   className?: string;
@@ -24,6 +26,8 @@ const DIMS = {
   md: { w: 40, h: 50, tile: 25 },
   lg: { w: 58, h: 72, tile: 36 },
 } as const;
+
+const SPEED = { fast: '0.6s', normal: '0.8s', slow: '1.15s' } as const;
 
 // One film tile: brand-violet body, a darker frame divider, white sprocket holes down
 // both edges, and a translucent frame window. preserveAspectRatio='none' lets it stretch
@@ -38,7 +42,7 @@ const TILE_SVG = encodeURIComponent(
   `</svg>`
 );
 
-export default function LogoLoader({ size = 'md', label, className = '' }: LogoLoaderProps) {
+export default function LogoLoader({ size = 'md', speed = 'normal', label, className = '' }: LogoLoaderProps) {
   const d = DIMS[size];
 
   return (
@@ -54,6 +58,7 @@ export default function LogoLoader({ size = 'md', label, className = '' }: LogoL
           height: d.h,
           // consumed by the @keyframes scroll distance
           ['--film-tile' as string]: `${d.tile}px`,
+          animationDuration: SPEED[speed],
           backgroundImage: `url("data:image/svg+xml,${TILE_SVG}")`,
           backgroundRepeat: 'repeat-y',
           backgroundSize: `${d.w}px ${d.tile}px`,

--- a/frontend/src/components/LogoSplash.tsx
+++ b/frontend/src/components/LogoSplash.tsx
@@ -1,0 +1,47 @@
+/**
+ * LogoSplash — the elevated, full-page loading moment for app boot / route splashes.
+ *
+ * Same film-strip DNA as LogoLoader, dialed up for big moments: the strip runs at a
+ * calmer pace inside a "projector gate" (framed card + a faint light flicker), with the
+ * Pitchey wordmark and a contextual caption fading up beneath it. Everywhere else keeps
+ * the bare LogoLoader strip — one identity, more polish only where it counts.
+ *
+ * Honors prefers-reduced-motion (see index.css).
+ */
+import Logo from './Logo';
+import LogoLoader from './LogoLoader';
+
+interface LogoSplashProps {
+  /** Contextual line under the wordmark, e.g. "Preparing your dashboard…". */
+  message?: string;
+  /** Full-screen overlay (default) vs. an inline centered block. */
+  fullScreen?: boolean;
+}
+
+export default function LogoSplash({ message = 'Loading…', fullScreen = true }: LogoSplashProps) {
+  const inner = (
+    <div className="flex flex-col items-center gap-6">
+      {/* Projector gate: the running film strip framed with a soft vignette + light flicker. */}
+      <div className="relative rounded-2xl bg-white p-3.5 shadow-lg ring-1 ring-black/5">
+        <LogoLoader size="lg" speed="slow" />
+        <span
+          className="pitchey-gate-flicker pointer-events-none absolute inset-0 rounded-2xl"
+          aria-hidden="true"
+        />
+      </div>
+
+      <div className="pitchey-splash-rise flex flex-col items-center gap-2.5">
+        <Logo size="md" />
+        <p className="text-sm text-gray-500">{message}</p>
+      </div>
+    </div>
+  );
+
+  if (!fullScreen) return inner;
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-gradient-to-br from-gray-50 to-gray-100">
+      {inner}
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -436,3 +436,26 @@
 @media (prefers-reduced-motion: reduce) {
   .pitchey-film-anim { animation: none; }
 }
+
+/* ── Pitchey splash (LogoSplash) — premium app-boot / route load moment ───── */
+@keyframes pitchey-splash-rise {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.pitchey-splash-rise { animation: pitchey-splash-rise 0.5s ease-out both; }
+
+/* Faint projector-light flicker over the film gate */
+@keyframes pitchey-gate-flicker {
+  0%, 100% { opacity: 0; }
+  45%      { opacity: 0.06; }
+  55%      { opacity: 0.10; }
+  70%      { opacity: 0.04; }
+}
+.pitchey-gate-flicker {
+  background: radial-gradient(120% 80% at 50% 28%, rgba(255,255,255,0.9), transparent 70%);
+  animation: pitchey-gate-flicker 2.4s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .pitchey-splash-rise { animation: none; }
+  .pitchey-gate-flicker { animation: none; opacity: 0; }
+}


### PR DESCRIPTION
Spices up the **big** loading moments (app boot / route splashes) while keeping one loader identity everywhere else.

- **`<LogoSplash>`** — the film strip at a calmer pace inside a **projector gate** (framed card + faint light flicker), with the **Pitchey wordmark** + a contextual caption fading up beneath. `prefers-reduced-motion` honored.
- **`LogoLoader` `speed` prop** (`fast`/`normal`/`slow`) — same animation, paced to context (snappy buttons, calm splash).
- Wired into App.tsx's three full-page loaders (auth-resolve, app-init, route-chunk Suspense), replacing the generic ring spinner. The bare strip stays for inline/section/button states.

Design choice: **one identity, dialed up only where it counts** — avoids the "five different spinners" inconsistency. `tsc` clean.