### PR TITLE
feat(ui): film loader on high-traffic page data-loads (targeted pass)

### DIFF
--- a/frontend/src/pages/Billing.tsx
+++ b/frontend/src/pages/Billing.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, Link, useSearchParams } from 'react-router-dom';
 import { toast } from 'react-hot-toast';
+import LogoLoader from '@/components/LogoLoader';
 import {
   CreditCard,
   Download,
@@ -110,7 +111,7 @@ export default function Billing() {
     return (
       <div className="flex items-center justify-center py-16">
         <div className="text-center">
-          <div className={`animate-spin rounded-full h-12 w-12 border-b-2 ${theme.spinnerBorder} mx-auto`}></div>
+          <LogoLoader size="md" className="mx-auto" />
           <p className="mt-4 text-gray-600">Loading billing information...</p>
         </div>
       </div>

--- a/frontend/src/pages/CreatorPortfolio.tsx
+++ b/frontend/src/pages/CreatorPortfolio.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Plus, Eye, TrendingUp, Film, MapPin, Calendar, BadgeCheck, E
 import { apiClient } from '../lib/api-client';
 import { useBetterAuthStore } from '../store/betterAuthStore';
 import ShareLinksModal from '../components/portfolio/ShareLinksModal';
+import LogoLoader from '@/components/LogoLoader';
 
 interface Pitch {
   id: string;
@@ -106,7 +107,7 @@ export default function CreatorPortfolio() {
     return (
       <div className="min-h-screen bg-gradient-to-br from-purple-50 to-indigo-50 flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-purple-600 mx-auto"></div>
+          <LogoLoader size="md" className="mx-auto" />
           <p className="mt-4 text-gray-600">Loading portfolio...</p>
         </div>
       </div>

--- a/frontend/src/pages/CreatorProfile.tsx
+++ b/frontend/src/pages/CreatorProfile.tsx
@@ -6,6 +6,7 @@ import {
   MessageSquare, Bookmark, UserPlus, UserCheck, TrendingUp
 } from 'lucide-react';
 import { useBetterAuthStore } from '../store/betterAuthStore';
+import LogoLoader from '@/components/LogoLoader';
 import FollowButton from '@features/browse/components/FollowButton';
 import { config } from '../config';
 import FormatDisplay from '../components/FormatDisplay';
@@ -208,7 +209,7 @@ const CreatorProfile = () => {
   if (loading) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600"></div>
+        <LogoLoader size="md" />
       </div>
     );
   }

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -4,6 +4,7 @@ import { Camera, Mail, Phone, MapPin, Building2, Calendar, Edit3, Save, X, Loade
 import { useBetterAuthStore } from '../store/betterAuthStore';
 import { API_URL } from '../config';
 import { usePortalTheme } from '@shared/hooks/usePortalTheme';
+import LogoLoader from '@/components/LogoLoader';
 import { prepareImageForUpload, PRE_COMPRESSION_MAX_BYTES } from '../utils/imageUpload';
 
 interface UserProfile {
@@ -214,7 +215,7 @@ export default function Profile() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-16">
-        <div className={`animate-spin rounded-full h-8 w-8 border-b-2 ${theme.spinnerBorder}`}></div>
+        <LogoLoader size="md" />
       </div>
     );
   }

--- a/frontend/src/pages/PublicPitchView.tsx
+++ b/frontend/src/pages/PublicPitchView.tsx
@@ -4,6 +4,7 @@ import { Eye, Heart, Share2, Tag, Film, Calendar, User, Shield, Lock, DollarSign
 import { pitchAPI } from '../lib/api';
 import type { Pitch } from '../lib/api';
 import { useBetterAuthStore } from '../store/betterAuthStore';
+import LogoLoader from '@/components/LogoLoader';
 import { formatCurrency } from '@shared/utils/formatters';
 import PortalTopNav from '@shared/components/layout/PortalTopNav';
 import { ndaService } from '@features/ndas/services/nda.service';
@@ -200,7 +201,7 @@ export default function PublicPitchView() {
   if (loading) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600"></div>
+        <LogoLoader size="md" />
       </div>
     );
   }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -7,6 +7,7 @@ import { sessionManager } from '../lib/session-manager';
 import { UserService } from '../services/user.service';
 import { API_URL } from '../config';
 import { usePortalTheme } from '@shared/hooks/usePortalTheme';
+import LogoLoader from '@/components/LogoLoader';
 
 interface NotificationSettings {
   emailNotifications: boolean;
@@ -209,7 +210,7 @@ export default function Settings() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-16">
-        <div className={`animate-spin rounded-full h-8 w-8 border-b-2 ${theme.spinnerBorder}`}></div>
+        <LogoLoader size="md" />
       </div>
     );
   }

--- a/frontend/src/pages/__tests__/Billing.test.tsx
+++ b/frontend/src/pages/__tests__/Billing.test.tsx
@@ -115,7 +115,7 @@ describe('Billing', () => {
     // Make getSubscriptionStatus never resolve during this test
     mockGetSubscriptionStatus.mockReturnValue(new Promise(() => {}))
     renderComponent()
-    expect(document.querySelector('.animate-spin')).toBeTruthy()
+    expect(document.querySelector('.pitchey-film-anim')).toBeTruthy()
   })
 
   it('renders Billing & Payments heading after loading', async () => {

--- a/frontend/src/pages/__tests__/CreatorPitchView.test.tsx
+++ b/frontend/src/pages/__tests__/CreatorPitchView.test.tsx
@@ -99,7 +99,7 @@ describe('CreatorPitchView', () => {
     mockGetPublicById.mockReturnValue(new Promise(() => {}))
     renderWithRoute()
 
-    const spinner = document.querySelector('.animate-spin')
+    const spinner = document.querySelector('.pitchey-film-anim')
     expect(spinner).toBeInTheDocument()
   })
 

--- a/frontend/src/pages/__tests__/CreatorProfile.test.tsx
+++ b/frontend/src/pages/__tests__/CreatorProfile.test.tsx
@@ -129,7 +129,7 @@ describe('CreatorProfile', () => {
   it('shows loading spinner initially', () => {
     mockFetch.mockReturnValue(new Promise(() => {}))
     render(<MemoryRouter><Component /></MemoryRouter>)
-    expect(document.querySelector('.animate-spin')).toBeInTheDocument()
+    expect(document.querySelector('.pitchey-film-anim')).toBeInTheDocument()
   })
 
   it('calls GET /api/users/:id for creator data', async () => {

--- a/frontend/src/pages/__tests__/Profile.test.tsx
+++ b/frontend/src/pages/__tests__/Profile.test.tsx
@@ -100,7 +100,7 @@ describe('Profile', () => {
       </MemoryRouter>
     )
     // Should show the spinner before data loads
-    const spinner = document.querySelector('.animate-spin')
+    const spinner = document.querySelector('.pitchey-film-anim')
     expect(spinner).toBeTruthy()
   })
 

--- a/frontend/src/pages/__tests__/PublicPitchView.test.tsx
+++ b/frontend/src/pages/__tests__/PublicPitchView.test.tsx
@@ -136,7 +136,7 @@ describe('PublicPitchView', () => {
         <PublicPitchView />
       </MemoryRouter>
     )
-    const spinner = document.querySelector('.animate-spin')
+    const spinner = document.querySelector('.pitchey-film-anim')
     expect(spinner).toBeTruthy()
   })
 

--- a/frontend/src/pages/__tests__/Settings.test.tsx
+++ b/frontend/src/pages/__tests__/Settings.test.tsx
@@ -94,7 +94,7 @@ describe('Settings', () => {
         <Settings />
       </MemoryRouter>
     )
-    const spinner = document.querySelector('.animate-spin')
+    const spinner = document.querySelector('.pitchey-film-anim')
     expect(spinner).toBeTruthy()
   })
 

--- a/frontend/src/portals/creator/pages/CreatorPitchView.tsx
+++ b/frontend/src/portals/creator/pages/CreatorPitchView.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
+import LogoLoader from '@/components/LogoLoader';
 import { 
   ArrowLeft, Eye, Heart, Share2, Edit, Trash2, BarChart3, 
   Shield, MessageSquare, Clock, Calendar, User, Tag, 
@@ -270,7 +271,7 @@ const CreatorPitchView: React.FC = () => {
   if (loading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-purple-50 via-white to-pink-50 flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600"></div>
+        <LogoLoader size="md" />
       </div>
     );
   }

--- a/frontend/src/portals/creator/pages/CreatorSlates.tsx
+++ b/frontend/src/portals/creator/pages/CreatorSlates.tsx
@@ -5,6 +5,7 @@ import {
   Film, MoreVertical, Pencil, Globe
 } from 'lucide-react';
 import { SlateService, type Slate } from '@/services/slate.service';
+import LogoLoader from '@/components/LogoLoader';
 
 export default function CreatorSlates() {
   const navigate = useNavigate();
@@ -198,7 +199,7 @@ export default function CreatorSlates() {
       {/* Slate List */}
       {loading ? (
         <div className="flex items-center justify-center py-20">
-          <div className="animate-spin h-8 w-8 border-2 border-purple-600 border-t-transparent rounded-full" />
+          <LogoLoader size="md" />
         </div>
       ) : filtered.length === 0 ? (
         <div className="text-center py-20 bg-white border border-gray-200 rounded-xl">


### PR DESCRIPTION
Targeted follow-up to the loader rollout — converts the **full-page ring spinner → film `LogoLoader`** on the busiest screens, so the branded animation shows during real data fetches there:

**Settings · Profile · CreatorProfile · Billing · CreatorPortfolio · PublicPitchView · CreatorPitchView · CreatorSlates**

Deliberately **not** a full sweep:
- Tiny inline **button/icon spinners stay as rings** (a film strip there would look wrong).
- The **dashboard keeps its skeletons** (better pattern than a single spinner).

6 page tests that detected loading via `.animate-spin` were updated to query the film loader's `.pitchey-film-anim`. `tsc` clean; **91 tests pass**.