### PR TITLE
fix(homepage): show Pitchey Score star on the heat-score section

### DIFF
--- a/src/handlers/heat-score.ts
+++ b/src/handlers/heat-score.ts
@@ -92,6 +92,7 @@ export async function hotPitchesHandler(
           COALESCE(p.view_count, 0)::int AS view_count,
           COALESCE(p.like_count, 0)::int AS like_count,
           p.heat_score::float AS heat_score,
+          COALESCE(p.pitchey_score_avg, 0)::float AS pitchey_score_avg,
           p.created_at,
           u.id AS creator_id, u.name AS creator_name, u.username AS creator_username,
           u.profile_image AS creator_avatar
@@ -110,6 +111,7 @@ export async function hotPitchesHandler(
           COALESCE(p.view_count, 0)::int AS view_count,
           COALESCE(p.like_count, 0)::int AS like_count,
           p.heat_score::float AS heat_score,
+          COALESCE(p.pitchey_score_avg, 0)::float AS pitchey_score_avg,
           p.created_at,
           u.id AS creator_id, u.name AS creator_name, u.username AS creator_username,
           u.profile_image AS creator_avatar
@@ -128,6 +130,7 @@ export async function hotPitchesHandler(
           COALESCE(p.view_count, 0)::int AS view_count,
           COALESCE(p.like_count, 0)::int AS like_count,
           p.heat_score::float AS heat_score,
+          COALESCE(p.pitchey_score_avg, 0)::float AS pitchey_score_avg,
           p.created_at,
           u.id AS creator_id, u.name AS creator_name, u.username AS creator_username,
           u.profile_image AS creator_avatar
@@ -146,6 +149,7 @@ export async function hotPitchesHandler(
           COALESCE(p.view_count, 0)::int AS view_count,
           COALESCE(p.like_count, 0)::int AS like_count,
           p.heat_score::float AS heat_score,
+          COALESCE(p.pitchey_score_avg, 0)::float AS pitchey_score_avg,
           p.created_at,
           u.id AS creator_id, u.name AS creator_name, u.username AS creator_username,
           u.profile_image AS creator_avatar


### PR DESCRIPTION
## Reported
The star rating doesn't appear on the homepage's "Top Pitches by Heat Score" section (while it now shows on the other card rows after #298).

## Root cause
That section's card renders the star only when `getPitcheyScore(pitch) > 0`, and `getPitcheyScore` reads `pitchey_score_avg`. But `/api/pitches/hot` (`hotPitchesHandler`) selected only `heat_score` — never `pitchey_score_avg` — so the score was always `0` and the star stayed hidden. Verified in prod: all 10 published pitches have a real `pitchey_score_avg` (max **9.25**).

Note this is a **different** endpoint than #298 fixed — the heat section uses `/api/pitches/hot` (heat-score.ts), not the public-filtered endpoints, so it needed its own fix.

## Fix
Added `COALESCE(p.pitchey_score_avg, 0)::float AS pitchey_score_avg` to all four query branches (genre+format / genre / format / none). The handler returns rows raw, so the field reaches the frontend where `getPitcheyScore` reads it. Heat ember (`heat_score`) was already correct.

## Verification
Backend type-check passes. Post-deploy I'll confirm `/api/pitches/hot` returns `pitchey_score_avg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)