### PR TITLE
fix(nav): drop "Messages" from the top nav (declutter)

### DIFF
--- a/frontend/src/shared/components/layout/PortalTopNav.tsx
+++ b/frontend/src/shared/components/layout/PortalTopNav.tsx
@@ -18,10 +18,10 @@ import { getPortalTheme } from '@shared/hooks/usePortalTheme';
 
 type NavItem = { label: string; to: string };
 
-// Note: a dedicated "Hot" nav item was removed (2026-06-16) — it deep-linked to
-// /marketplace?sort=hot, which is now a first-class sort pill in the marketplace
-// itself, so the top-level link was redundant and over-filled the desktop nav.
-// The Hot discovery path lives on the marketplace's sort row.
+// Note: "Hot" (2026-06-16) and "Messages" (2026-06-16) were removed from this
+// top nav to keep the desktop bar from over-filling. Hot is now a marketplace
+// sort pill; Messages remains reachable from each portal's dashboard quick-actions
+// (creator/investor/production all expose a Messages action).
 
 const NAV_BY_ROLE: Partial<Record<UserTypeCanonical, NavItem[]>> = {
   creator: [
@@ -29,7 +29,6 @@ const NAV_BY_ROLE: Partial<Record<UserTypeCanonical, NavItem[]>> = {
     { label: 'My Pitches', to: CREATOR_ROUTES.pitches },
     { label: 'Marketplace', to: '/marketplace' },
     { label: 'Opportunities', to: '/opportunities' },
-    { label: 'Messages', to: CREATOR_ROUTES.messages },
     { label: 'NDAs', to: CREATOR_ROUTES.ndas },
     { label: 'Portfolio', to: CREATOR_ROUTES.portfolio },
   ],
@@ -40,7 +39,6 @@ const NAV_BY_ROLE: Partial<Record<UserTypeCanonical, NavItem[]>> = {
     { label: 'Compare', to: '/compare' },
     { label: 'Watchlist', to: INVESTOR_ROUTES.watchlist },
     { label: 'Portfolio', to: INVESTOR_ROUTES.portfolio },
-    { label: 'Messages', to: '/messages' },
     { label: 'NDAs', to: INVESTOR_ROUTES.ndaRequests },
   ],
   production: [
@@ -49,7 +47,6 @@ const NAV_BY_ROLE: Partial<Record<UserTypeCanonical, NavItem[]>> = {
     { label: 'Opportunities', to: '/opportunities' },
     { label: 'Compare', to: '/compare' },
     { label: 'NDAs', to: '/production/ndas' },
-    { label: 'Messages', to: PRODUCTION_ROUTES.messages },
   ],
   watcher: [
     { label: 'Dashboard', to: WATCHER_ROUTES.dashboard },


### PR DESCRIPTION
Follows the "Hot" removal (#297) — the desktop top nav is over-full. "Messages" was a top-level item for creator/investor/production, but **every one of those portals already exposes a Messages action in its dashboard quick-actions** (`CreatorDashboard.tsx`, `InvestorDashboard.tsx`, `ProductionDashboard.tsx`), so the nav link was redundant.

- Removed from creator / investor / production navs (watcher + anon never had it).
- No feature lost — Messages stays one click away from each dashboard.

Frontend type-check passes; no test asserted the nav "Messages".

🤖 Generated with [Claude Code](https://claude.com/claude-code)