### PR TITLE
fix(admin): real data for admin metrics (no fabrication / stuck-at-zero)

### DIFF
--- a/frontend/src/pages/__tests__/Transactions.test.tsx
+++ b/frontend/src/pages/__tests__/Transactions.test.tsx
@@ -275,22 +275,24 @@ describe('Transactions', () => {
       })
     })
 
-    it('shows refund section for refundable transactions', async () => {
+    it('shows refund section pointing to Stripe for refundable transactions', async () => {
       const user = userEvent.setup()
       renderComponent()
       await waitFor(() => {
         expect(screen.getAllByText('View').length).toBe(5)
       })
-      // First transaction is completed payment with refundableAmount
+      // First transaction is a completed payment with refundableAmount.
       await user.click(screen.getAllByText('View')[0])
       await waitFor(() => {
         expect(screen.getByText('Transaction Details')).toBeInTheDocument()
       })
-      // "Process Refund" appears as both section heading and button text
-      expect(screen.getAllByText('Process Refund').length).toBeGreaterThanOrEqual(1)
-      expect(screen.getByText('Refund Amount')).toBeInTheDocument()
-      expect(screen.getByText('Refund Reason')).toBeInTheDocument()
-      expect(screen.getByText('Max')).toBeInTheDocument()
+      // Refunds are issued in Stripe (not automated in-app) — the section points
+      // the admin to the Stripe dashboard rather than an in-app refund form.
+      expect(screen.getByText('Refunds')).toBeInTheDocument()
+      expect(screen.getByText(/Refunds are issued from the Stripe dashboard/i)).toBeInTheDocument()
+      const stripeLink = screen.getByText(/Open in Stripe to refund/i).closest('a') as HTMLAnchorElement
+      expect(stripeLink).toBeTruthy()
+      expect(stripeLink.getAttribute('href')).toContain('dashboard.stripe.com/payments/')
     })
 
     it('shows subscription plan in metadata when available', async () => {

--- a/frontend/src/portals/admin/pages/Transactions.tsx
+++ b/frontend/src/portals/admin/pages/Transactions.tsx
@@ -52,8 +52,6 @@ const Transactions: React.FC = () => {
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction | null>(null);
   const [showTransactionModal, setShowTransactionModal] = useState(false);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
-  const [refundAmount, setRefundAmount] = useState(0);
-  const [refundReason, setRefundReason] = useState('');
 
   useEffect(() => {
     loadTransactions();
@@ -69,22 +67,6 @@ const Transactions: React.FC = () => {
       console.error('Transactions error:', err);
     } finally {
       setLoading(false);
-    }
-  };
-
-  const handleProcessRefund = async (transactionId: string, amount: number, reason: string) => {
-    try {
-      setActionLoading(transactionId);
-      await adminService.processRefund(transactionId, amount, reason);
-      await loadTransactions();
-      setShowTransactionModal(false);
-      setRefundAmount(0);
-      setRefundReason('');
-    } catch (err) {
-      console.error('Process refund error:', err);
-      alert('Failed to process refund');
-    } finally {
-      setActionLoading(null);
     }
   };
 
@@ -141,11 +123,7 @@ const Transactions: React.FC = () => {
             <div className="flex justify-between items-center">
               <h2 className="text-2xl font-semibold">Transaction Details</h2>
               <button
-                onClick={() => {
-                  setShowTransactionModal(false);
-                  setRefundAmount(0);
-                  setRefundReason('');
-                }}
+                onClick={() => setShowTransactionModal(false)}
                 className="text-gray-400 hover:text-gray-600"
               >
                 ✕
@@ -267,55 +245,29 @@ const Transactions: React.FC = () => {
               </div>
             )}
 
-            {/* Refund Section */}
+            {/* Refunds are issued directly in Stripe — the platform intentionally
+                does not automate refunds (the admin bulk-action handler refuses
+                them). Point the admin at Stripe instead of offering an in-app
+                control that always errors. */}
             {canRefund && (
               <div className="border-t pt-6">
-                <h3 className="text-lg font-semibold mb-4">Process Refund</h3>
-                <div className="space-y-4">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
-                      Refund Amount
-                    </label>
-                    <div className="flex space-x-2">
-                      <input
-                        type="number"
-                        value={refundAmount}
-                        onChange={(e) => setRefundAmount(Number(e.target.value))}
-                        max={transaction.refundableAmount}
-                        min={0}
-                        step="0.01"
-                        className="flex-1 border border-gray-300 rounded-md px-3 py-2"
-                      />
-                      <button
-                        onClick={() => setRefundAmount(transaction.refundableAmount || 0)}
-                        className="px-3 py-2 text-sm bg-gray-100 text-gray-700 rounded hover:bg-gray-200"
-                      >
-                        Max
-                      </button>
-                    </div>
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
-                      Refund Reason
-                    </label>
-                    <textarea
-                      value={refundReason}
-                      onChange={(e) => setRefundReason(e.target.value)}
-                      rows={3}
-                      className="w-full border border-gray-300 rounded-md px-3 py-2"
-                      placeholder="Reason for refund..."
-                    />
-                  </div>
-
-                  <button
-                    onClick={() => handleProcessRefund(transaction.id, refundAmount, refundReason)}
-                    disabled={actionLoading === transaction.id || refundAmount <= 0 || !refundReason.trim()}
-                    className="w-full bg-red-600 text-white py-2 rounded hover:bg-red-700 disabled:opacity-50"
+                <h3 className="text-lg font-semibold mb-2">Refunds</h3>
+                <p className="text-sm text-gray-600 mb-4">
+                  Refunds are issued from the Stripe dashboard, not from this panel.
+                  Up to {formatCurrency(transaction.refundableAmount || 0, transaction.currency)} is refundable.
+                </p>
+                {transaction.stripeTransactionId ? (
+                  <a
+                    href={`https://dashboard.stripe.com/payments/${transaction.stripeTransactionId}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-block bg-indigo-600 text-white py-2 px-4 rounded hover:bg-indigo-700"
                   >
-                    {actionLoading === transaction.id ? 'Processing...' : 'Process Refund'}
-                  </button>
-                </div>
+                    Open in Stripe to refund →
+                  </a>
+                ) : (
+                  <p className="text-sm text-gray-500">No Stripe payment ID is attached to this transaction.</p>
+                )}
               </div>
             )}
           </div>

--- a/src/worker-modules/admin-endpoints.ts
+++ b/src/worker-modules/admin-endpoints.ts
@@ -340,6 +340,7 @@ export class AdminEndpointsHandler {
           (SELECT COUNT(*)::int FROM pitches) AS total_pitches,
           (SELECT COUNT(*)::int FROM pitches WHERE status IN ('published','active')) AS approved_pitches,
           (SELECT COUNT(*)::int FROM pitches WHERE status = 'draft') AS draft_pitches,
+          (SELECT COUNT(*)::int FROM pitches WHERE moderation_status = 'rejected') AS rejected_pitches,
           (SELECT COUNT(*)::int FROM ndas WHERE status = 'pending') AS pending_ndas,
           (SELECT COALESCE(SUM(amount), 0)::float FROM payments WHERE status = 'completed') AS total_revenue
       `;
@@ -352,7 +353,7 @@ export class AdminEndpointsHandler {
         activeUsers: s.active_users ?? 0,
         recentSignups: s.recent_signups ?? 0,
         approvedPitches: s.approved_pitches ?? 0,
-        rejectedPitches: 0
+        rejectedPitches: s.rejected_pitches ?? 0
       }, corsHeaders);
     } catch (error) {
       await this.logger.captureError(error instanceof Error ? error : new Error(String(error)));
@@ -392,6 +393,22 @@ export class AdminEndpointsHandler {
         FROM pitches`);
       const inv = await one(sql`SELECT COUNT(*)::int AS cnt, COALESCE(SUM(amount), 0)::float AS volume FROM investments`);
       const nda = await one(sql`SELECT COUNT(*) FILTER (WHERE status IN ('signed','approved'))::int AS active FROM ndas`);
+      // Real moderation queue + financial-health counts. Each block is its own
+      // defensive query so a missing column in some env degrades that metric to 0
+      // (honest) without zeroing the others or 500ing the dashboard. These were
+      // previously hardcoded 0, which gave admins a false "all clear".
+      const pmod = await one(sql`
+        SELECT COUNT(*) FILTER (WHERE moderation_status = 'flagged')::int AS flagged,
+               COUNT(*) FILTER (WHERE moderation_status = 'rejected')::int AS removed
+        FROM pitches`);
+      const cr = await one(sql`
+        SELECT COUNT(*) FILTER (WHERE status = 'pending')::int AS pending_flags,
+               COUNT(*) FILTER (WHERE resolved_at >= date_trunc('day', NOW()))::int AS actions_today,
+               COUNT(DISTINCT moderator_id) FILTER (WHERE resolved_at >= NOW() - INTERVAL '30 days')::int AS active_moderators,
+               COALESCE(AVG(EXTRACT(EPOCH FROM (resolved_at - created_at)) / 3600)
+                        FILTER (WHERE resolved_at IS NOT NULL), 0)::float AS avg_resolution_hours
+        FROM content_reports`);
+      const pay = await one(sql`SELECT COUNT(*) FILTER (WHERE status = 'pending')::int AS pending FROM payments`);
 
       const stats: SystemStats = {
         users: {
@@ -406,20 +423,20 @@ export class AdminEndpointsHandler {
           total_pitches: p.total || 0,
           published_pitches: p.published || 0,
           draft_pitches: p.draft || 0,
-          flagged_content: 0,
-          removed_content: 0
+          flagged_content: pmod.flagged || 0,
+          removed_content: pmod.removed || 0
         },
         moderation: {
-          pending_flags: 0,
-          actions_today: 0,
-          active_moderators: 0,
-          average_resolution_time: 0
+          pending_flags: cr.pending_flags || 0,
+          actions_today: cr.actions_today || 0,
+          active_moderators: cr.active_moderators || 0,
+          average_resolution_time: cr.avg_resolution_hours || 0
         },
         financial: {
           total_investments: inv.cnt || 0,
           total_volume: inv.volume || 0,
           active_ndas: nda.active || 0,
-          pending_payments: 0
+          pending_payments: pay.pending || 0
         }
       };
 
@@ -689,9 +706,22 @@ export class AdminEndpointsHandler {
       }
       await sql`UPDATE users SET account_locked_until = NOW() + INTERVAL '30 days', account_lock_reason = ${body.reason}, updated_at = NOW() WHERE id = ${userId}`;
 
+      // Persist a real moderation record and use its DB id — previously this was
+      // a fabricated Math.random() value with no audit trail behind it.
+      let actionId = 0;
+      try {
+        const auditRows = await sql`
+          INSERT INTO audit_logs (user_id, action, entity_type, entity_id, new_values, event_category, description, created_at)
+          VALUES (${userAuth.userId}, 'suspension', 'user', ${userId},
+                  ${JSON.stringify({ reason: body.reason, duration: body.duration || '7 days' })}::jsonb, 'admin',
+                  ${`Suspended user #${userId}`}, NOW())
+          RETURNING id`;
+        actionId = auditRows?.[0]?.id ?? 0;
+      } catch { /* audit is non-critical — never block the suspension on it */ }
+
       // Create moderation action
       const moderationAction: ModerationAction = {
-        id: Math.floor(Math.random() * 1000) + 100,
+        id: actionId,
         action_type: 'suspension',
         target_type: 'user',
         target_id: userId,


### PR DESCRIPTION
## Why

Continuation of the data-reality audit (#287/#288). I swept all three remaining portals' **live** dashboards. **Watcher and Production came back clean** — every metric traces to a real query, no fabrication. The findings were all in **Admin**, and they're the higher-stakes kind because they give the people who act on them a false "all clear."

## Fixes

**1. Moderation + financial health — was hardcoded `0`** (`admin-endpoints.ts` `handleSystemStats`)
`flagged_content`, `removed_content`, `pending_flags`, `actions_today`, `active_moderators`, `average_resolution_time`, `pending_payments` were all literal `0`. An admin saw "0 pending flags" even with a real moderation backlog. Now derived from real, individually try-wrapped queries over `pitches.moderation_status`, `content_reports` (`status`/`resolved_at`/`moderator_id`), and `payments.status` — a missing column degrades that single metric to 0 without 500ing the dashboard.

**2. `rejectedPitches` — was hardcoded `0`** (`handleAdminDashboard`)
Now counts `pitches.moderation_status = 'rejected'`.

**3. Fabricated moderation-action id** (`handleSuspendUser`)
Returned `id: Math.floor(Math.random() * 1000) + 100` with no audit trail. Now persists a real `audit_logs` row (`RETURNING id`) and returns that id; non-critical audit failure falls back to 0 without blocking the suspension.

**4. Dead refund modal** (admin `Transactions.tsx`)
The in-app refund form POSTed to a bulk-action endpoint that **intentionally** refuses automated refunds (501, "issue from Stripe"), so admins just got "Failed to process refund". Replaced with a direct **"Open in Stripe to refund →"** link (uses `stripeTransactionId`); removed the dead handler/state; updated the test.

## Verification
- Frontend + backend type-check pass.
- Admin + Transactions tests green (23 Transactions tests pass; updated the refund-section assertion to the Stripe pointer).
- All new backend queries use columns already used by live handlers in the same file (`handleGetFlags`, content-moderation handlers), and are defensively wrapped.

## Not changed (deliberately)
Watcher dashboard (clean), Production dashboard (clean; only honest `—`/zeroed-trend placeholders). The `/admin` `maintenance`/`broadcast` endpoints return 501 but have no live UI, so left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)