### PR TITLE
fix(settings): refresh session cache after profile save (stale username)

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -4,6 +4,7 @@ import { Shield, Bell, Eye, Mail, Smartphone, Lock, Key, Trash2, AlertCircle, Us
 import { toast } from 'react-hot-toast';
 import { useBetterAuthStore } from '../store/betterAuthStore';
 import { sessionManager } from '../lib/session-manager';
+import { sessionCache } from '../store/sessionCache';
 import { UserService } from '../services/user.service';
 import { API_URL } from '../config';
 import { usePortalTheme } from '@shared/hooks/usePortalTheme';
@@ -70,6 +71,10 @@ export default function Settings() {
       });
       sessionManager.clearCache();
       await checkSession();
+      // Re-write the localStorage session cache with the fresh user so a page
+      // refresh doesn't surface the stale pre-change username for the cache TTL.
+      const freshUser = useBetterAuthStore.getState().user;
+      if (freshUser) sessionCache.set(freshUser);
       toast.success('Profile updated');
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));


### PR DESCRIPTION
After changing username, the Zustand store updated (correct in-session) but the localStorage `sessionCache` did not — `checkSession()` only re-writes it on a `userType` change. So a page refresh loaded the stale cached user and showed the **old username** (header, feedback authoring, etc.) for the cache TTL.

`saveProfile` now writes the fresh user back into `sessionCache` immediately after `checkSession()`. tsc clean; 20 Settings tests pass.