### PR TITLE
feat(search): revive Saved Searches — real-schema rebuild (#308)

### DIFF
--- a/frontend/src/pages/AdvancedSearch.tsx
+++ b/frontend/src/pages/AdvancedSearch.tsx
@@ -5,8 +5,9 @@ import {
   Star, Clock, DollarSign, Calendar, Users,
   MapPin, Film, Award, Eye, Heart, ChevronDown,
   X, RefreshCw, Download, ArrowUpDown, User,
-  ArrowLeft, Home, ShoppingBag, LogOut
+  ArrowLeft, Home, ShoppingBag, LogOut, Bookmark
 } from 'lucide-react';
+import { SavedSearches } from '../features/browse/components/Search';
 import { useBetterAuthStore } from '../store/betterAuthStore';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@shared/components/ui/card';
 import { Badge } from '@shared/components/ui/badge';
@@ -63,6 +64,7 @@ export default function AdvancedSearch() {
   const [loading, setLoading] = useState(false);
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
   const [showFilters, setShowFilters] = useState(false);
+  const [savedOpen, setSavedOpen] = useState(false);
   
   const [filters, setFilters] = useState<SearchFilters>({
     query: '',
@@ -428,6 +430,31 @@ export default function AdvancedSearch() {
                   </div>
                 </CardHeader>
                 <CardContent className="space-y-6">
+                  {/* Saved Searches */}
+                  <div className="border-b border-gray-100 pb-4">
+                    <button
+                      type="button"
+                      onClick={() => setSavedOpen(o => !o)}
+                      className="flex w-full items-center justify-between text-sm font-medium text-gray-700"
+                    >
+                      <span className="flex items-center gap-2">
+                        <Bookmark className="w-4 h-4" /> Saved Searches
+                      </span>
+                      <ChevronDown className={`w-4 h-4 transition-transform ${savedOpen ? 'rotate-180' : ''}`} />
+                    </button>
+                    {savedOpen && (
+                      <div className="mt-3">
+                        <SavedSearches
+                          onSearchExecute={(query) => {
+                            // Apply the saved query and let the debounced effect re-run the search.
+                            setFilters(prev => ({ ...prev, query }));
+                            setShowFilters(false);
+                          }}
+                        />
+                      </div>
+                    )}
+                  </div>
+
                   {/* Search Type */}
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-2">Search Type</label>

--- a/src/db/migrations/107_saved_searches_revive.sql
+++ b/src/db/migrations/107_saved_searches_revive.sql
@@ -1,0 +1,42 @@
+-- 107_saved_searches_revive.sql
+-- Revive the Saved Searches feature (#308 revive candidate). The saved_searches
+-- table (migration 021) and the SavedSearches.tsx UI already existed but the
+-- backend contract was never reconciled. This reconciles the schema to what the
+-- live handlers now persist + adds the execution counter powering the anonymized
+-- community-"trending" Popular list.
+--
+-- Self-contained + idempotent: CREATE TABLE IF NOT EXISTS guarantees the table,
+-- then ADD COLUMN IF NOT EXISTS for EVERY column the handlers touch — so this is
+-- safe whether or not migration 021 fully applied / left a partial table (the
+-- exact drift class that bit migration 081).
+
+CREATE TABLE IF NOT EXISTS saved_searches (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name VARCHAR(255) NOT NULL,
+  query TEXT,
+  filters JSONB,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
+ALTER TABLE saved_searches
+  ADD COLUMN IF NOT EXISTS query TEXT,
+  ADD COLUMN IF NOT EXISTS filters JSONB,
+  ADD COLUMN IF NOT EXISTS description TEXT,
+  -- Only public saved searches feed the anonymized community-trending list.
+  ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE,
+  -- notify_on_results (frontend) maps to alert_enabled; alerts are stored-only for now.
+  ADD COLUMN IF NOT EXISTS alert_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS alert_frequency VARCHAR(50) NOT NULL DEFAULT 'never',
+  -- Bumped on POST /api/search/saved/:id/execute; powers use_count + trending rank.
+  ADD COLUMN IF NOT EXISTS execution_count INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_executed_at TIMESTAMP,
+  ADD COLUMN IF NOT EXISTS created_at TIMESTAMP DEFAULT NOW(),
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT NOW();
+
+CREATE INDEX IF NOT EXISTS idx_saved_searches_user ON saved_searches (user_id);
+-- Trending reads the most-executed public searches; index the hot path.
+CREATE INDEX IF NOT EXISTS idx_saved_searches_public_trending
+  ON saved_searches (execution_count DESC)
+  WHERE is_public = TRUE;

--- a/src/db/migrations/107_saved_searches_revive.sql
+++ b/src/db/migrations/107_saved_searches_revive.sql
@@ -1,41 +1,24 @@
 -- 107_saved_searches_revive.sql
--- Revive the Saved Searches feature (#308 revive candidate). The saved_searches
--- table (migration 021) and the SavedSearches.tsx UI already existed but the
--- backend contract was never reconciled. This reconciles the schema to what the
--- live handlers now persist + adds the execution counter powering the anonymized
--- community-"trending" Popular list.
+-- Revive the Saved Searches feature (#308 revive candidate).
 --
--- Self-contained + idempotent: CREATE TABLE IF NOT EXISTS guarantees the table,
--- then ADD COLUMN IF NOT EXISTS for EVERY column the handlers touch — so this is
--- safe whether or not migration 021 fully applied / left a partial table (the
--- exact drift class that bit migration 081).
-
-CREATE TABLE IF NOT EXISTS saved_searches (
-  id SERIAL PRIMARY KEY,
-  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  name VARCHAR(255) NOT NULL,
-  query TEXT,
-  filters JSONB,
-  created_at TIMESTAMP DEFAULT NOW(),
-  updated_at TIMESTAMP DEFAULT NOW()
-);
+-- IMPORTANT: the LIVE saved_searches table was created by migration 012 with
+-- columns search_query JSONB ({"query":"..."}), search_filters JSONB,
+-- notification_enabled BOOLEAN. Migration 021 re-declared it with
+-- query/filters/alert_enabled, but that CREATE TABLE IF NOT EXISTS was a silent
+-- no-op (012 already made the table) — those columns DO NOT exist in prod.
+-- This migration extends the REAL table; it must not target the 021 phantom columns.
+--
+-- Adds: description + is_public (anonymized community-trending feeds off public
+-- searches), alert_frequency (deferred alerts), execution_count + last_executed_at
+-- (powers use_count + trending rank). Idempotent.
 
 ALTER TABLE saved_searches
-  ADD COLUMN IF NOT EXISTS query TEXT,
-  ADD COLUMN IF NOT EXISTS filters JSONB,
   ADD COLUMN IF NOT EXISTS description TEXT,
-  -- Only public saved searches feed the anonymized community-trending list.
   ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE,
-  -- notify_on_results (frontend) maps to alert_enabled; alerts are stored-only for now.
-  ADD COLUMN IF NOT EXISTS alert_enabled BOOLEAN NOT NULL DEFAULT FALSE,
   ADD COLUMN IF NOT EXISTS alert_frequency VARCHAR(50) NOT NULL DEFAULT 'never',
-  -- Bumped on POST /api/search/saved/:id/execute; powers use_count + trending rank.
   ADD COLUMN IF NOT EXISTS execution_count INTEGER NOT NULL DEFAULT 0,
-  ADD COLUMN IF NOT EXISTS last_executed_at TIMESTAMP,
-  ADD COLUMN IF NOT EXISTS created_at TIMESTAMP DEFAULT NOW(),
-  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT NOW();
+  ADD COLUMN IF NOT EXISTS last_executed_at TIMESTAMP;
 
-CREATE INDEX IF NOT EXISTS idx_saved_searches_user ON saved_searches (user_id);
 -- Trending reads the most-executed public searches; index the hot path.
 CREATE INDEX IF NOT EXISTS idx_saved_searches_public_trending
   ON saved_searches (execution_count DESC)

--- a/src/handlers/search-filters.ts
+++ b/src/handlers/search-filters.ts
@@ -337,52 +337,114 @@ export class SearchFiltersHandler {
   }
 
   // Save search
+  // ── Saved searches ─────────────────────────────────────────────────────────
+  // Maps a saved_searches row to the shape SavedSearches.tsx reads: search_query
+  // (db column `query`), use_count (db `execution_count`), notify_on_results
+  // (db `alert_enabled`). `filters` is normalized to an object.
+  private toSavedSearch(row: any) {
+    let filters: any = row?.filters ?? {};
+    if (typeof filters === 'string') {
+      try { filters = JSON.parse(filters); } catch { filters = {}; }
+    }
+    return {
+      id: row.id,
+      name: row.name,
+      description: row.description ?? '',
+      search_query: row.query ?? '',
+      filters: filters ?? {},
+      is_public: row.is_public ?? false,
+      notify_on_results: row.alert_enabled ?? false,
+      alert_frequency: row.alert_frequency ?? 'never',
+      use_count: row.execution_count ?? 0,
+      created_at: row.created_at,
+    };
+  }
+
   async saveSearch(userId: number, data: any) {
     try {
-      const { name, query, filters, alertEnabled = false } = data;
+      const name = (data?.name ?? '').toString().trim();
+      if (!name) return { success: false, error: 'Name is required' };
+      // Accept the frontend field name (search_query) and the legacy one (query).
+      const query = (data?.search_query ?? data?.query ?? '').toString();
+      const filters = data?.filters ?? {};
+      const description = (data?.description ?? '').toString();
+      const isPublic = data?.is_public === true;
+      const notify = data?.notify_on_results === true || data?.alertEnabled === true;
+      const alertFrequency = (data?.alert_frequency ?? 'never').toString();
 
-      const savedSearch = await this.db.query(
-        `INSERT INTO saved_searches (user_id, name, query, filters, alert_enabled)
-         VALUES ($1, $2, $3, $4, $5)
+      const rows = await this.db.query(
+        `INSERT INTO saved_searches
+           (user_id, name, description, query, filters, is_public, alert_enabled, alert_frequency)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
          RETURNING *`,
-        [userId, name, query, JSON.stringify(filters), alertEnabled]
+        [userId, name, description, query, JSON.stringify(filters), isPublic, notify, alertFrequency]
       );
-
-      return { success: true, data: { savedSearch: savedSearch[0] } };
+      return { success: true, data: this.toSavedSearch(rows[0]) };
     } catch (error) {
       console.error('Save search error:', error);
       return { success: false, error: 'Failed to save search' };
     }
   }
 
-  // Get saved searches
   async getSavedSearches(userId: number) {
     try {
-      const searches = await this.db.query(
-        `SELECT *, 
-          (SELECT COUNT(*) FROM search_alerts WHERE search_id = ss.id) as alert_count
-         FROM saved_searches ss
-         WHERE user_id = $1
-         ORDER BY created_at DESC`,
+      const rows = await this.db.query(
+        `SELECT * FROM saved_searches WHERE user_id = $1 ORDER BY created_at DESC`,
         [userId]
       );
-
-      return { success: true, data: { searches } };
+      return { success: true, data: rows.map((r: any) => this.toSavedSearch(r)) };
     } catch (error) {
       console.error('Get saved searches error:', error);
-      return { success: true, data: { searches: [] } };
+      return { success: true, data: [] };
     }
   }
 
-  // Delete saved search
+  // Anonymized community trending: the most-executed PUBLIC saved searches,
+  // one card per distinct query, with no saver identity exposed.
+  async getPopularSearches(limit = 10) {
+    try {
+      const lim = Math.min(Math.max(parseInt(String(limit), 10) || 10, 1), 50);
+      const rows = await this.db.query(
+        `SELECT DISTINCT ON (query) *
+           FROM saved_searches
+          WHERE is_public = TRUE AND query IS NOT NULL AND query <> ''
+          ORDER BY query, execution_count DESC, created_at DESC`,
+        []
+      );
+      const ranked = rows
+        .map((r: any) => this.toSavedSearch(r))
+        .sort((a: any, b: any) => b.use_count - a.use_count)
+        .slice(0, lim);
+      return { success: true, data: ranked };
+    } catch (error) {
+      console.error('Get popular searches error:', error);
+      return { success: true, data: [] };
+    }
+  }
+
+  async executeSavedSearch(userId: number, searchId: number) {
+    try {
+      const rows = await this.db.query(
+        `UPDATE saved_searches
+            SET execution_count = execution_count + 1, last_executed_at = NOW()
+          WHERE id = $1 AND user_id = $2
+          RETURNING *`,
+        [searchId, userId]
+      );
+      if (!rows || rows.length === 0) return { success: false, error: 'Saved search not found' };
+      return { success: true, data: this.toSavedSearch(rows[0]) };
+    } catch (error) {
+      console.error('Execute saved search error:', error);
+      return { success: false, error: 'Failed to execute search' };
+    }
+  }
+
   async deleteSavedSearch(userId: number, searchId: number) {
     try {
       await this.db.query(
-        `DELETE FROM saved_searches 
-         WHERE id = $1 AND user_id = $2`,
+        `DELETE FROM saved_searches WHERE id = $1 AND user_id = $2`,
         [searchId, userId]
       );
-
       return { success: true, data: { message: 'Search deleted successfully' } };
     } catch (error) {
       console.error('Delete saved search error:', error);

--- a/src/handlers/search-filters.ts
+++ b/src/handlers/search-filters.ts
@@ -338,22 +338,27 @@ export class SearchFiltersHandler {
 
   // Save search
   // ── Saved searches ─────────────────────────────────────────────────────────
-  // Maps a saved_searches row to the shape SavedSearches.tsx reads: search_query
-  // (db column `query`), use_count (db `execution_count`), notify_on_results
-  // (db `alert_enabled`). `filters` is normalized to an object.
+  // The LIVE table (migration 012) stores: search_query JSONB ({"query":"..."}),
+  // search_filters JSONB, notification_enabled BOOLEAN. Migration 107 adds
+  // description, is_public, alert_frequency, execution_count, last_executed_at.
+  // This maps a row to the shape SavedSearches.tsx reads (search_query as a STRING,
+  // use_count, notify_on_results).
   private toSavedSearch(row: any) {
-    let filters: any = row?.filters ?? {};
-    if (typeof filters === 'string') {
-      try { filters = JSON.parse(filters); } catch { filters = {}; }
-    }
+    // search_query is jsonb {"query": "..."} — extract the string; tolerate legacy
+    // bare-string/stringified values.
+    let sq: any = row?.search_query;
+    if (typeof sq === 'string') { try { sq = JSON.parse(sq); } catch { sq = { query: sq }; } }
+    const queryStr = (sq && typeof sq === 'object') ? (sq.query ?? '') : (sq ?? '');
+    let filters: any = row?.search_filters ?? {};
+    if (typeof filters === 'string') { try { filters = JSON.parse(filters); } catch { filters = {}; } }
     return {
       id: row.id,
       name: row.name,
       description: row.description ?? '',
-      search_query: row.query ?? '',
+      search_query: queryStr,
       filters: filters ?? {},
       is_public: row.is_public ?? false,
-      notify_on_results: row.alert_enabled ?? false,
+      notify_on_results: row.notification_enabled ?? false,
       alert_frequency: row.alert_frequency ?? 'never',
       use_count: row.execution_count ?? 0,
       created_at: row.created_at,
@@ -364,20 +369,20 @@ export class SearchFiltersHandler {
     try {
       const name = (data?.name ?? '').toString().trim();
       if (!name) return { success: false, error: 'Name is required' };
-      // Accept the frontend field name (search_query) and the legacy one (query).
-      const query = (data?.search_query ?? data?.query ?? '').toString();
+      const queryStr = (data?.search_query ?? data?.query ?? '').toString();
       const filters = data?.filters ?? {};
       const description = (data?.description ?? '').toString();
       const isPublic = data?.is_public === true;
-      const notify = data?.notify_on_results === true || data?.alertEnabled === true;
+      const notify = data?.notify_on_results === true;
       const alertFrequency = (data?.alert_frequency ?? 'never').toString();
 
       const rows = await this.db.query(
         `INSERT INTO saved_searches
-           (user_id, name, description, query, filters, is_public, alert_enabled, alert_frequency)
+           (user_id, name, description, search_query, search_filters, is_public, notification_enabled, alert_frequency)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
          RETURNING *`,
-        [userId, name, description, query, JSON.stringify(filters), isPublic, notify, alertFrequency]
+        // search_query is jsonb {"query": "..."} to match the existing data model.
+        [userId, name, description, JSON.stringify({ query: queryStr }), JSON.stringify(filters), isPublic, notify, alertFrequency]
       );
       return { success: true, data: this.toSavedSearch(rows[0]) };
     } catch (error) {
@@ -400,15 +405,17 @@ export class SearchFiltersHandler {
   }
 
   // Anonymized community trending: the most-executed PUBLIC saved searches,
-  // one card per distinct query, with no saver identity exposed.
+  // one card per distinct query text, with no saver identity exposed.
   async getPopularSearches(limit = 10) {
     try {
       const lim = Math.min(Math.max(parseInt(String(limit), 10) || 10, 1), 50);
       const rows = await this.db.query(
-        `SELECT DISTINCT ON (query) *
+        `SELECT DISTINCT ON (search_query->>'query') *
            FROM saved_searches
-          WHERE is_public = TRUE AND query IS NOT NULL AND query <> ''
-          ORDER BY query, execution_count DESC, created_at DESC`,
+          WHERE is_public = TRUE
+            AND search_query->>'query' IS NOT NULL
+            AND search_query->>'query' <> ''
+          ORDER BY search_query->>'query', execution_count DESC, created_at DESC`,
         []
       );
       const ranked = rows

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -2524,7 +2524,11 @@ class RouteRegistry {
     // (→ this.search) was dead. Removed to kill the duplicate-route confusion.
     this.register('GET', '/api/search/advanced', this.advancedSearch.bind(this));
     this.register('GET', '/api/filters', this.getFilters.bind(this));
-    this.register('POST', '/api/search/save', this.saveSearch.bind(this));
+    // Saved searches — register specific paths before the :id param route.
+    this.register('GET', '/api/search/saved/popular', this.getPopularSearches.bind(this));
+    this.register('POST', '/api/search/saved/:id/execute', this.executeSavedSearch.bind(this));
+    this.register('POST', '/api/search/save', this.saveSearch.bind(this));      // legacy alias
+    this.register('POST', '/api/search/saved', this.saveSearch.bind(this));     // SavedSearches.tsx create
     this.register('GET', '/api/search/saved', this.getSavedSearches.bind(this));
     this.register('DELETE', '/api/search/saved/:id', this.deleteSavedSearch.bind(this));
 
@@ -20845,7 +20849,8 @@ Signatures: [To be completed upon signing]
       const result = await handler.saveSearch(authCheck.user.id, data);
 
       const origin = request.headers.get('Origin');
-      return new Response(JSON.stringify(result), {
+      // SavedSearches.tsx reads the created object directly from the response body.
+      return new Response(JSON.stringify(result.success ? result.data : result), {
         headers: getCorsHeaders(origin),
         status: result.success ? 201 : 400
       });
@@ -20863,9 +20868,52 @@ Signatures: [To be completed upon signing]
       const result = await handler.getSavedSearches(authCheck.user.id);
 
       const origin = request.headers.get('Origin');
-      return new Response(JSON.stringify(result), {
+      // SavedSearches.tsx reads `data.savedSearches`.
+      return new Response(JSON.stringify({ savedSearches: result.data ?? [] }), {
         headers: getCorsHeaders(origin),
         status: 200
+      });
+    } catch (error) {
+      return errorHandler(error, request);
+    }
+  }
+
+  private async getPopularSearches(request: Request): Promise<Response> {
+    try {
+      // Popular/trending is a read of public searches — no auth required.
+      const url = new URL(request.url);
+      const limit = url.searchParams.get('limit') ?? '10';
+
+      const handler = new (await import('./handlers/search-filters')).SearchFiltersHandler(this.db);
+      const result = await handler.getPopularSearches(Number(limit));
+
+      const origin = request.headers.get('Origin');
+      // SavedSearches.tsx reads `data.popularSearches`.
+      return new Response(JSON.stringify({ popularSearches: result.data ?? [] }), {
+        headers: getCorsHeaders(origin),
+        status: 200
+      });
+    } catch (error) {
+      return errorHandler(error, request);
+    }
+  }
+
+  private async executeSavedSearch(request: Request): Promise<Response> {
+    try {
+      const authCheck = await this.requireAuth(request);
+      if (!authCheck.authorized) return authCheck.response;
+
+      // /api/search/saved/:id/execute → ['', 'api', 'search', 'saved', ':id', 'execute']
+      const url = new URL(request.url);
+      const searchId = parseInt(url.pathname.split('/')[4] || '0');
+
+      const handler = new (await import('./handlers/search-filters')).SearchFiltersHandler(this.db);
+      const result = await handler.executeSavedSearch(authCheck.user.id, searchId);
+
+      const origin = request.headers.get('Origin');
+      return new Response(JSON.stringify(result), {
+        headers: getCorsHeaders(origin),
+        status: result.success ? 200 : 404
       });
     } catch (error) {
       return errorHandler(error, request);


### PR DESCRIPTION
Reworked Saved Searches revive on a **clean branch off main** (supersedes #312, which was built on a phantom schema and got conflated with another session's commits).

## Why the rework
#312 targeted `query`/`filters`/`alert_enabled` — columns that **don't exist in prod**. They came from migration 021's `CREATE TABLE IF NOT EXISTS`, a silent no-op because migration 012 already created `saved_searches` with the real columns: **`search_query` JSONB (`{"query":"…"}`), `search_filters` JSONB, `notification_enabled`**. Shipping #312 would have broken the feature in prod. (Verified the live schema directly before catching this.)

## This PR
- **Migration 107** — extends the *real* table: `ADD COLUMN IF NOT EXISTS description, is_public, alert_frequency, execution_count, last_executed_at` (+ trending index). No phantom columns, no `CREATE TABLE`.
- **`SearchFiltersHandler`** — maps the real schema to the frontend contract: `search_query.query`↔frontend string (stored as jsonb `{"query": …}`), `search_filters`↔filters, `notification_enabled`↔`notify_on_results`, `execution_count`↔`use_count`. Trending dedupes on `search_query->>'query'`.
- **Endpoints + frontend mount** unchanged from the original revive (schema-agnostic): `POST /api/search/saved`, `/popular`, `/:id/execute`; panel mounted in Advanced Search.
- Decisions unchanged: popular = anonymized community-trending; alerts deferred.

## Verification (against the REAL prod schema, via rollback transactions — prod untouched)
- Migration ALTER applies cleanly.
- The exact `WorkerDatabase`-interpolated jsonb INSERT stores `{"query":"horror"}` and `search_query->>'query'` resolves to `horror` (caught + corrected a jsonb double-encoding red herring from a wrong-driver test).
- Trending query returns the seeded public row.
- Worker builds clean; backend suite **21 files / 1029** green.

## ⚠️ Ship note
Migration 107 must be applied to prod (`npm run db:migrate apply`) — it is **not** yet applied. CI deploy-preflight enforces it's recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)