### PR TITLE
fix(nav): keep portal (sidebar) chrome on marketplace — stop the dashboard↔marketplace nav flip

### DIFF
--- a/frontend/src/pages/MarketplaceEnhanced.tsx
+++ b/frontend/src/pages/MarketplaceEnhanced.tsx
@@ -51,6 +51,8 @@ import {
 } from 'lucide-react';
 import { API_URL } from '../config';
 import { formatBudgetCompact } from '@shared/utils/formatters';
+import { getBrowsePath } from '@/utils/navigation';
+import { normalizeUserType } from '@shared/types/user-type';
 
 // Get the best available image URL from a pitch (handles snake_case API + camelCase)
 function getPitchImageUrl(pitch: Pitch): string | undefined {
@@ -190,7 +192,22 @@ export default function MarketplaceEnhanced() {
   // When rendered inside a portal (e.g. /watcher/browse), PortalLayout
   // already provides a header — hide the standalone one to avoid duplicates.
   const isInsidePortal = /^\/(watcher|creator|investor|production|admin)\//.test(location.pathname);
-  
+
+  // Keep the chrome consistent: an authenticated portal user should always browse
+  // inside their PortalLayout (sidebar) shell, never the standalone /marketplace
+  // top-nav. Many dashboard links still point at /marketplace; rather than chase
+  // every call site, redirect here to the in-portal browse route so navigating
+  // dashboard → marketplace no longer flips sidebar → top-bar. Query string (e.g.
+  // ?sort=hot) is preserved. Anonymous users keep the standalone marketplace.
+  const inPortalBrowsePath = isAuthenticated ? getBrowsePath(normalizeUserType(user?.userType)) : '/marketplace';
+  const shouldRedirectIntoPortal = !isInsidePortal && isAuthenticated && inPortalBrowsePath !== '/marketplace';
+  useEffect(() => {
+    if (shouldRedirectIntoPortal) {
+      navigate(`${inPortalBrowsePath}${location.search}`, { replace: true });
+    }
+  }, [shouldRedirectIntoPortal, inPortalBrowsePath, location.search, navigate]);
+
+
   // Per-tab state management to prevent content bleeding
   interface TabState {
     pitches: Pitch[];


### PR DESCRIPTION
## Reported
"The top nav changes when I've routed to the dashboard then come back to marketplace."

## Root cause (it's not item count — it's two chrome systems)
- **Dashboard** (`/creator/dashboard` …) renders inside **`PortalLayout`** → a **sidebar** (`EnhancedCreatorNav` / `EnhancedInvestorNav` / `EnhancedProductionNav`).
- **Standalone `/marketplace`** renders **`PortalTopNav`** → a **horizontal top bar**.

Dozens of dashboard links call `navigate('/marketplace')` (InvestorDashboard alone has 4, plus NDARequests, ProductionSaved, InvestorDiscover…), so an authenticated portal user gets pulled from sidebar chrome into top-bar chrome — which reads as "the nav changed". In-portal browse routes (`/<portal>/browse`) already exist and render the same Marketplace **inside** the sidebar, but most links bypass them.

## Fix (one point, not N call sites)
When an authenticated portal user lands on standalone `/marketplace`, redirect to their in-portal browse route via `getBrowsePath()` → `/<portal>/browse`, which renders the same Marketplace inside `PortalLayout` (sidebar). Query string (e.g. `?sort=hot`) is preserved. Anonymous users keep the standalone marketplace + `PortalTopNav`.

**Net effect:** dashboard and marketplace share one consistent sidebar chrome for logged-in users — no more flip.

## Scope note
`/opportunities` and `/compare` still use the top bar for authenticated users (same latent pattern). Not addressed here since they'd need in-portal routes; happy to follow up if you want full consistency.

## Verification
Frontend type-check passes; marketplace test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)