### PR TITLE
fix(rating): public pitch cards showed "—" despite real ratings (wrong field)

### DIFF
--- a/frontend/src/pages/Homepage.tsx
+++ b/frontend/src/pages/Homepage.tsx
@@ -422,7 +422,7 @@ export default function Homepage() {
                           </span>
                           <span className="flex items-center gap-1 text-amber-500">
                             <Star className="w-3 h-3" />
-                            {pitch.ratingAverage ? Number(pitch.ratingAverage).toFixed(1) : '—'}
+                            {(() => { const r = Number((pitch as any).rating ?? pitch.ratingAverage ?? 0); return r > 0 ? r.toFixed(1) : '—'; })()}
                           </span>
                         </div>
                         <span className="flex items-center gap-1">
@@ -510,7 +510,7 @@ export default function Homepage() {
                           </span>
                           <span className="flex items-center gap-1 text-amber-500">
                             <Star className="w-3 h-3" />
-                            {pitch.ratingAverage ? Number(pitch.ratingAverage).toFixed(1) : '—'}
+                            {(() => { const r = Number((pitch as any).rating ?? pitch.ratingAverage ?? 0); return r > 0 ? r.toFixed(1) : '—'; })()}
                           </span>
                         </div>
                         <span className="flex items-center gap-1">

--- a/src/utils/public-data-filter.ts
+++ b/src/utils/public-data-filter.ts
@@ -171,7 +171,11 @@ export function filterPitchForPublic(pitch: any): PublicPitch | null {
     nda_count: pitch.nda_count || 0,
     comment_count: pitch.comment_count || 0,
     share_count: pitch.share_count || 0,
-    rating: pitch.rating != null ? Number(pitch.rating) : undefined,
+    // Source the REAL computed rating (rating_average, maintained by the feedback
+    // system) — not the legacy `rating` column, which is always 0. Every public
+    // card reads this; sourcing the dead column made every star render "—" even
+    // though pitches have ratings.
+    rating: Number(pitch.rating_average ?? pitch.rating ?? 0) || undefined,
     require_nda: pitch.require_nda,
     seeking_investment: pitch.seeking_investment,
 


### PR DESCRIPTION
## Reported
Homepage pitch cards render the star rating as **"—"** for every pitch.

## Root cause (verified against prod)
Two layers, classic "data's there, field mismatch hides it":
- The `pitches` table has a **legacy `rating` column that is always `0`** and the real computed **`rating_average`** (maintained by the feedback system). Checked prod: all 10 published pitches have `rating_average > 0` (max **9.29**); `rating = 0.00` everywhere.
- `filterPitchesForPublic` exposed the **dead `rating`** column and dropped `rating_average`, so the homepage's public endpoints (`getPublicTrending/New/Featured/Hot`) emitted `rating: 0`.
- Homepage read `pitch.ratingAverage` — which the public payload never contained — so it always fell through to `"—"`.

## Fix
- **`public-data-filter.ts`**: source the public `rating` field from `rating_average` (fallback to legacy `rating`), so the contract field carries the real value.
- **`Homepage.tsx`**: read the `rating` field the public API actually sends (fallback to `ratingAverage`); show `"—"` only when genuinely 0.

## Scope note
The **marketplace** (`/api/pitches`) already returns `rating_average` and its card reads it directly, so it showed ratings correctly — this bug was specific to the **public-filtered** endpoints behind the homepage.

## Verification
Frontend + backend type-check pass; Homepage test green. Live DB confirms the values exist (e.g. 7.00, 7.15, 9.29) — they'll now render instead of `"—"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)