### PR TITLE
fix(onboarding): de-trap signup flow with a shared step indicator

### DIFF
--- a/frontend/src/features/auth/components/OnboardingStepper.tsx
+++ b/frontend/src/features/auth/components/OnboardingStepper.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Check } from 'lucide-react';
+
+/**
+ * Presentational 3-step progress indicator for the signup journey:
+ * Create account → Verify email → Complete profile.
+ *
+ * Shown on Register, VerifyEmail and the onboarding profile page so the three
+ * screens read as one continuous, finite flow rather than disconnected steps.
+ * No store dependency — purely driven by the `current` prop.
+ */
+
+export type StepperAccent = 'indigo' | 'emerald' | 'amber' | 'purple';
+
+interface OnboardingStepperProps {
+  /** 1-based index of the step the user is currently on. */
+  current: 1 | 2 | 3;
+  /** Portal tint for the active/completed states. Defaults to purple (brand). */
+  accent?: StepperAccent;
+  className?: string;
+}
+
+const STEPS = ['Create account', 'Verify email', 'Complete profile'] as const;
+
+// Tailwind can't compose class names dynamically — map each accent explicitly.
+const ACCENT: Record<StepperAccent, { done: string; current: string; label: string }> = {
+  indigo: { done: 'bg-indigo-600 text-white', current: 'bg-indigo-600 text-white ring-4 ring-indigo-100', label: 'text-indigo-700' },
+  emerald: { done: 'bg-emerald-600 text-white', current: 'bg-emerald-600 text-white ring-4 ring-emerald-100', label: 'text-emerald-700' },
+  amber: { done: 'bg-amber-600 text-white', current: 'bg-amber-600 text-white ring-4 ring-amber-100', label: 'text-amber-700' },
+  purple: { done: 'bg-purple-600 text-white', current: 'bg-purple-600 text-white ring-4 ring-purple-100', label: 'text-purple-700' },
+};
+
+export function OnboardingStepper({ current, accent = 'purple', className = '' }: OnboardingStepperProps) {
+  const colors = ACCENT[accent] ?? ACCENT.purple;
+
+  return (
+    <nav aria-label="Sign-up progress" className={`w-full ${className}`}>
+      <ol className="flex items-center justify-center">
+        {STEPS.map((label, i) => {
+          const stepNum = i + 1;
+          const isDone = stepNum < current;
+          const isCurrent = stepNum === current;
+          const isLast = stepNum === STEPS.length;
+
+          const circle = isDone
+            ? colors.done
+            : isCurrent
+              ? colors.current
+              : 'bg-gray-200 text-gray-500';
+
+          return (
+            <li key={label} className="flex items-center" {...(isLast ? {} : { 'aria-hidden': false })}>
+              <div className="flex flex-col items-center" aria-current={isCurrent ? 'step' : undefined}>
+                <span
+                  className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-semibold transition-colors ${circle}`}
+                >
+                  {isDone ? <Check className="h-4 w-4" aria-hidden="true" /> : stepNum}
+                </span>
+                <span
+                  className={`mt-1.5 text-xs font-medium whitespace-nowrap ${
+                    isCurrent ? colors.label : isDone ? 'text-gray-600' : 'text-gray-400'
+                  }`}
+                >
+                  {label}
+                </span>
+              </div>
+              {!isLast && (
+                <span
+                  aria-hidden="true"
+                  className={`mx-2 h-0.5 w-8 sm:w-12 self-start mt-4 rounded ${stepNum < current ? 'bg-current opacity-60 ' + colors.label : 'bg-gray-200'}`}
+                />
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}
+
+export default OnboardingStepper;

--- a/frontend/src/features/auth/components/__tests__/OnboardingStepper.test.tsx
+++ b/frontend/src/features/auth/components/__tests__/OnboardingStepper.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { OnboardingStepper } from '../OnboardingStepper';
+
+describe('OnboardingStepper', () => {
+  it('renders all three step labels', () => {
+    render(<OnboardingStepper current={1} />);
+    expect(screen.getByText('Create account')).toBeInTheDocument();
+    expect(screen.getByText('Verify email')).toBeInTheDocument();
+    expect(screen.getByText('Complete profile')).toBeInTheDocument();
+  });
+
+  it('marks the current step with aria-current="step"', () => {
+    render(<OnboardingStepper current={2} />);
+    const current = document.querySelector('[aria-current="step"]');
+    expect(current).not.toBeNull();
+    expect(current?.textContent).toContain('Verify email');
+  });
+
+  it('renders a check (not the number) for completed steps', () => {
+    render(<OnboardingStepper current={3} />);
+    // Steps 1 and 2 are done → their numerals should not be rendered as text.
+    expect(screen.queryByText('1')).not.toBeInTheDocument();
+    expect(screen.queryByText('2')).not.toBeInTheDocument();
+    // Current step 3 still shows its numeral.
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('exposes an accessible progress landmark', () => {
+    render(<OnboardingStepper current={1} />);
+    expect(screen.getByRole('navigation', { name: 'Sign-up progress' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -5,6 +5,7 @@ import { UserPlus, Mail, User, Briefcase, AlertCircle, CheckCircle } from 'lucid
 import PasswordInput from '../components/PasswordInput';
 import Turnstile, { TURNSTILE_ENABLED } from '../components/Turnstile';
 import { setPendingReturnTo, isSafeReturnPath } from '@/utils/postLoginRedirect';
+import { OnboardingStepper } from '@/features/auth/components/OnboardingStepper';
 
 
 export default function Register() {
@@ -94,6 +95,7 @@ export default function Register() {
       </div>
 
       <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+        <OnboardingStepper current={1} className="mb-6" />
         <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
           {registrationComplete ? (
             <div className="text-center">

--- a/frontend/src/pages/VerifyEmail.tsx
+++ b/frontend/src/pages/VerifyEmail.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Link, useSearchParams, useNavigate } from 'react-router-dom';
 import { CheckCircle, AlertCircle, Mail, RefreshCw } from 'lucide-react';
 import { authAPI } from '../lib/api';
+import { OnboardingStepper } from '@/features/auth/components/OnboardingStepper';
 
 export default function VerifyEmail() {
   const [searchParams] = useSearchParams();
@@ -66,35 +67,34 @@ export default function VerifyEmail() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <Link to="/" className="flex justify-center">
-          <h1 className="text-4xl font-bold bg-gradient-to-r from-purple-400 to-blue-400 bg-clip-text text-transparent">
-            Pitchey
-          </h1>
+          <img src="/pitchey-logotype.png" alt="Pitchey" className="h-12 w-auto" />
         </Link>
-        <h2 className="mt-6 text-center text-3xl font-extrabold text-white">
+        <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
           Email Verification
         </h2>
       </div>
 
       <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-        <div className="bg-gray-800 py-8 px-4 shadow-xl sm:rounded-lg sm:px-10 border border-gray-700">
+        <OnboardingStepper current={2} className="mb-6" />
+        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
           {verifying ? (
             <div className="text-center">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-400 mx-auto"></div>
-              <p className="mt-4 text-gray-400">Verifying your email address...</p>
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600 mx-auto"></div>
+              <p className="mt-4 text-gray-600">Verifying your email address...</p>
             </div>
           ) : verified ? (
             <div className="text-center">
-              <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-green-900/50 mb-4">
-                <CheckCircle className="h-6 w-6 text-green-400" />
+              <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-green-100 mb-4">
+                <CheckCircle className="h-6 w-6 text-green-600" />
               </div>
-              <h3 className="text-lg font-medium text-white mb-2">
+              <h3 className="text-lg font-medium text-gray-900 mb-2">
                 Email verified successfully!
               </h3>
-              <p className="text-sm text-gray-400 mb-6">
-                Your email has been verified. You can now access all features of your account.
+              <p className="text-sm text-gray-600 mb-6">
+                Next: log in and finish your profile — that's the last step before your dashboard.
               </p>
               <p className="text-xs text-gray-500 mb-6">
                 Redirecting to login page...
@@ -103,24 +103,24 @@ export default function VerifyEmail() {
                 to="/login"
                 className="inline-block w-full py-2 px-4 border border-transparent rounded-lg text-sm font-medium text-white bg-purple-600 hover:bg-purple-700"
               >
-                Go to login
+                Continue to login
               </Link>
             </div>
           ) : error ? (
             <div className="text-center">
-              <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-900/50 mb-4">
-                <AlertCircle className="h-6 w-6 text-red-400" />
+              <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100 mb-4">
+                <AlertCircle className="h-6 w-6 text-red-600" />
               </div>
-              <h3 className="text-lg font-medium text-white mb-2">
+              <h3 className="text-lg font-medium text-gray-900 mb-2">
                 Verification failed
               </h3>
-              <p className="text-sm text-gray-400 mb-6">
+              <p className="text-sm text-gray-600 mb-6">
                 {error}
               </p>
-              
+
               {resent ? (
-                <div className="bg-green-900/30 border border-green-700 rounded-lg p-4 mb-4">
-                  <p className="text-sm text-green-400">
+                <div className="bg-green-50 border border-green-200 rounded-lg p-4 mb-4">
+                  <p className="text-sm text-green-700">
                     A new verification email has been sent. Please check your inbox.
                   </p>
                 </div>
@@ -128,10 +128,10 @@ export default function VerifyEmail() {
                 <button
                   onClick={resendVerification}
                   disabled={resending}
-                  className="w-full flex justify-center items-center py-2 px-4 border border-gray-600 rounded-lg text-sm font-medium text-gray-300 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed mb-4"
+                  className="w-full flex justify-center items-center py-2 px-4 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed mb-4"
                 >
                   {resending ? (
-                    <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
+                    <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-purple-600"></div>
                   ) : (
                     <>
                       <RefreshCw className="h-4 w-4 mr-2" />
@@ -140,7 +140,7 @@ export default function VerifyEmail() {
                   )}
                 </button>
               )}
-              
+
               <Link
                 to="/login"
                 className="block w-full py-2 px-4 border border-transparent rounded-lg text-sm font-medium text-white bg-purple-600 hover:bg-purple-700"
@@ -150,23 +150,23 @@ export default function VerifyEmail() {
             </div>
           ) : (
             <div className="text-center">
-              <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-purple-900/50 mb-4">
-                <Mail className="h-6 w-6 text-purple-400" />
+              <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-purple-100 mb-4">
+                <Mail className="h-6 w-6 text-purple-600" />
               </div>
-              <h3 className="text-lg font-medium text-white mb-2">
+              <h3 className="text-lg font-medium text-gray-900 mb-2">
                 Verify your email
               </h3>
-              <p className="text-sm text-gray-400 mb-6">
+              <p className="text-sm text-gray-600 mb-6">
                 We sent a verification email to your registered email address.
                 Please check your inbox and click the verification link.
               </p>
               <p className="text-xs text-gray-500 mb-6">
                 The link will expire in 24 hours. If you don't see the email, check your spam folder.
               </p>
-              
+
               {resent ? (
-                <div className="bg-green-900/30 border border-green-700 rounded-lg p-4 mb-4">
-                  <p className="text-sm text-green-400">
+                <div className="bg-green-50 border border-green-200 rounded-lg p-4 mb-4">
+                  <p className="text-sm text-green-700">
                     A new verification email has been sent. Please check your inbox.
                   </p>
                 </div>
@@ -174,10 +174,10 @@ export default function VerifyEmail() {
                 <button
                   onClick={resendVerification}
                   disabled={resending}
-                  className="w-full flex justify-center items-center py-2 px-4 border border-gray-600 rounded-lg text-sm font-medium text-gray-300 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed mb-4"
+                  className="w-full flex justify-center items-center py-2 px-4 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed mb-4"
                 >
                   {resending ? (
-                    <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
+                    <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-purple-600"></div>
                   ) : (
                     <>
                       <RefreshCw className="h-4 w-4 mr-2" />
@@ -186,7 +186,7 @@ export default function VerifyEmail() {
                   )}
                 </button>
               )}
-              
+
               <Link
                 to="/login"
                 className="block w-full py-2 px-4 border border-transparent rounded-lg text-sm font-medium text-white bg-purple-600 hover:bg-purple-700"
@@ -196,13 +196,13 @@ export default function VerifyEmail() {
             </div>
           )}
         </div>
-        
+
         <div className="mt-6 text-center">
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-500">
             Having trouble?{' '}
             <a
               href="mailto:support@pitchey.com"
-              className="font-medium text-purple-400 hover:text-purple-300"
+              className="font-medium text-purple-600 hover:text-purple-700"
             >
               Contact support
             </a>

--- a/frontend/src/pages/__tests__/VerifyEmail.test.tsx
+++ b/frontend/src/pages/__tests__/VerifyEmail.test.tsx
@@ -68,7 +68,7 @@ describe('VerifyEmail', () => {
       await waitFor(() => {
         expect(screen.getByText('Email verified successfully!')).toBeInTheDocument()
       })
-      expect(screen.getByText(/Your email has been verified/)).toBeInTheDocument()
+      expect(screen.getByText(/finish your profile/)).toBeInTheDocument()
       expect(screen.getByText('Redirecting to login page...')).toBeInTheDocument()
     })
 
@@ -81,7 +81,7 @@ describe('VerifyEmail', () => {
       })
     })
 
-    it('renders Go to login link after success', async () => {
+    it('renders Continue to login link after success', async () => {
       mockVerifyEmail.mockResolvedValue(undefined)
       renderComponent()
 
@@ -89,7 +89,7 @@ describe('VerifyEmail', () => {
         expect(screen.getByText('Email verified successfully!')).toBeInTheDocument()
       }, { timeout: 5000 })
 
-      const goToLogin = screen.getByRole('link', { name: 'Go to login' })
+      const goToLogin = screen.getByRole('link', { name: 'Continue to login' })
       expect(goToLogin).toBeInTheDocument()
       expect(goToLogin).toHaveAttribute('href', '/login')
     })
@@ -216,7 +216,7 @@ describe('VerifyEmail', () => {
     it('renders the Pitchey brand', () => {
       mockVerifyEmail.mockReturnValue(new Promise(() => {}))
       renderComponent()
-      expect(screen.getByText('Pitchey')).toBeInTheDocument()
+      expect(screen.getByAltText('Pitchey')).toBeInTheDocument()
     })
 
     it('renders the Email Verification heading', () => {

--- a/frontend/src/portals/creator/pages/CreatorOnboardingPage.tsx
+++ b/frontend/src/portals/creator/pages/CreatorOnboardingPage.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { useBetterAuthStore } from '@/store/betterAuthStore';
 import { UserService } from '@/services/user.service';
 import { getPortalPath } from '@/utils/navigation';
+import { OnboardingStepper } from '@/features/auth/components/OnboardingStepper';
 
 const MAX_BIO_LENGTH = 500;
 
@@ -133,13 +134,22 @@ export default function OnboardingPage() {
   return (
     <div className={`min-h-screen bg-gradient-to-br ${cfg.gradient} flex items-center justify-center px-4 py-12`}>
       <div className="w-full max-w-lg">
-        {/* Branding */}
+        {/* Branding — logo links home so the screen isn't a dead-end */}
         <div className="text-center mb-8">
-          <img src="/pitchey-logotype.png" alt="Pitchey" className="h-10 w-auto mx-auto" />
-          <p className="mt-2 text-gray-600">{cfg.subtitle}</p>
+          <Link to="/" className="inline-block">
+            <img src="/pitchey-logotype.png" alt="Pitchey" className="h-10 w-auto mx-auto" />
+          </Link>
+          <p className={`mt-3 text-sm font-medium ${colors.title}`}>Last step — you're almost in</p>
+          <p className="mt-1 text-gray-600">{cfg.subtitle}</p>
         </div>
 
+        {/* Journey progress — this is step 3 of 3, not a trap */}
+        <OnboardingStepper current={3} accent={cfg.accent} className="mb-8" />
+
         <form onSubmit={(e) => { void handleSubmit(e); }} className="bg-white rounded-2xl shadow-lg p-8 space-y-6">
+          <p className="text-sm text-gray-500 -mt-1">
+            Your name and bio appear on your pitches and profile so others know who they're dealing with.
+          </p>
           {/* Profile Photo */}
           <div className="flex flex-col items-center">
             <button
@@ -259,6 +269,13 @@ export default function OnboardingPage() {
             </button>
           </p>
         </form>
+
+        <p className="text-center text-sm text-gray-500 mt-6">
+          Need help?{' '}
+          <a href="mailto:support@pitchey.com" className={`${colors.title} hover:underline font-medium`}>
+            Contact support
+          </a>
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
Karl reported poor navigation in the signup/onboarding flow. This adds a shared 3-step progress stepper (Create account → Verify email → Complete profile) across Register, VerifyEmail, and the creator onboarding page, and de-traps the mandatory onboarding screen (logo links home, escape valve, support link).

- New `frontend/src/features/auth/components/OnboardingStepper.tsx` + test
- VerifyEmail re-skinned dark→light to match; forward-pointing success copy
- Onboarding gate left **mandatory** — ProfileGuard/isProfileComplete untouched (no bypass)
- Frontend-only; no migration, no backend change
- 64/64 tests pass, tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)