### PR TITLE
feat(search): bridge saved search → Open Call (demand→supply)

### DIFF
--- a/frontend/src/features/browse/components/Search/SavedSearches.tsx
+++ b/frontend/src/features/browse/components/Search/SavedSearches.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { Search, Play, Edit, Bell, Clock, Plus, Trash2, Users, TrendingUp } from 'lucide-react';
+import { Search, Play, Edit, Bell, Clock, Plus, Trash2, Users, TrendingUp, Megaphone } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useBetterAuthStore } from '@/store/betterAuthStore';
 
 interface SearchFilters {
   genres?: string[];
@@ -40,6 +42,28 @@ export const SavedSearches: React.FC<SavedSearchesProps> = ({
   const [activeTab, setActiveTab] = useState<'mine' | 'popular'>('mine');
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [_editingSearch, setEditingSearch] = useState<SavedSearch | null>(null);
+
+  const navigate = useNavigate();
+  const { user } = useBetterAuthStore();
+  // A saved search is private demand intent; only investors/production can turn
+  // it into a public Open Call (the demand→supply bridge). The Open Call create
+  // form opens pre-filled so demand is reviewed before it publishes + notifies
+  // matching creators.
+  const canPostCalls = user?.userType === 'investor' || user?.userType === 'production';
+
+  const postAsOpenCall = (search: SavedSearch) => {
+    const f = (search.filters || {}) as SearchFilters;
+    const genres = Array.isArray(f.genres) ? f.genres : [];
+    const fmt = Array.isArray(f.format)
+      ? (f.format as unknown as string[])
+      : (typeof f.format === 'string' && f.format ? [f.format] : []);
+    const params = new URLSearchParams({ post: '1' });
+    if (search.name) params.set('title', search.name);
+    if (search.search_query) params.set('mandate', search.search_query);
+    if (genres.length) params.set('genres', genres.join(','));
+    if (fmt.length) params.set('formats', fmt.join(','));
+    navigate(`/opportunities?${params.toString()}`);
+  };
 
   useEffect(() => {
     void loadSavedSearches();
@@ -290,6 +314,16 @@ export const SavedSearches: React.FC<SavedSearchesProps> = ({
               >
                 <Edit className="h-4 w-4" />
               </button>
+
+              {canPostCalls && (
+                <button
+                  onClick={() => postAsOpenCall(search)}
+                  className="p-2 text-purple-600 hover:bg-purple-50 rounded"
+                  title="Post as Open Call — notify matching creators"
+                >
+                  <Megaphone className="h-4 w-4" />
+                </button>
+              )}
 
               <button
                 onClick={() => { void deleteSearch(search.id); }}

--- a/frontend/src/pages/OpportunitiesBoard.tsx
+++ b/frontend/src/pages/OpportunitiesBoard.tsx
@@ -247,18 +247,20 @@ function ChipGroup({ label, options, selected, onToggle }: { label: string; opti
   );
 }
 
-function PostCallModal({ editing, onClose, onSaved }: { editing: OpenCall | null; onClose: () => void; onSaved: () => void }) {
+function PostCallModal({ editing, prefill, onClose, onSaved }: { editing: OpenCall | null; prefill?: Partial<OpenCall> | null; onClose: () => void; onSaved: () => void }) {
   const toast = useToast();
   const allGenres = useMemo(() => [...getGenresSync()], []);
   const allFormats = useMemo(() => [...getFormatsSync()], []);
   const [saving, setSaving] = useState(false);
-  const [title, setTitle] = useState(editing?.title ?? '');
-  const [mandate, setMandate] = useState(editing?.mandate ?? '');
-  const [genres, setGenres] = useState<string[]>(splitList(editing?.seeking_genres ?? null));
-  const [formats, setFormats] = useState<string[]>(splitList(editing?.seeking_formats ?? null));
-  const [budgetMin, setBudgetMin] = useState(editing?.budget_min_usd != null ? String(editing.budget_min_usd) : '');
-  const [budgetMax, setBudgetMax] = useState(editing?.budget_max_usd != null ? String(editing.budget_max_usd) : '');
-  const [region, setRegion] = useState(editing?.region ?? '');
+  // `prefill` seeds a NEW call (from the saved-search bridge) without flipping to
+  // edit mode — submit still branches on `editing` only, so prefill → create.
+  const [title, setTitle] = useState(editing?.title ?? prefill?.title ?? '');
+  const [mandate, setMandate] = useState(editing?.mandate ?? prefill?.mandate ?? '');
+  const [genres, setGenres] = useState<string[]>(splitList(editing?.seeking_genres ?? prefill?.seeking_genres ?? null));
+  const [formats, setFormats] = useState<string[]>(splitList(editing?.seeking_formats ?? prefill?.seeking_formats ?? null));
+  const [budgetMin, setBudgetMin] = useState(editing?.budget_min_usd != null ? String(editing.budget_min_usd) : (prefill?.budget_min_usd != null ? String(prefill.budget_min_usd) : ''));
+  const [budgetMax, setBudgetMax] = useState(editing?.budget_max_usd != null ? String(editing.budget_max_usd) : (prefill?.budget_max_usd != null ? String(prefill.budget_max_usd) : ''));
+  const [region, setRegion] = useState(editing?.region ?? prefill?.region ?? '');
   const [slots, setSlots] = useState(editing?.slots != null ? String(editing.slots) : '');
   const [deadline, setDeadline] = useState(editing?.deadline ?? '');
 
@@ -564,10 +566,38 @@ export default function OpportunitiesBoard() {
   }, [isInsidePortal, inPortalPath, location.search, navigate]);
 
   const [calls, setCalls] = useState<OpenCall[]>([]);
+
+  // Saved-search → Open Call bridge: /opportunities?post=1&title=&mandate=&genres=&formats=
+  // opens the create form pre-filled so demand is reviewed before it publishes +
+  // notifies matching creators. We wait for the in-portal redirect to land first,
+  // then consume the params (and strip them so a refresh doesn't reopen the modal).
+  useEffect(() => {
+    if (!isInsidePortal && inPortalPath) return; // let the redirect above land first
+    const params = new URLSearchParams(location.search);
+    if (params.get('post') !== '1') return;
+    if (canPost) {
+      const csv = (k: string) => {
+        const v = params.get(k);
+        return v ? v.split(',').map((s) => s.trim()).filter(Boolean).join(', ') : undefined;
+      };
+      setPrefill({
+        title: params.get('title') ?? undefined,
+        mandate: params.get('mandate') ?? undefined,
+        seeking_genres: csv('genres'),
+        seeking_formats: csv('formats'),
+      } as Partial<OpenCall>);
+      setEditing(null);
+      setShowPost(true);
+    }
+    // strip the consumed params either way (canPost or not)
+    navigate(location.pathname, { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isInsidePortal, inPortalPath, location.search, canPost]);
   const [loading, setLoading] = useState(true);
   const [typeFilter, setTypeFilter] = useState('all');
   const [showPost, setShowPost] = useState(false);
   const [editing, setEditing] = useState<OpenCall | null>(null);
+  const [prefill, setPrefill] = useState<Partial<OpenCall> | null>(null);
   const [viewing, setViewing] = useState<OpenCall | null>(null);
   const [submitting, setSubmitting] = useState<OpenCall | null>(null);
   const [submissionsFor, setSubmissionsFor] = useState<OpenCall | null>(null);
@@ -716,8 +746,9 @@ export default function OpportunitiesBoard() {
       {showPost && (
         <PostCallModal
           editing={editing}
-          onClose={() => { setShowPost(false); setEditing(null); }}
-          onSaved={() => { setShowPost(false); setEditing(null); load(); }}
+          prefill={editing ? null : prefill}
+          onClose={() => { setShowPost(false); setEditing(null); setPrefill(null); }}
+          onSaved={() => { setShowPost(false); setEditing(null); setPrefill(null); load(); }}
         />
       )}
       {viewing && (


### PR DESCRIPTION
Step 2 of evolving saved searches into the demand→supply loop (step 1 was #318, open-call→creator notifications).

A saved search is **private demand intent**. This lets investors/production convert one into a **public Open Call** — which now notifies matching creators — via a "Post as Open Call" action that opens the create form **pre-filled** (title, mandate, genres, formats). Demand is reviewed before it publishes + notifies; not a silent one-click.

- **SavedSearches**: gated button (investor/production only) → `/opportunities?post=1&…`
- **OpportunitiesBoard**: consumes the params after the in-portal redirect lands, opens the form pre-filled, strips the params (refresh-safe)
- **PostCallModal**: new `prefill` prop seeds a *new* call without flipping to edit mode

Best-effort genre prefill (saved-search genres vs the form's canonical chips may diverge); title/mandate always carry intent. Frontend-only, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)