### PR TITLE
fix(nav): drop redundant "Hot" top-nav item; make Hot a marketplace sort pill

### DIFF
--- a/frontend/src/pages/MarketplaceEnhanced.tsx
+++ b/frontend/src/pages/MarketplaceEnhanced.tsx
@@ -23,6 +23,7 @@ import PortalTopNav from '@shared/components/layout/PortalTopNav';
 import SortPillRow from '@shared/components/ui/SortPillRow';
 import {
   Search,
+  Flame,
   TrendingUp,
   Eye,
   Clock,
@@ -139,6 +140,7 @@ function getCreatorDisplay(pitch: Pitch): string {
 // Enhanced filtering and sorting options.
 // `shortLabel` is used in the compact pill row; `label` stays in the a11y/title.
 const SORT_OPTIONS = [
+  { value: 'hot', label: 'Hot', shortLabel: 'Hot', icon: Flame },
   { value: 'trending', label: 'Trending Now', shortLabel: 'Trending', icon: TrendingUp },
   { value: 'newest', label: 'Newest First', shortLabel: 'New', icon: Clock },
   { value: 'popular', label: 'Most Popular', shortLabel: 'Popular', icon: Star },

--- a/frontend/src/shared/components/layout/PortalTopNav.tsx
+++ b/frontend/src/shared/components/layout/PortalTopNav.tsx
@@ -18,11 +18,10 @@ import { getPortalTheme } from '@shared/hooks/usePortalTheme';
 
 type NavItem = { label: string; to: string };
 
-// "Hot" surfaces the heat-score discovery path (Bayesian + role-weighted)
-// from anywhere in the app — deep-links to the marketplace with the Hot sort
-// pill pre-selected. Kept as a top-level item across every role so users don't
-// have to remember it lives under a filter.
-const HOT_LINK: NavItem = { label: 'Hot', to: '/marketplace?sort=hot' };
+// Note: a dedicated "Hot" nav item was removed (2026-06-16) — it deep-linked to
+// /marketplace?sort=hot, which is now a first-class sort pill in the marketplace
+// itself, so the top-level link was redundant and over-filled the desktop nav.
+// The Hot discovery path lives on the marketplace's sort row.
 
 const NAV_BY_ROLE: Partial<Record<UserTypeCanonical, NavItem[]>> = {
   creator: [
@@ -30,7 +29,6 @@ const NAV_BY_ROLE: Partial<Record<UserTypeCanonical, NavItem[]>> = {
     { label: 'My Pitches', to: CREATOR_ROUTES.pitches },
     { label: 'Marketplace', to: '/marketplace' },
     { label: 'Opportunities', to: '/opportunities' },
-    HOT_LINK,
     { label: 'Messages', to: CREATOR_ROUTES.messages },
     { label: 'NDAs', to: CREATOR_ROUTES.ndas },
     { label: 'Portfolio', to: CREATOR_ROUTES.portfolio },
@@ -40,7 +38,6 @@ const NAV_BY_ROLE: Partial<Record<UserTypeCanonical, NavItem[]>> = {
     { label: 'Browse', to: INVESTOR_ROUTES.browse },
     { label: 'Opportunities', to: '/opportunities' },
     { label: 'Compare', to: '/compare' },
-    HOT_LINK,
     { label: 'Watchlist', to: INVESTOR_ROUTES.watchlist },
     { label: 'Portfolio', to: INVESTOR_ROUTES.portfolio },
     { label: 'Messages', to: '/messages' },
@@ -51,14 +48,12 @@ const NAV_BY_ROLE: Partial<Record<UserTypeCanonical, NavItem[]>> = {
     { label: 'Browse', to: '/marketplace' },
     { label: 'Opportunities', to: '/opportunities' },
     { label: 'Compare', to: '/compare' },
-    HOT_LINK,
     { label: 'NDAs', to: '/production/ndas' },
     { label: 'Messages', to: PRODUCTION_ROUTES.messages },
   ],
   watcher: [
     { label: 'Dashboard', to: WATCHER_ROUTES.dashboard },
     { label: 'Marketplace', to: '/marketplace' },
-    HOT_LINK,
     { label: 'Library', to: WATCHER_ROUTES.library },
     { label: 'Saved', to: WATCHER_ROUTES.saved },
     { label: 'Following', to: WATCHER_ROUTES.following },
@@ -68,7 +63,6 @@ const NAV_BY_ROLE: Partial<Record<UserTypeCanonical, NavItem[]>> = {
 const ANON_NAV: NavItem[] = [
   { label: 'Marketplace', to: '/marketplace' },
   { label: 'Opportunities', to: '/opportunities' },
-  HOT_LINK,
   { label: 'How It Works', to: '/how-it-works' },
   { label: 'About', to: '/about' },
 ];


### PR DESCRIPTION
## Why

The desktop top nav is over-full in the marketplace. "Hot" was a top-level nav item in **every** role's nav (creator/investor/production/watcher) + anon, but it only deep-linked to `/marketplace?sort=hot` — i.e. a marketplace sort. Redundant with the marketplace's own discovery row, and it crowded the desktop nav.

## What

- **Removed** `HOT_LINK` from `PortalTopNav` (all 5 nav lists).
- **Added** `hot` as the **leading sort pill** in `MarketplaceEnhanced` `SORT_OPTIONS` (Flame icon).

The catch this avoids: the `'hot'` sort case already existed (sorts by `heat_score`) and the sort-row comment already *claimed* "Hot/Trending/New" were the marquee pills — but Hot was never actually in `SORT_OPTIONS`, so its **only** UI entry point was the nav link. Deleting the nav link alone would have made Hot discovery UI-unreachable. Promoting it to a real pill keeps the discovery path (now consistent with the user's mental model that "Hot is a filter"). `?sort=hot` deep-links still resolve.

## Verification
- Frontend type-check passes.
- `MarketplaceEnhanced` tests green; no test asserted the nav "Hot".

🤖 Generated with [Claude Code](https://claude.com/claude-code)