### PR TITLE
feat(notifications): notify on comment/feedback + fix silently-dropped NDA-rejected

### DIFF
--- a/src/db/queries/documents.ts
+++ b/src/db/queries/documents.ts
@@ -558,7 +558,7 @@ export async function rejectNDARequest(
         'NDA Rejected',
         ${reason || 'Your NDA request has been rejected'},
         ${nda.pitch_id}, ${rejectorId},
-        'medium', NOW()
+        'normal', NOW()
       )
     `;
 

--- a/src/handlers/pitch-feedback.ts
+++ b/src/handlers/pitch-feedback.ts
@@ -21,6 +21,26 @@ function errorResponse(message: string, origin: string | null, status = 400): Re
   return jsonResponse({ success: false, error: message }, origin, status);
 }
 
+// Fire-and-forget in-app notification to a pitch's owner. Mirrors the live insert
+// pattern used across handlers: OMIT `priority` (prod's notifications_priority_check
+// rejects 'normal'; the column default applies) and never let a notify failure break
+// the user's action. Skips self-notification (a creator acting on their own pitch).
+async function notifyPitchOwner(
+  sql: ReturnType<typeof getDb>,
+  opts: { ownerId: number; actorId: number | null; pitchId: number; type: string; title: string; message: string },
+): Promise<void> {
+  if (!sql) return;
+  if (opts.actorId != null && String(opts.actorId) === String(opts.ownerId)) return;
+  try {
+    await sql`
+      INSERT INTO notifications (user_id, type, title, message, related_pitch_id, related_user_id, action_url, is_read, created_at)
+      VALUES (${opts.ownerId}, ${opts.type}, ${opts.title}, ${opts.message}, ${opts.pitchId}, ${opts.actorId ?? null}, ${`/pitch/${opts.pitchId}`}, false, NOW())
+    `;
+  } catch (err) {
+    console.error('notifyPitchOwner error:', err instanceof Error ? err.message : String(err));
+  }
+}
+
 function extractPitchId(request: Request): number {
   const url = new URL(request.url);
   const parts = url.pathname.split('/');
@@ -253,6 +273,17 @@ export async function submitPitchFeedback(request: Request, env: Env): Promise<R
     `;
 
     await updateRatingStats(sql, pitchId);
+
+    // Notify the pitch owner of new feedback (previously a silent gap). Respect
+    // the anonymous flag — null the actor so related_user_id can't unmask the reviewer.
+    await notifyPitchOwner(sql, {
+      ownerId: Number(pitch.user_id),
+      actorId: isAnonymous ? null : Number(userId),
+      pitchId,
+      type: 'pitch_feedback',
+      title: 'New feedback on your pitch',
+      message: rating ? `Your pitch received new feedback (${rating}★).` : 'Your pitch received new feedback.',
+    });
 
     return jsonResponse({ success: true, data: result[0] }, origin, 201);
   } catch (err) {
@@ -709,6 +740,18 @@ export async function submitPitchComment(request: Request, env: Env): Promise<Re
       VALUES (${pitchId}, ${userId ? Number(userId) : null}, ${userType}, ${content}, ${ipHash})
       RETURNING id, created_at
     `;
+
+    // Notify the pitch owner that someone commented (previously a silent gap —
+    // the comment was stored but the creator got no signal). Anonymous commenter
+    // → actorId null so we don't expose a non-existent/identifiable user.
+    await notifyPitchOwner(sql, {
+      ownerId: Number(pitch.user_id),
+      actorId: userId ? Number(userId) : null,
+      pitchId,
+      type: 'pitch_comment',
+      title: 'New comment on your pitch',
+      message: 'Someone left a comment on your pitch.',
+    });
 
     return jsonResponse({ success: true, data: result[0] }, origin, 201);
   } catch (err) {

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -8712,7 +8712,7 @@ pitchey_analytics_datapoints_per_minute 1250
             priority, created_at
           ) VALUES (
             $1, 'nda_rejected', 'NDA Request Rejected',
-            $2, $3, $4, 'medium', NOW()
+            $2, $3, $4, 'normal', NOW()
           )
         `, [
           this.safeParseInt(nda.signer_id),


### PR DESCRIPTION
## Why

Continuing the data-reality thread — notifications are real *when they fire*; the open question was *which events that should notify actually do*. A coverage audit (verified against the prod schema) found three real problems.

## What this fixes

**1. New gaps wired up** (`pitch-feedback.ts`): comments and structured feedback were stored but the creator got **no in-app notification**. Now both notify the pitch owner via a `notifyPitchOwner()` helper that mirrors the proven live insert (`handlers/calls.ts`):
- `pitch_comment` — anonymous commenter → `actorId` null.
- `pitch_feedback` — **respects `is_anonymous`** (null actor so `related_user_id` can't unmask the reviewer); rating in the message when present.
- Skips self-notification.

**2. Silently-dropped NDA-rejected notification** (`documents.ts`, `worker-integrated.ts`): both NDA-rejected inserts hardcoded `priority='medium'`, which the prod constraint **rejects** → the insert threw and was swallowed, so a requester whose NDA was rejected got nothing. Changed `'medium'` → `'normal'`.

## The priority constraint (verified against prod, settles a doc contradiction)

```
CHECK (priority IN ('low','normal','high','urgent'))   default 'normal'
```
So `'normal'` is valid (the `calls.ts` comment claiming prod rejects it is wrong — though omitting priority is still safe), and `'medium'` is rejected. NDA request/approved use `'high'` (valid); only rejection was broken. Swept every other notification insert — no remaining invalid literals.

## Remaining gaps → tracked in #296
Direct messages, Stripe (credits / payment-failed / subscription), team-join-code redemption. Non-gaps confirmed already firing: follows, pitch-publish-to-followers, NDA request/approve/**reject (after this fix)**/revoke, collaboration invite/accept, call submission + status, investment received.

## Verification
Backend type-check passes; new inserts are column-identical to the live `notify()` insert; the constraint was read directly from prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)