### PR TITLE
fix(analytics): stop fabricating investor/creator analytics data (#287, #288)

### DIFF
--- a/frontend/src/features/analytics/components/Analytics/EnhancedCreatorAnalytics.tsx
+++ b/frontend/src/features/analytics/components/Analytics/EnhancedCreatorAnalytics.tsx
@@ -3,7 +3,6 @@ import {
   TrendingUp,
   Eye,
   Heart,
-  Share2,
   Users,
   DollarSign,
   Film,
@@ -45,7 +44,6 @@ interface CreatorAnalyticsData {
     totalPitches: number;
     totalViews: number;
     totalLikes: number;
-    totalShares: number;
     engagementRate: number;
     fundingReceived: number;
     averageRating: number;
@@ -57,7 +55,6 @@ interface CreatorAnalyticsData {
     pitchesChange: number;
     viewsChange: number;
     likesChange: number;
-    sharesChange: number;
     engagementChange: number;
     fundingChange: number;
     ratingChange: number;
@@ -144,7 +141,6 @@ export const EnhancedCreatorAnalytics: React.FC<CreatorAnalyticsProps> = ({
           totalPitches: overview.totalPitches || 0,
           totalViews: overview.totalViews || 0,
           totalLikes: overview.totalLikes || 0,
-          totalShares: 0,
           engagementRate: performance.engagementTrend?.length ?
             performance.engagementTrend.reduce((acc, curr) => acc + (curr?.rate || 0), 0) / performance.engagementTrend.length : 0,
           fundingReceived: dashboardMetrics?.revenue?.total || 0,
@@ -157,7 +153,6 @@ export const EnhancedCreatorAnalytics: React.FC<CreatorAnalyticsProps> = ({
           pitchesChange: overview.pitchesChange || 0,
           viewsChange: overview.viewsChange || 0,
           likesChange: overview.likesChange || 0,
-          sharesChange: 0,
           engagementChange: 0,
           fundingChange: dashboardMetrics?.revenue?.growth || 0,
           ratingChange: 0,
@@ -368,14 +363,13 @@ export const EnhancedCreatorAnalytics: React.FC<CreatorAnalyticsProps> = ({
           icon={<Heart className="w-5 h-5 text-pink-500" />}
           variant="danger"
         />
-        <AnalyticCard 
-          title="Shares"
-          value={analyticsData.kpis.totalShares}
-          change={analyticsData.changes.sharesChange}
-          icon={<Share2 className="w-5 h-5 text-blue-500" />}
-          variant="primary"
-        />
-        <AnalyticCard 
+        {/*
+          "Shares" KPI removed — it was hardwired to 0 with no backend source.
+          Shares are not tracked anywhere (the pitch_shares table exists but is
+          never written to or queried). Reinstate when real share tracking lands.
+          See issue #288.
+        */}
+        <AnalyticCard
           title="NDA Requests"
           value={analyticsData.kpis.ndaRequests}
           change={analyticsData.changes.ndaChange}

--- a/frontend/src/features/analytics/components/Analytics/EnhancedCreatorAnalytics.tsx
+++ b/frontend/src/features/analytics/components/Analytics/EnhancedCreatorAnalytics.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import {
-  TrendingUp,
   Eye,
   Heart,
   Users,
@@ -376,21 +375,11 @@ export const EnhancedCreatorAnalytics: React.FC<CreatorAnalyticsProps> = ({
           icon={<MessageSquare className="w-5 h-5 text-orange-500" />}
           variant="warning"
         />
-        <AnalyticCard 
-          title="Average Rating"
-          value={analyticsData.kpis.averageRating.toFixed(1)}
-          change={analyticsData.changes.ratingChange}
-          icon={<TrendingUp className="w-5 h-5 text-yellow-500" />}
-          variant="warning"
-        />
-        <AnalyticCard 
-          title="Response Rate"
-          value={analyticsData.kpis.responseRate}
-          change={analyticsData.changes.responseChange}
-          icon={<MessageSquare className="w-5 h-5 text-teal-500" />}
-          variant="success"
-          format="percentage"
-        />
+        {/*
+          "Average Rating" and "Response Rate" KPIs removed — both were hardwired
+          to 0 with no backend source. Reinstate when real values are wired up.
+          See issue #288.
+        */}
       </div>
 
       {/* Charts Grid */}

--- a/frontend/src/features/analytics/components/Analytics/EnhancedInvestorAnalytics.tsx
+++ b/frontend/src/features/analytics/components/Analytics/EnhancedInvestorAnalytics.tsx
@@ -116,7 +116,7 @@ export const EnhancedInvestorAnalytics: React.FC<InvestorAnalyticsProps> = ({
 
       if (result.success && analyticsData) {
         // Transform API response to component data structure
-        const transformedData: InvestorAnalyticsData = transformApiResponse(analyticsData, timeRange);
+        const transformedData: InvestorAnalyticsData = transformApiResponse(analyticsData);
         setAnalyticsData(transformedData);
       } else {
         console.warn('API returned unexpected structure', result);
@@ -133,73 +133,107 @@ export const EnhancedInvestorAnalytics: React.FC<InvestorAnalyticsProps> = ({
     }
   }, [timeRange]);
 
-  // Transform API response to component data structure
-  const transformApiResponse = (apiData: any, range: string): InvestorAnalyticsData => {
-    const multiplier = range === '7d' ? 0.25 : range === '30d' ? 1 : range === '90d' ? 3 : 12;
+  // Transform API response to component data structure.
+  //
+  // The /api/investor/analytics endpoint returns ONLY real fields:
+  //   performance[], topPerformers[], riskAnalysis{}, genrePerformance[].
+  // It does NOT return portfolio value, active-deal counts, monthly-deal counts,
+  // NDA counts, or period-over-period deltas. Anything we can't derive from the
+  // real fields is left at 0 — we do NOT fabricate it. (KPIs at 0 read as "no
+  // data"; AnalyticCard hides the trend badge when change === 0.)
+  const transformApiResponse = (apiData: any): InvestorAnalyticsData => {
+    const genres: any[] = Array.isArray(apiData.genrePerformance) ? apiData.genrePerformance : [];
+    const performance: any[] = Array.isArray(apiData.performance) ? apiData.performance : [];
+    const risk = apiData.riskAnalysis;
+
+    const totalInvested = genres.reduce((sum, g) => sum + (g.totalValue || 0), 0);
+    const totalInvestments = genres.reduce((sum, g) => sum + (g.investments || 0), 0);
+
+    // Value-weighted average ROI across genres (avgROI comes from real roi_percentage).
+    const averageROI = totalInvested > 0
+      ? genres.reduce((sum, g) => sum + (g.avgROI || 0) * (g.totalValue || 0), 0) / totalInvested
+      : 0;
+
+    // Current portfolio value derived from invested capital + recorded ROI per genre.
+    // This is the only honest portfolio-value aggregate the API supports.
+    const portfolioValue = Math.round(
+      genres.reduce((sum, g) => sum + (g.totalValue || 0) * (1 + (g.avgROI || 0) / 100), 0)
+    );
+
+    // Diversification = (1 − Herfindahl index over invested value) × 10, 0–10 scale.
+    const diversificationIndex = totalInvested > 0
+      ? (1 - genres.reduce((sum, g) => sum + Math.pow((g.totalValue || 0) / totalInvested, 2), 0)) * 10
+      : 0;
+
+    // riskAnalysis values are real percentages (sum to 100 when investments exist).
+    const riskScore = risk
+      ? ((risk.highRisk || 0) * 3 + (risk.mediumRisk || 0) * 2 + (risk.lowRisk || 0)) / 100 * 10
+      : 0;
 
     return {
       kpis: {
-        totalInvestments: apiData.performance?.length || Math.round(15 * multiplier / 12),
-        totalInvested: apiData.genrePerformance?.reduce((sum: number, g: any) => sum + (g.totalValue || 0), 0) || Math.round(2500000 * multiplier),
-        portfolioValue: Math.round((apiData.genrePerformance?.reduce((sum: number, g: any) => sum + (g.totalValue || 0), 0) || 2500000) * 1.28 * multiplier),
-        activeDeals: Math.round(8 * (range === '7d' ? 0.8 : 1)),
-        averageROI: apiData.genrePerformance?.reduce((sum: number, g: any) => sum + (g.avgROI || 0), 0) / Math.max(apiData.genrePerformance?.length || 1, 1) || 22.5,
-        successRate: 0,
-        monthlyDeals: range === '7d' ? 1 : range === '30d' ? 3 : range === '90d' ? 9 : 36,
-        ndasSigned: Math.round(45 * multiplier / 12),
-        diversificationIndex: 0,
-        riskScore: apiData.riskAnalysis ? (apiData.riskAnalysis.highRisk * 3 + apiData.riskAnalysis.mediumRisk * 2 + apiData.riskAnalysis.lowRisk) / 100 * 10 : 0,
+        totalInvestments,
+        totalInvested,
+        portfolioValue,
+        activeDeals: 0,   // not provided by the API
+        averageROI,
+        successRate: 0,   // not provided by the API
+        monthlyDeals: 0,  // not provided by the API
+        ndasSigned: 0,    // not provided by the API
+        diversificationIndex,
+        riskScore,
       },
       changes: {
-        investmentsChange: range === '7d' ? 10 : range === '30d' ? 25 : range === '90d' ? 40 : 60,
-        investedChange: range === '7d' ? 8 : range === '30d' ? 18 : range === '90d' ? 30 : 50,
-        portfolioChange: range === '7d' ? 12 : range === '30d' ? 28 : range === '90d' ? 45 : 70,
-        dealsChange: range === '7d' ? 5 : range === '30d' ? 14 : range === '90d' ? 25 : 40,
-        roiChange: 3.2,
-        successChange: 5,
+        // The analytics API does not return period-over-period deltas. Show no
+        // trend badge rather than invent one (AnalyticCard hides change === 0).
+        investmentsChange: 0,
+        investedChange: 0,
+        portfolioChange: 0,
+        dealsChange: 0,
+        roiChange: 0,
+        successChange: 0,
         monthlyDealsChange: 0,
-        ndaChange: range === '7d' ? 5 : range === '30d' ? 15 : range === '90d' ? 25 : 40,
-        diversificationChange: 0.5,
-        riskChange: -0.3,
+        ndaChange: 0,
+        diversificationChange: 0,
+        riskChange: 0,
       },
       charts: {
-        portfolioGrowth: generateTimeSeriesData(range, 2000000, 3500000),
-        investmentsByCategory: apiData.genrePerformance?.map((g: any) => ({
+        // Real time-series from the API; empty array → charts render their empty state.
+        portfolioGrowth: performance.map((p) => ({
+          date: p.date,
+          value: (p.invested || 0) + (p.returns || 0),
+        })),
+        investmentsByCategory: genres.map((g) => ({
           category: g.genre || 'Unknown',
           amount: g.totalValue || 0,
-          count: g.investments || 0
-        })) || [],
-        dealFlow: generateTimeSeriesData(range, 1, 5),
-        roiTrends: generateTimeSeriesData(range, 15, 35),
-        riskAssessment: apiData.riskAnalysis ? [
-          { risk: 'Low Risk', count: apiData.riskAnalysis.lowRisk || 45 },
-          { risk: 'Medium Risk', count: apiData.riskAnalysis.mediumRisk || 35 },
-          { risk: 'High Risk', count: apiData.riskAnalysis.highRisk || 20 },
-        ] : [
-          { risk: 'Low Risk', count: 45 },
-          { risk: 'Medium Risk', count: 35 },
-          { risk: 'High Risk', count: 20 },
-        ],
-        monthlyPerformance: generateMonthlyPerformance(range),
-        topInvestments: apiData.topPerformers?.map((p: any) => ({
+          count: g.investments || 0,
+        })),
+        dealFlow: [], // per-period deal counts not provided by the API
+        roiTrends: performance.map((p) => ({
+          date: p.date,
+          value: p.invested > 0 ? Math.round(((p.returns || 0) / p.invested) * 100) : 0,
+        })),
+        riskAssessment: risk ? [
+          { risk: 'Low Risk', count: risk.lowRisk || 0 },
+          { risk: 'Medium Risk', count: risk.mediumRisk || 0 },
+          { risk: 'High Risk', count: risk.highRisk || 0 },
+        ] : [],
+        monthlyPerformance: performance.map((p) => ({
+          month: p.date,
+          invested: p.invested || 0,
+          returns: p.returns || 0,
+          deals: 0,
+        })),
+        topInvestments: (apiData.topPerformers || []).map((p: any) => ({
           title: p.pitchTitle || 'Unknown',
           amount: p.amount || 0,
           roi: p.currentValue && p.amount ? Math.round((p.currentValue - p.amount) / p.amount * 100) : 0,
-          status: 'Active'
-        })) || [],
-        marketSegments: apiData.marketSegments?.map((s: any) => ({
-          segment: s.segment || 'Unknown',
-          allocation: s.allocation || 0,
-          performance: s.performance || 0,
-        })) || [],
+          status: p.status || 'Active',
+        })),
+        marketSegments: [], // not provided by the API
       }
     };
   };
-
-  // Empty chart data generators (no fake data — charts show "no data" state)
-  const generateTimeSeriesData = (_range: string, _min: number, _max: number): { date: string; value: number }[] => [];
-
-  const generateMonthlyPerformance = (_range: string): { month: string; invested: number; returns: number; deals: number }[] => [];
 
   useEffect(() => {
     fetchAnalyticsData();
@@ -360,22 +394,30 @@ export const EnhancedInvestorAnalytics: React.FC<InvestorAnalyticsProps> = ({
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Portfolio Growth */}
         <ChartContainer title="Portfolio Value Growth">
-          <AreaChart
-            data={analyticsData.charts.portfolioGrowth}
-            title="Portfolio Value ($)"
-            color="#10B981"
-            height={300}
-          />
+          {analyticsData.charts.portfolioGrowth.length > 0 ? (
+            <AreaChart
+              data={analyticsData.charts.portfolioGrowth}
+              title="Portfolio Value ($)"
+              color="#10B981"
+              height={300}
+            />
+          ) : (
+            <div className="flex items-center justify-center h-[300px] text-gray-500">No data available</div>
+          )}
         </ChartContainer>
 
         {/* ROI Trends */}
         <ChartContainer title="ROI Trends">
-          <LineChart
-            data={analyticsData.charts.roiTrends}
-            title="ROI (%)"
-            color="#8B5CF6"
-            height={300}
-          />
+          {analyticsData.charts.roiTrends.length > 0 ? (
+            <LineChart
+              data={analyticsData.charts.roiTrends}
+              title="ROI (%)"
+              color="#8B5CF6"
+              height={300}
+            />
+          ) : (
+            <div className="flex items-center justify-center h-[300px] text-gray-500">No data available</div>
+          )}
         </ChartContainer>
 
         {/* Investment by Category */}
@@ -396,27 +438,35 @@ export const EnhancedInvestorAnalytics: React.FC<InvestorAnalyticsProps> = ({
 
         {/* Risk Assessment */}
         <ChartContainer title="Portfolio Risk Distribution">
-          <PieChartComponent
-            data={analyticsData.charts.riskAssessment.map(item => ({
-              category: item.risk,
-              value: item.count
-            }))}
-            title="Investment Risk Levels"
-            type="doughnut"
-            height={300}
-          />
+          {analyticsData.charts.riskAssessment.some(item => item.count > 0) ? (
+            <PieChartComponent
+              data={analyticsData.charts.riskAssessment.map(item => ({
+                category: item.risk,
+                value: item.count
+              }))}
+              title="Investment Risk Levels"
+              type="doughnut"
+              height={300}
+            />
+          ) : (
+            <div className="flex items-center justify-center h-[300px] text-gray-500">No data available</div>
+          )}
         </ChartContainer>
 
         {/* Deal Flow */}
         <ChartContainer title="Monthly Deal Flow">
-          <BarChart
-            data={analyticsData.charts.dealFlow.map((item, index) => ({
-              category: new Date(item.date).toLocaleDateString('en-US', { month: 'short' }),
-              value: item.value
-            }))}
-            title="Number of Deals"
-            height={300}
-          />
+          {analyticsData.charts.dealFlow.length > 0 ? (
+            <BarChart
+              data={analyticsData.charts.dealFlow.map((item) => ({
+                category: new Date(item.date).toLocaleDateString('en-US', { month: 'short' }),
+                value: item.value
+              }))}
+              title="Number of Deals"
+              height={300}
+            />
+          ) : (
+            <div className="flex items-center justify-center h-[300px] text-gray-500">No data available</div>
+          )}
         </ChartContainer>
 
         {/* Market Segments Performance */}
@@ -451,16 +501,20 @@ export const EnhancedInvestorAnalytics: React.FC<InvestorAnalyticsProps> = ({
 
       {/* Monthly Performance Overview */}
       <ChartContainer title="Monthly Investment Performance">
-        <StackedBarChart
-          data={analyticsData.charts.monthlyPerformance.map(item => ({
-            category: item.month,
-            values: [
-              { label: 'Invested', value: item.invested / 1000 },
-              { label: 'Returns', value: item.returns / 1000 }
-            ]
-          }))}
-          height={350}
-        />
+        {analyticsData.charts.monthlyPerformance.length > 0 ? (
+          <StackedBarChart
+            data={analyticsData.charts.monthlyPerformance.map(item => ({
+              category: item.month,
+              values: [
+                { label: 'Invested', value: item.invested / 1000 },
+                { label: 'Returns', value: item.returns / 1000 }
+              ]
+            }))}
+            height={350}
+          />
+        ) : (
+          <div className="flex items-center justify-center h-[350px] text-gray-500">No data available</div>
+        )}
       </ChartContainer>
 
       {/* Top Investments */}
@@ -503,60 +557,14 @@ export const EnhancedInvestorAnalytics: React.FC<InvestorAnalyticsProps> = ({
         )}
       </div>
 
-      {/* Portfolio Insights */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <div className="bg-white rounded-xl border p-6">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">Portfolio Health</h3>
-          <div className="space-y-3">
-            <div className="flex justify-between items-center">
-              <span className="text-gray-600">Diversification</span>
-              <span className="font-semibold text-green-600">Excellent</span>
-            </div>
-            <div className="flex justify-between items-center">
-              <span className="text-gray-600">Risk Level</span>
-              <span className="font-semibold text-yellow-600">Moderate</span>
-            </div>
-            <div className="flex justify-between items-center">
-              <span className="text-gray-600">Liquidity</span>
-              <span className="font-semibold text-blue-600">High</span>
-            </div>
-            <div className="flex justify-between items-center">
-              <span className="text-gray-600">Performance</span>
-              <span className="font-semibold text-green-600">Above Market</span>
-            </div>
-          </div>
-        </div>
-
-        <div className="bg-white rounded-xl border p-6">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">Market Insights</h3>
-          <div className="space-y-3">
-            <div className="bg-green-50 p-3 rounded-lg">
-              <p className="text-sm text-green-800">Action films showing 15% growth</p>
-            </div>
-            <div className="bg-yellow-50 p-3 rounded-lg">
-              <p className="text-sm text-yellow-800">Comedy genre underperforming</p>
-            </div>
-            <div className="bg-blue-50 p-3 rounded-lg">
-              <p className="text-sm text-blue-800">Documentary market expanding</p>
-            </div>
-          </div>
-        </div>
-
-        <div className="bg-white rounded-xl border p-6">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">Recommendations</h3>
-          <div className="space-y-3">
-            <div className="border-l-4 border-blue-500 pl-3">
-              <p className="text-sm text-gray-700">Consider increasing Sci-Fi allocation</p>
-            </div>
-            <div className="border-l-4 border-green-500 pl-3">
-              <p className="text-sm text-gray-700">Excellent ROI in current portfolio</p>
-            </div>
-            <div className="border-l-4 border-yellow-500 pl-3">
-              <p className="text-sm text-gray-700">Monitor risk levels closely</p>
-            </div>
-          </div>
-        </div>
-      </div>
+      {/*
+        Removed the static "Portfolio Health", "Market Insights", and
+        "Recommendations" panels — they rendered hardcoded strings
+        ("Action films showing 15% growth", "Consider increasing Sci-Fi
+        allocation", etc.) to every investor regardless of their actual
+        portfolio. No data source backs them. Reinstate only when a real
+        insights/recommendations endpoint exists. See issue #287.
+      */}
     </div>
   );
 };

--- a/frontend/src/pages/InvestorDashboard.tsx
+++ b/frontend/src/pages/InvestorDashboard.tsx
@@ -467,7 +467,6 @@ function InvestorDashboard() {
                 {formatPercentage(portfolio.averageROI, 0)}
               </p>
               <p className="text-sm font-medium text-gray-600 mt-1">Average ROI</p>
-              <p className="text-xs text-gray-400 mt-0.5">Industry avg: 12.3%</p>
             </div>
 
             <div className="group relative bg-white rounded-2xl p-6 border border-gray-100 shadow-sm hover:shadow-md hover:-translate-y-0.5 transition-all duration-200">

--- a/frontend/src/pages/InvestorDashboard.tsx
+++ b/frontend/src/pages/InvestorDashboard.tsx
@@ -139,6 +139,21 @@ function InvestorDashboard() {
   const initialLoading = !sectionStatus.portfolio.loaded && !sectionStatus.portfolio.error;
   const isOnline = useOnlineStatus();
 
+  // Derived analytics/financials metrics — computed from REAL investment data.
+  // Previously these tabs showed hardcoded fabrications ($67,500 returns, 73%
+  // success rate, $250,000 available funds, a fake transactions table) to every
+  // investor regardless of activity. We only show what we can derive; anything
+  // without a real data source is omitted rather than invented. See issue #287.
+  const totalReturns = investments.reduce((sum, inv) => sum + (inv.amount * (inv.roi || 0)) / 100, 0);
+  const profitableCount = investments.filter((inv) => (inv.roi || 0) > 0).length;
+  const successRate = investments.length > 0 ? Math.round((profitableCount / investments.length) * 100) : 0;
+  const avgDealSize = investments.length > 0
+    ? investments.reduce((sum, inv) => sum + (inv.amount || 0), 0) / investments.length
+    : 0;
+  const pendingAmount = investments
+    .filter((inv) => /pending|negotiat/i.test(inv.status || ''))
+    .reduce((sum, inv) => sum + (inv.amount || 0), 0);
+
   // Check session on mount and redirect if not authenticated
   useEffect(() => {
     const validateSession = async () => {
@@ -1036,22 +1051,22 @@ function InvestorDashboard() {
                   </div>
                 </div>
                 
-                {/* Key Metrics */}
+                {/* Key Metrics — derived from real investment data */}
                 <div className="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4">
                   <div className="bg-gray-50 rounded-lg p-4">
                     <p className="text-sm text-gray-600">Total Returns</p>
-                    <p className="text-2xl font-bold text-gray-900">$67,500</p>
-                    <p className="text-xs text-indigo-600 mt-1">+15% YTD</p>
+                    <p className="text-2xl font-bold text-gray-900">{formatCurrency(totalReturns)}</p>
+                    <p className="text-xs text-gray-500 mt-1">Across {investments.length} investment{investments.length === 1 ? '' : 's'}</p>
                   </div>
                   <div className="bg-gray-50 rounded-lg p-4">
                     <p className="text-sm text-gray-600">Success Rate</p>
-                    <p className="text-2xl font-bold text-gray-900">73%</p>
-                    <p className="text-xs text-gray-500 mt-1">11 of 15 profitable</p>
+                    <p className="text-2xl font-bold text-gray-900">{successRate}%</p>
+                    <p className="text-xs text-gray-500 mt-1">{profitableCount} of {investments.length} profitable</p>
                   </div>
                   <div className="bg-gray-50 rounded-lg p-4">
                     <p className="text-sm text-gray-600">Avg. Deal Size</p>
-                    <p className="text-2xl font-bold text-gray-900">$75,000</p>
-                    <p className="text-xs text-gray-500 mt-1">Last 6 months</p>
+                    <p className="text-2xl font-bold text-gray-900">{formatCurrency(avgDealSize)}</p>
+                    <p className="text-xs text-gray-500 mt-1">Per investment</p>
                   </div>
                 </div>
               </div>
@@ -1068,17 +1083,9 @@ function InvestorDashboard() {
                   </button>
                 </div>
                 
-                {/* Financial Summary Cards */}
-                <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
-                  <div className="bg-indigo-50 rounded-lg p-4">
-                    <div className="flex items-center justify-between mb-2">
-                      <p className="text-sm text-gray-600">Available Funds</p>
-                      <Wallet className="w-4 h-4 text-indigo-600" />
-                    </div>
-                    <p className="text-2xl font-bold text-gray-900">$250,000</p>
-                    <p className="text-xs text-gray-500 mt-1">Ready to invest</p>
-                  </div>
-                  
+                {/* Financial Summary Cards — derived from real investment data.
+                    "Available Funds" removed: no wallet-balance data source exists. */}
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
                   <div className="bg-blue-50 rounded-lg p-4">
                     <div className="flex items-center justify-between mb-2">
                       <p className="text-sm text-gray-600">Allocated</p>
@@ -1087,22 +1094,22 @@ function InvestorDashboard() {
                     <p className="text-2xl font-bold text-gray-900">{formatCurrency(portfolio.totalInvested)}</p>
                     <p className="text-xs text-gray-500 mt-1">In active investments</p>
                   </div>
-                  
+
                   <div className="bg-purple-50 rounded-lg p-4">
                     <div className="flex items-center justify-between mb-2">
                       <p className="text-sm text-gray-600">Total Returns</p>
                       <TrendingUp className="w-4 h-4 text-purple-600" />
                     </div>
-                    <p className="text-2xl font-bold text-gray-900">$67,500</p>
-                    <p className="text-xs text-indigo-600 mt-1">+15% YTD</p>
+                    <p className="text-2xl font-bold text-gray-900">{formatCurrency(totalReturns)}</p>
+                    <p className="text-xs text-gray-500 mt-1">Realized + projected</p>
                   </div>
-                  
+
                   <div className="bg-orange-50 rounded-lg p-4">
                     <div className="flex items-center justify-between mb-2">
                       <p className="text-sm text-gray-600">Pending</p>
                       <Clock className="w-4 h-4 text-orange-600" />
                     </div>
-                    <p className="text-2xl font-bold text-gray-900">$45,000</p>
+                    <p className="text-2xl font-bold text-gray-900">{formatCurrency(pendingAmount)}</p>
                     <p className="text-xs text-gray-500 mt-1">In negotiation</p>
                   </div>
                 </div>
@@ -1132,63 +1139,35 @@ function InvestorDashboard() {
                         </tr>
                       </thead>
                       <tbody className="bg-white divide-y divide-gray-200">
-                        <tr>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                            Dec 15, 2024
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                            Investment: "Digital Dreams"
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                            Investment
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-red-600">
-                            -$50,000
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap">
-                            <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-indigo-100 text-indigo-800">
-                              Completed
-                            </span>
-                          </td>
-                        </tr>
-                        <tr>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                            Dec 10, 2024
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                            Return: "The Last Echo"
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                            Return
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-indigo-600">
-                            +$12,500
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap">
-                            <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-indigo-100 text-indigo-800">
-                              Received
-                            </span>
-                          </td>
-                        </tr>
-                        <tr>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                            Dec 5, 2024
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                            Deposit: Wire Transfer
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                            Deposit
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-indigo-600">
-                            +$100,000
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap">
-                            <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-indigo-100 text-indigo-800">
-                              Cleared
-                            </span>
-                          </td>
-                        </tr>
+                        {investments.length > 0 ? (
+                          investments.slice(0, 10).map((inv) => (
+                            <tr key={inv.id}>
+                              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                {inv.dateInvested ? new Date(inv.dateInvested).toLocaleDateString() : '—'}
+                              </td>
+                              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                Investment: "{inv.pitchTitle}"
+                              </td>
+                              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                Investment
+                              </td>
+                              <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-red-600">
+                                -{formatCurrency(inv.amount)}
+                              </td>
+                              <td className="px-6 py-4 whitespace-nowrap">
+                                <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-indigo-100 text-indigo-800">
+                                  {inv.status || 'Recorded'}
+                                </span>
+                              </td>
+                            </tr>
+                          ))
+                        ) : (
+                          <tr>
+                            <td colSpan={5} className="px-6 py-8 text-center text-sm text-gray-500">
+                              No transactions yet
+                            </td>
+                          </tr>
+                        )}
                       </tbody>
                     </table>
                   </div>

--- a/frontend/src/pages/__tests__/CreatorPitchesPublished.test.tsx
+++ b/frontend/src/pages/__tests__/CreatorPitchesPublished.test.tsx
@@ -142,7 +142,9 @@ describe('CreatorPitchesPublished', () => {
 
     expect(screen.getByText('Total Views')).toBeInTheDocument()
     expect(screen.getByText('Avg. Rating')).toBeInTheDocument()
-    expect(screen.getByText('Investment Interest')).toBeInTheDocument()
+    // "Investment Interest" summary card was replaced with "Total NDAs" — the old
+    // card always rendered $0 (no backend source); NDAs are real. See #287/#288.
+    expect(screen.getByText('Total NDAs')).toBeInTheDocument()
   })
 
   it('shows correct total published count', async () => {

--- a/frontend/src/portals/creator/pages/CreatorPitchesPublished.tsx
+++ b/frontend/src/portals/creator/pages/CreatorPitchesPublished.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
-  Globe, Eye, Heart, MessageSquare, Star, TrendingUp,
+  Globe, Eye, Heart, Star, TrendingUp,
   Calendar, Clock, Edit, MoreVertical, Filter, Search,
-  Download, Share2, BarChart3, DollarSign, Users, AlertCircle
+  Download, Share2, BarChart3, Users, AlertCircle
 } from 'lucide-react';
 import { PitchService, type Pitch } from '@features/pitches/services/pitch.service';
 
@@ -19,10 +19,8 @@ interface PublishedPitch {
   stats: {
     views: number;
     likes: number;
-    comments: number;
-    shares: number;
+    ndas: number;
     rating: number;
-    investmentInterest: number;
   };
   thumbnail?: string;
   visibility: 'public' | 'private' | 'nda_required';
@@ -56,12 +54,12 @@ function transformPitch(apiPitch: Pitch): PublishedPitch {
     publishedDate: new Date(apiPitch.publishedAt || apiPitch.createdAt),
     lastModified: new Date(apiPitch.updatedAt),
     stats: {
+      // All real, from the creator-pitches API. Comments/shares/investment-interest
+      // were dropped — no backend source exists (they only ever rendered 0).
       views: apiPitch.viewCount || 0,
       likes: apiPitch.likeCount || 0,
-      comments: 0, // Not tracked in API yet
-      shares: 0, // Not tracked in API yet
-      rating: 0, // Not tracked in API yet
-      investmentInterest: 0 // Would need to aggregate from investments
+      ndas: apiPitch.ndaCount || 0,
+      rating: Number(apiPitch.ratingAverage) || 0,
     },
     thumbnail: apiPitch.titleImage,
     visibility
@@ -150,7 +148,7 @@ export default function CreatorPitchesPublished() {
       case 'views':
         return b.stats.views - a.stats.views;
       case 'engagement':
-        return (b.stats.likes + b.stats.comments) - (a.stats.likes + a.stats.comments);
+        return (b.stats.likes + b.stats.ndas) - (a.stats.likes + a.stats.ndas);
       case 'rating':
         return b.stats.rating - a.stats.rating;
       default:
@@ -229,12 +227,12 @@ export default function CreatorPitchesPublished() {
           <div className="bg-white rounded-lg shadow-sm border p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-gray-600">Investment Interest</p>
+                <p className="text-sm text-gray-600">Total NDAs</p>
                 <p className="text-2xl font-bold text-gray-900">
-                  ${formatNumber(pitches.reduce((acc, p) => acc + p.stats.investmentInterest, 0))}
+                  {formatNumber(pitches.reduce((acc, p) => acc + p.stats.ndas, 0))}
                 </p>
               </div>
-              <DollarSign className="w-8 h-8 text-green-600" />
+              <Users className="w-8 h-8 text-green-600" />
             </div>
           </div>
         </div>
@@ -341,11 +339,11 @@ export default function CreatorPitchesPublished() {
                       <p className="text-xs text-gray-500">Likes</p>
                     </div>
                     <div className="text-center">
-                      <p className="text-lg font-semibold text-gray-900">{pitch.stats.comments}</p>
-                      <p className="text-xs text-gray-500">Comments</p>
+                      <p className="text-lg font-semibold text-gray-900">{formatNumber(pitch.stats.ndas)}</p>
+                      <p className="text-xs text-gray-500">NDAs</p>
                     </div>
                     <div className="text-center">
-                      <p className="text-lg font-semibold text-gray-900">{pitch.stats.rating}</p>
+                      <p className="text-lg font-semibold text-gray-900">{pitch.stats.rating.toFixed(1)}</p>
                       <p className="text-xs text-gray-500">Rating</p>
                     </div>
                   </div>

--- a/src/handlers/creator-pitches.ts
+++ b/src/handlers/creator-pitches.ts
@@ -66,6 +66,8 @@ export async function creatorPitchesHandler(request: Request, env: Env): Promise
           view_count,
           like_count,
           nda_count,
+          rating_average,
+          rating_count,
           published_at,
           created_at,
           updated_at
@@ -105,6 +107,8 @@ export async function creatorPitchesHandler(request: Request, env: Env): Promise
           view_count,
           like_count,
           nda_count,
+          rating_average,
+          rating_count,
           published_at,
           created_at,
           updated_at
@@ -145,6 +149,8 @@ export async function creatorPitchesHandler(request: Request, env: Env): Promise
       viewCount: pitch.view_count || 0,
       likeCount: pitch.like_count || 0,
       ndaCount: pitch.nda_count || 0,
+      ratingAverage: Number(pitch.rating_average) || 0,
+      ratingCount: Number(pitch.rating_count) || 0,
       publishedAt: pitch.published_at,
       createdAt: pitch.created_at,
       updatedAt: pitch.updated_at


### PR DESCRIPTION
## Summary

Removes fabricated analytics data that was shown to users as if it were real. Surfaced during a data-reality audit (likes/saves/follows/notifications were all verified **real** — analytics was the exception).

Closes #287, closes #288.

## The problem

A demo investor with **£0 invested** saw a populated six-figure portfolio:
- **Live `InvestorDashboard.tsx`** Analytics tab: `$67,500` Total Returns / `+15% YTD`, `73%` Success Rate / `11 of 15 profitable`, `$75,000` Avg. Deal Size — all hardcoded.
- **Live `InvestorDashboard.tsx`** Financials tab: `$250,000` Available Funds, `$67,500` returns, `$45,000` Pending, plus a 3-row transactions table of invented deals ("Digital Dreams" −$50,000, "The Last Echo" +$12,500, "Wire Transfer" +$100,000).
- **`EnhancedInvestorAnalytics.tsx`**: a hardcoded €2.5M portfolio baseline, fabricated change %s, and static "insight/recommendation" panels with hardcoded advice.
- **`EnhancedCreatorAnalytics.tsx`**: "Shares", "Average Rating", "Response Rate" KPIs hardwired to `0` with no source.
- **`CreatorPitchesPublished.tsx`**: "Comments", "Rating", "Investment Interest" always rendered `0`/`$0`.
- **`InvestorDashboard.tsx`**: a static "Industry avg: 12.3%" benchmark label with no source.

> ⚠️ Routing gotcha: `EnhancedInvestorAnalytics`/`EnhancedCreatorAnalytics` are only mounted in the **debug** page (`InvestorDashboardDebug.tsx`). The fabrication a real user sees is the inline tabs in `InvestorDashboard.tsx`. Both addressed.

## The fix

Everything now derives from **real data** (`investments[]`, `portfolio`, the analytics API's real `genrePerformance`/`performance`/`riskAnalysis`, and `pitches.rating_average`/`nda_count`). Metrics with no source are omitted/zeroed — never invented:

- **Investor dashboard**: Total Returns (Σ amount×roi), Success Rate (profitable/total), Avg Deal Size, Pending (Σ pending/negotiating), real transactions table + "No transactions yet" empty state. "Available Funds" and the "Industry avg" label removed (no source).
- **EnhancedInvestorAnalytics**: KPIs from real fields, unsupported metrics + all change deltas → 0 (`AnalyticCard` hides the badge at `change === 0`), every chart gated with a "No data available" empty state, static insight panels deleted.
- **EnhancedCreatorAnalytics**: Shares / Average Rating / Response Rate cards removed.
- **CreatorPitchesPublished**: stats trimmed to all-real fields (views/likes/NDAs/rating). "Comments" → real **NDAs**; "Investment Interest" summary card → real **Total NDAs**; Rating now reads `pitches.rating_average`. **Backend**: `creator-pitches.ts` now SELECTs + returns `rating_average`/`rating_count`.

## Verification

- Frontend + backend type-check pass; **118 tests green** (updated one label assertion: Investment Interest → Total NDAs).
- Investor dashboard driven live in-browser against the prod API with the demo investor account: Analytics + Financials tabs show `£0` / "No transactions yet" instead of the fabricated figures.

## Deploy note

This PR now includes a **backend change** (`creator-pitches.ts`), so shipping it requires a Worker redeploy in addition to the frontend deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)