### PR TITLE
fix(ci): green the two pre-existing red gates on main

### DIFF
--- a/frontend/src/features/teams/components/__tests__/CompanyJoinCodeCard.test.tsx
+++ b/frontend/src/features/teams/components/__tests__/CompanyJoinCodeCard.test.tsx
@@ -24,16 +24,16 @@ beforeEach(() => {
 })
 
 describe('CompanyJoinCodeCard — per-seat NDA status', () => {
-  it('lists members with Signed / Pending status and a doc link for signed', async () => {
+  it('lists members with NDA signed / NDA pending status and a doc link for signed', async () => {
     render(<CompanyJoinCodeCard />)
 
     await waitFor(() => expect(screen.getByText('Alex Creator')).toBeInTheDocument())
     expect(screen.getByText('Dana Writer')).toBeInTheDocument()
-    expect(screen.getByText('Signed')).toBeInTheDocument()
-    expect(screen.getByText('Pending')).toBeInTheDocument()
+    expect(screen.getByText('NDA signed')).toBeInTheDocument()
+    expect(screen.getByText('NDA pending')).toBeInTheDocument()
 
     // Signed member exposes a "View NDA" link to the document endpoint.
-    const link = screen.getByTitle('View signed NDA') as HTMLAnchorElement
+    const link = screen.getByTitle('View the signed company collaboration NDA') as HTMLAnchorElement
     expect(link.getAttribute('href')).toContain('/api/teams/2/collaboration-nda/document?signerId=1025')
   })
 })

--- a/src/handlers/promo-codes.ts
+++ b/src/handlers/promo-codes.ts
@@ -201,6 +201,7 @@ export async function createPromoCodesHandler(request: Request, env: Env): Promi
       return jsonResponse({ success: false, error: 'Admin access required' }, origin, 403);
     }
 
+    // fire-and-forget
     const body = (await request.json().catch(() => ({}))) as { count?: number; percentOff?: number };
     const count = Math.max(1, Math.min(50, Math.floor(Number(body.count) || 0)));
     const percentOff = Math.max(1, Math.min(100, Math.floor(Number(body.percentOff ?? 100))));
@@ -275,6 +276,7 @@ export async function sendPromoInviteHandler(request: Request, env: Env): Promis
       return jsonResponse({ success: false, error: 'Admin access required' }, origin, 403);
     }
 
+    // fire-and-forget
     const body = (await request.json().catch(() => ({}))) as {
       promoId?: string; code?: string; recipientName?: string; recipientEmail?: string;
     };


### PR DESCRIPTION
## Why

Two CI gates were red on `main` itself — independent of feature work — so every PR inherited a failing signal that masked real regressions. Surfaced while merging #289. Root-caused both; both fixes are no-op at runtime.

## 1. Frontend Tests — stale test
`CompanyJoinCodeCard.test.tsx` asserted the old per-seat NDA badge copy. Commit `8129a6a5` (2026-06-14, "disambiguate the company-member join-code card copy") renamed:
- `Signed` → `NDA signed`
- `Pending` → `NDA pending`
- link title `View signed NDA` → `View the signed company collaboration NDA`

…in `CompanyTeamCards.tsx`, but the test wasn't updated. **Test-only** fix to match the current copy.

## 2. Worker Tests — catch-swallow gate
`scripts/catch-swallow-gate.mjs --threshold 0` flagged two untagged `.catch(() => …)` sites: `handlers/promo-codes.ts:204` and `:278`. Both are `request.json().catch(() => ({}))` — best-effort body parses with a safe `{}` default (downstream uses optional chaining + numeric/string defaults), i.e. genuine **fire-and-forget**, identical to the already-tagged pattern in `portfolio-share.ts` / `slates.ts`. Added the `// fire-and-forget` tag. Gate untagged residue **2 → 0**.

> Note: these were authored *after* the gate went live (`06aeb968`, 2026-05-08) — i.e. they were merged past a red gate that nobody was enforcing as blocking. `main` is currently unprotected, which is how. Worth considering branch protection separately.

## Verification
- `node scripts/catch-swallow-gate.mjs --threshold 0 --list` → RC 0, residue 0.
- `CompanyJoinCodeCard.test.tsx` → passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)