### PR TITLE
feat(calls): notify matching creators when an Open Call is posted

### DIFF
--- a/src/handlers/calls.ts
+++ b/src/handlers/calls.ts
@@ -228,6 +228,42 @@ export async function createCallHandler(request: Request, env: Env): Promise<Res
         ${region}, ${slots}, ${deadline}
       ) RETURNING id
     `;
+
+    // Demand → supply signal: notify creators whose PUBLISHED pitches match the
+    // call's genres/formats. Targeted (not spam-all): a criteria-less call (no
+    // genres/formats) matches no one. Tolerant case-insensitive substring match
+    // because genre/format values are inconsistent ("Sci-Fi" vs "Science Fiction
+    // (Sci-Fi)"). Fire-and-forget — a notify failure must never fail the call.
+    try {
+      const seeking = [seekingGenres, seekingFormats].filter(Boolean).join(', ');
+      if (seekingGenres || seekingFormats) {
+        const msg = `A ${userType} posted "${title.slice(0, 80)}" seeking ${seeking}. Tap to submit a matching pitch.`;
+        await sql`
+          INSERT INTO notifications (user_id, type, title, message, related_user_id, action_url, is_read, created_at)
+          SELECT m.uid, 'open_call', 'New open call matching your work', ${msg}, ${userId}, '/opportunities', false, NOW()
+          FROM (
+            SELECT DISTINCT p.user_id AS uid
+            FROM pitches p
+            JOIN users u ON u.id = p.user_id
+            WHERE p.status = 'published'
+              AND u.user_type = 'creator'
+              AND u.deleted_at IS NULL
+              AND p.user_id <> ${userId}
+              AND (
+                (${seekingGenres}::text IS NOT NULL AND p.genre IS NOT NULL
+                   AND position(lower(p.genre) IN lower(${seekingGenres}::text)) > 0)
+                OR
+                (${seekingFormats}::text IS NOT NULL AND p.format IS NOT NULL
+                   AND position(lower(p.format) IN lower(${seekingFormats}::text)) > 0)
+              )
+            LIMIT 500
+          ) m
+        `;
+      }
+    } catch (err) {
+      console.error('createCallHandler notify error:', err instanceof Error ? err.message : String(err));
+    }
+
     return jsonResponse({ id: row?.id, created: true }, origin, 201);
   } catch (err) {
     console.error('createCallHandler error:', err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
**Closes the "zero-notify on open call" gap.** Posting an Open Call inserted the row but notified no one, so demand never reached the supply side (submissions + accept/reject already notify; posting didn't). This is the load-bearing prerequisite for turning saved-search/demand intent into a real demand→supply loop.

`createCallHandler` now fires one targeted, fire-and-forget `INSERT…SELECT` notifying creators whose **published** pitches match the call's genres/formats:
- Criteria-less call → notifies no one (no spam-all).
- Tolerant case-insensitive substring match (genre values are inconsistent: `Sci-Fi` vs `Science Fiction (Sci-Fi)`).
- Excludes poster, non-creators, deleted users; capped at 500; `try/catch` so a notify failure never fails call creation.

Validated against the real prod schema via rollback transaction (notified a real matching creator; criteria-less → 0 inserts). `build:worker` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)