### PR TITLE
fix(account): make Delete Account work (anonymize + correct wiring)

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -197,19 +197,27 @@ export default function Settings() {
 
   const handleDeleteAccount = async () => {
     try {
-    const response = await fetch(`${API_URL}/api/user/settings`, {
-      method: 'DELETE',
-      credentials: 'include' // Send cookies for Better Auth session
-    });
-      
+      // Live delete endpoint is DELETE /api/user/account and requires the
+      // explicit confirmation token (the previous /api/user/settings DELETE had
+      // no route registered, so the button silently no-op'd).
+      const response = await fetch(`${API_URL}/api/user/account`, {
+        method: 'DELETE',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ confirmation: 'DELETE_MY_ACCOUNT' }),
+      });
+
       if (response.ok) {
+        toast.success('Your account has been deleted.');
         logout();
         navigate('/');
       } else {
-        console.error('Failed to delete account');
+        const data = await response.json().catch(() => ({} as { error?: string }));
+        toast.error(data?.error || 'Failed to delete account. Please try again.');
       }
     } catch (error) {
       console.error('Failed to delete account:', error);
+      toast.error('Failed to delete account. Please try again.');
     }
   };
 

--- a/src/db/queries/settings.ts
+++ b/src/db/queries/settings.ts
@@ -363,20 +363,59 @@ export async function disableTwoFactor(sql: Sql, userId: string): Promise<boolea
 }
 
 /**
- * Delete user account and all related data
+ * Delete a user account via anonymization (soft-delete).
+ *
+ * NOT a hard DELETE:
+ *  - GDPR right-to-erasure is satisfied by scrubbing PII.
+ *  - Financial/legal records (transactions, deals, signed NDAs, generated
+ *    documents) must be retained — and the FK graph blocks a hard delete
+ *    anyway: pitches/ndas/user_roles/etc. reference users with NO ACTION /
+ *    RESTRICT, so `DELETE FROM users` throws a FK violation for any real user.
+ *  - email/username are UNIQUE, so we scrub them to per-id sentinels (this also
+ *    frees the original email for re-registration).
+ * Returns false if the user was already deleted (idempotent).
  */
 export async function deleteUserAccount(sql: Sql, userId: string): Promise<boolean> {
   try {
-    // The CASCADE will handle deleting related data
     const result = await sql`
-      DELETE FROM users
-      WHERE id = ${userId}
+      UPDATE users SET
+        deleted_at        = NOW(),
+        is_active         = false,
+        email             = 'deleted_' || id || '@deleted.invalid',
+        username          = 'deleted_' || id,
+        password          = 'DELETED_ACCOUNT',
+        password_hash     = NULL,
+        first_name        = NULL,
+        last_name         = NULL,
+        -- `name` is a generated column (COALESCE(username, email)); it
+        -- auto-recomputes to the scrubbed username, so we must NOT set it here.
+        bio               = NULL,
+        phone             = NULL,
+        location          = NULL,
+        company_name      = NULL,
+        company_website   = NULL,
+        company_address   = NULL,
+        profile_image     = NULL,
+        profile_image_url = NULL,
+        avatar_url        = NULL,
+        image             = NULL,
+        two_factor_secret = NULL,
+        backup_codes      = NULL,
+        stripe_customer_id = NULL,
+        preferences       = NULL,
+        metadata          = NULL,
+        updated_at        = NOW()
+      WHERE id = ${userId} AND deleted_at IS NULL
       RETURNING id
     `;
-    
-    return result.length > 0;
+
+    if (result.length === 0) return false;
+
+    // Invalidate every session so the cookie is dead and they're logged out.
+    await sql`DELETE FROM sessions WHERE user_id = ${userId}`;
+    return true;
   } catch (error) {
-    console.error('Error deleting user account:', error);
+    console.error('Error anonymizing user account:', error);
     throw error;
   }
 }

--- a/src/db/queries/settings.ts
+++ b/src/db/queries/settings.ts
@@ -387,8 +387,10 @@ export async function deleteUserAccount(sql: Sql, userId: string): Promise<boole
         password_hash     = NULL,
         first_name        = NULL,
         last_name         = NULL,
-        -- `name` is a generated column (COALESCE(username, email)); it
-        -- auto-recomputes to the scrubbed username, so we must NOT set it here.
+        -- NOTE: do not set the "name" column here. It is a generated column
+        -- (COALESCE of username, email) and auto-recomputes to the scrubbed
+        -- username. Setting it errors; backticks are avoided in this comment
+        -- because the query is a tagged template literal.
         bio               = NULL,
         phone             = NULL,
         location          = NULL,

--- a/src/handlers/settings.ts
+++ b/src/handlers/settings.ts
@@ -399,6 +399,16 @@ export async function deleteAccountHandler(request: Request, env: Env): Promise<
 
     const db = neon(env.DATABASE_URL);
 
+    // Demo accounts are shared public credentials (and referenced by the admin
+    // allowlist + demo flows) — refuse to anonymize them.
+    const demoRows = await db`SELECT is_demo_account FROM users WHERE id = ${authResult.user.id}` as Array<{ is_demo_account: boolean | null }>;
+    if (demoRows[0]?.is_demo_account) {
+      return new Response(JSON.stringify({ error: 'Demo accounts cannot be deleted' }), {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
     // Log the action before deletion
     await logAccountAction(db as any, {
       userId: authResult.user.id.toString(),

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -1426,7 +1426,7 @@ class RouteRegistry {
         SELECT id, email, username, name, user_type, first_name, last_name,
                bio, company_name, profile_image
         FROM users
-        WHERE email = $1 AND user_type = $2
+        WHERE email = $1 AND user_type = $2 AND deleted_at IS NULL
         LIMIT 1
       `;
 


### PR DESCRIPTION
**Karl: "delete an account doesn't work."** Two layers of breakage:

1. **Frontend wired to a dead endpoint** — the Settings "Delete Account" button called `DELETE /api/user/settings` (only `GET`/`PUT` registered) with no confirmation → 404 → silent `console.error`. Nothing happened, no error shown.
2. **Backend hard-delete is impossible** — `deleteUserAccount` did `DELETE FROM users` relying on cascade, but ~24 `NO ACTION` + 3 `RESTRICT` FKs (plus duplicate-FK drift on `pitches`/`ndas`) block it for any real user → 500.

**Fix (anonymize / soft-delete — chosen for GDPR + record retention):**
- `deleteUserAccount` → `UPDATE users` scrubbing PII, setting `deleted_at` + `is_active=false`, scrubbing `email`/`username` to per-id sentinels (frees the email for re-registration), then `DELETE FROM sessions`. Keeps financial/legal records (transactions, deals, signed NDAs, generated docs). `name` left alone (generated column).
- `deleteAccountHandler` refuses demo accounts (shared public creds).
- Login lookup gains `AND deleted_at IS NULL` so deleted accounts can't log back in.
- `Settings.tsx` calls `DELETE /api/user/account` with the `DELETE_MY_ACCOUNT` token and surfaces success/failure via toast.

**Verified** against the real prod schema via a rollback transaction (prod untouched): anonymize succeeds where the hard-delete 500'd, pitches retained, post-delete login lookup → 0 hits. Worker builds; frontend typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)