### PR TITLE
fix(nav): keep portal (sidebar) chrome on /opportunities and /compare

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -507,6 +507,9 @@ function App() {
             <Route index element={<Navigate to="dashboard" replace />} />
             <Route path="onboarding" element={<OnboardingPage />} />
             <Route path="dashboard" element={<CreatorDashboard />} />
+            {/* In-portal opportunities + compare — keep PortalLayout sidebar chrome. */}
+            <Route path="opportunities" element={<OpportunitiesBoard />} />
+            <Route path="compare" element={<ComparePage />} />
             {/* In-portal browse — keeps the creator PortalLayout chrome (see getBrowsePath). */}
             <Route path="browse" element={<Marketplace />} />
             <Route path="pitch/new" element={<CreatePitch />} />
@@ -538,6 +541,8 @@ function App() {
             <Route index element={<Navigate to="dashboard" replace />} />
             <Route path="onboarding" element={<OnboardingPage />} />
             <Route path="dashboard" element={<InvestorDashboard />} />
+            <Route path="opportunities" element={<OpportunitiesBoard />} />
+            <Route path="compare" element={<ComparePage />} />
             {import.meta.env.DEV && <Route path="dashboard/debug" element={<InvestorDashboardDebug />} />}
             <Route path="following" element={<Following />} />
             <Route path="browse" element={<InvestorBrowse />} />
@@ -572,6 +577,8 @@ function App() {
             <Route index element={<Navigate to="dashboard" replace />} />
             <Route path="onboarding" element={<OnboardingPage />} />
             <Route path="dashboard" element={<ProductionDashboard />} />
+            <Route path="opportunities" element={<OpportunitiesBoard />} />
+            <Route path="compare" element={<ComparePage />} />
             {/* In-portal browse — keeps the production PortalLayout chrome instead of
                 dumping the user onto the standalone /marketplace (old layout).
                 MarketplaceEnhanced hides its own top nav when isInsidePortal matches /production/. */}

--- a/frontend/src/pages/ComparePage.tsx
+++ b/frontend/src/pages/ComparePage.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useNavigate, useLocation } from 'react-router-dom';
+import { useBetterAuthStore } from '../store/betterAuthStore';
+import { getPortalPath } from '@/utils/navigation';
+import { normalizeUserType } from '@shared/types/user-type';
 import {
   BarChart3, Plus, X, Search, Loader2, Flame, Eye, Heart, Star, BadgeCheck, Crown, Layers,
   Share2, Bookmark, Trash2, Copy, Check,
@@ -339,6 +342,23 @@ function SavedMenu({ onLoad }: { onLoad: (c: SavedComparison) => void }) {
 // ---------------------------------------------------------------------------
 
 export default function ComparePage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { user, isAuthenticated } = useBetterAuthStore();
+
+  // Keep portal chrome consistent (same fix as /marketplace + /opportunities):
+  // authenticated creator/investor/production users land inside their PortalLayout
+  // sidebar (/<portal>/compare) rather than the standalone top-nav page. Query
+  // string (type/ids/token) preserved; watcher/admin/anon keep the standalone page.
+  const isInsidePortal = /^\/(watcher|creator|investor|production|admin)\//.test(location.pathname);
+  const portalSeg = getPortalPath(normalizeUserType(user?.userType));
+  const inPortalPath = (isAuthenticated && ['creator', 'investor', 'production'].includes(portalSeg)) ? `/${portalSeg}/compare` : null;
+  useEffect(() => {
+    if (!isInsidePortal && inPortalPath) {
+      navigate(`${inPortalPath}${location.search}`, { replace: true });
+    }
+  }, [isInsidePortal, inPortalPath, location.search, navigate]);
+
   const [saveOpen, setSaveOpen] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const rawType = searchParams.get('type');
@@ -384,7 +404,7 @@ export default function ComparePage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-stone-50 via-white to-stone-50">
-      <PortalTopNav />
+      {!isInsidePortal && <PortalTopNav />}
 
       <section className="relative overflow-hidden bg-gradient-to-r from-purple-700 via-purple-600 to-indigo-600 text-white">
         <div aria-hidden className="absolute inset-0 bg-[radial-gradient(50%_60%_at_85%_0%,rgba(245,158,11,0.18),transparent_60%)]" />

--- a/frontend/src/pages/OpportunitiesBoard.tsx
+++ b/frontend/src/pages/OpportunitiesBoard.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import {
   Briefcase, Building2, Wallet, Plus, X, MapPin, CalendarDays, DollarSign,
   BadgeCheck, Loader2, Pencil, Megaphone, ArrowRight, Send, Inbox, Check, Star, BarChart3,
 } from 'lucide-react';
 import PortalTopNav from '@shared/components/layout/PortalTopNav';
+import { getPortalPath } from '@/utils/navigation';
+import { normalizeUserType } from '@shared/types/user-type';
 import { useBetterAuthStore } from '../store/betterAuthStore';
 import { useToast } from '@shared/components/feedback/ToastProvider';
 import { getGenresSync, getFormatsSync } from '@config/pitchConstants';
@@ -534,10 +536,24 @@ const TYPE_TABS = [
 
 export default function OpportunitiesBoard() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { user, isAuthenticated } = useBetterAuthStore();
   const userType = user?.userType;
   const canPost = isAuthenticated && (userType === 'production' || userType === 'investor');
   const canSubmit = isAuthenticated && (userType === 'creator' || userType === 'production');
+
+  // Keep portal chrome consistent (same fix as /marketplace): authenticated
+  // creator/investor/production users browse this inside their PortalLayout sidebar
+  // (/<portal>/opportunities) instead of the standalone top-nav page. Watcher/admin/
+  // anon keep the standalone page (no in-portal route for them). Query string preserved.
+  const isInsidePortal = /^\/(watcher|creator|investor|production|admin)\//.test(location.pathname);
+  const portalSeg = getPortalPath(normalizeUserType(userType));
+  const inPortalPath = ['creator', 'investor', 'production'].includes(portalSeg) ? `/${portalSeg}/opportunities` : null;
+  useEffect(() => {
+    if (!isInsidePortal && inPortalPath) {
+      navigate(`${inPortalPath}${location.search}`, { replace: true });
+    }
+  }, [isInsidePortal, inPortalPath, location.search, navigate]);
 
   const [calls, setCalls] = useState<OpenCall[]>([]);
   const [loading, setLoading] = useState(true);
@@ -593,7 +609,7 @@ export default function OpportunitiesBoard() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-stone-50 via-white to-stone-50">
-      <PortalTopNav />
+      {!isInsidePortal && <PortalTopNav />}
 
       {/* Hero */}
       <section className="relative overflow-hidden bg-gradient-to-r from-purple-700 via-purple-600 to-indigo-600 text-white">


### PR DESCRIPTION
Extends #301's marketplace fix to the other two standalone pages that flipped logged-in users from the PortalLayout **sidebar** to the PortalTopNav **top bar**.

## Changes
- **App.tsx**: added in-portal routes (`opportunities`, `compare`) to the **creator / investor / production** portal groups, so they render inside `PortalLayout`. Watcher excluded (not in its nav).
- **OpportunitiesBoard / ComparePage**: hide their own `PortalTopNav` when `isInsidePortal`, and redirect authenticated creator/investor/production users from the standalone page to `/<portal>/{opportunities,compare}` (`getPortalPath`), preserving the query string (`type`/`ids`/`sort`/`token`). Watcher/admin/anon keep the standalone page.

## Net effect
Dashboard ↔ marketplace ↔ opportunities ↔ compare now share **one consistent sidebar chrome** for logged-in portal users — the nav no longer flips anywhere in that loop.

## Verification
Full frontend type-check passes. (No existing tests for these pages; CI smoke/smoke-regression exercise the routes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)