### PR TITLE
feat(provenance): Sealed on [date] content-hash provenance for pitches

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -114,6 +114,7 @@ const Marketplace = lazyRetry(() => import('./pages/MarketplaceEnhanced'));
 const OpportunitiesBoard = lazyRetry(() => import('./pages/OpportunitiesBoard'));
 const ComparePage = lazyRetry(() => import('./pages/ComparePage'));
 const SharedComparePage = lazyRetry(() => import('./pages/SharedComparePage'));
+const ProvenanceVerify = lazyRetry(() => import('./pages/ProvenanceVerify'));
 const PublicPitchView = lazyRetry(() => import('./pages/PublicPitchView'));
 
 // Creator Pages
@@ -416,6 +417,7 @@ function App() {
           <Route path="/opportunities" element={<OpportunitiesBoard />} />
           <Route path="/compare" element={<ComparePage />} />
           <Route path="/compare/s/:token" element={<SharedComparePage />} />
+          <Route path="/verify/p/:hash" element={<ProvenanceVerify />} />
           <Route path="/marketplace-old" element={<Marketplace />} />
           
           {/* Browse Route */}

--- a/frontend/src/components/SealBadge.tsx
+++ b/frontend/src/components/SealBadge.tsx
@@ -1,0 +1,32 @@
+import { ShieldCheck } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+interface Provenance {
+  sealed_at: string;
+  content_hash: string;
+}
+
+/**
+ * "Sealed [date]" provenance badge. Proves the pitch's content existed on Pitchey
+ * at a date (priority-of-idea) — protects the IDEA, distinct from the creator's
+ * verification tier (which is about the PERSON). Links to the public certificate.
+ * Renders nothing if the pitch was never sealed.
+ */
+export default function SealBadge({ provenance, className = '' }: { provenance?: Provenance | null; className?: string }) {
+  if (!provenance?.sealed_at || !provenance?.content_hash) return null;
+
+  const date = new Date(provenance.sealed_at).toLocaleDateString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric',
+  });
+
+  return (
+    <Link
+      to={`/verify/p/${provenance.content_hash}`}
+      title="This pitch's content was sealed with a tamper-evident timestamp. Click to verify."
+      className={`inline-flex items-center gap-1.5 rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-medium text-emerald-700 ring-1 ring-inset ring-emerald-200 transition hover:bg-emerald-100 ${className}`}
+    >
+      <ShieldCheck className="h-3.5 w-3.5" aria-hidden />
+      Sealed {date}
+    </Link>
+  );
+}

--- a/frontend/src/pages/PitchDetail.tsx
+++ b/frontend/src/pages/PitchDetail.tsx
@@ -20,6 +20,7 @@ import { formatCurrency } from '@shared/utils/formatters';
 import FeedbackSection from '../components/feedback/FeedbackSection';
 import { getHeatScore } from '../components/HeatBadge';
 import VerificationBadge from '../components/VerificationBadge';
+import SealBadge from '../components/SealBadge';
 import HumanMadeBadge from '../components/HumanMadeBadge';
 import { viewService } from '@features/analytics/services/view.service';
 import PortalTopNav from '@shared/components/layout/PortalTopNav';
@@ -458,6 +459,7 @@ export default function PitchDetail() {
                       {pitch.creator?.name || pitch.creator?.username || 'Unknown Creator'}
                     </span>
                     <VerificationBadge tier={(pitch as any).creator_verification_tier || (pitch.creator as any)?.verificationTier} />
+                    <SealBadge provenance={(pitch as any).provenance} />
                     {/* Follow lives in the unified InterestedCard below — no inline duplicate */}
                   </div>
                 ) : (

--- a/frontend/src/pages/ProvenanceVerify.tsx
+++ b/frontend/src/pages/ProvenanceVerify.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { ShieldCheck, ShieldX, Loader2 } from 'lucide-react';
+import { API_URL } from '../config';
+
+interface VerifyResult {
+  sealed: boolean;
+  sealed_at?: string;
+  content_version?: number;
+  creator_username?: string;
+  pitch_title?: string;
+  pitch_id?: number;
+}
+
+/**
+ * Public provenance certificate page (/verify/p/:hash). Anyone with the hash can
+ * confirm the pitch's content was sealed on Pitchey at a date — the artifact a
+ * creator shows to prove priority of idea. Shows date/creator/title only; never
+ * the protected content.
+ */
+export default function ProvenanceVerify() {
+  const { hash = '' } = useParams();
+  const [loading, setLoading] = useState(true);
+  const [result, setResult] = useState<VerifyResult | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    (async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(`${API_URL}/api/verify/p/${encodeURIComponent(hash)}`);
+        const data = (await res.json().catch(() => ({ sealed: false }))) as VerifyResult;
+        if (live) setResult(data);
+      } catch {
+        if (live) setResult({ sealed: false });
+      } finally {
+        if (live) setLoading(false);
+      }
+    })();
+    return () => { live = false; };
+  }, [hash]);
+
+  const sealedDate = result?.sealed_at
+    ? new Date(result.sealed_at).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })
+    : null;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-stone-50 via-white to-stone-50 flex items-center justify-center px-4 py-16">
+      <div className="w-full max-w-lg rounded-2xl bg-white shadow-sm ring-1 ring-gray-100 p-8">
+        {loading ? (
+          <div className="flex flex-col items-center gap-3 py-8 text-gray-500">
+            <Loader2 className="h-7 w-7 animate-spin" />
+            Verifying certificate…
+          </div>
+        ) : result?.sealed ? (
+          <div className="text-center">
+            <span className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-50 text-emerald-600 ring-1 ring-inset ring-emerald-100">
+              <ShieldCheck className="h-7 w-7" />
+            </span>
+            <h1 className="mt-4 text-xl font-bold text-gray-900">Provenance verified</h1>
+            <p className="mt-1 text-sm text-gray-500">
+              This content was sealed on Pitchey and has not changed since.
+            </p>
+
+            <dl className="mt-6 divide-y divide-gray-100 text-left text-sm">
+              <div className="flex justify-between py-2.5">
+                <dt className="text-gray-400">Pitch</dt>
+                <dd className="font-medium text-gray-900">
+                  {result.pitch_id
+                    ? <Link to={`/pitch/${result.pitch_id}`} className="text-indigo-600 hover:underline">{result.pitch_title}</Link>
+                    : result.pitch_title}
+                </dd>
+              </div>
+              <div className="flex justify-between py-2.5">
+                <dt className="text-gray-400">Creator</dt>
+                <dd className="font-medium text-gray-900">@{result.creator_username}</dd>
+              </div>
+              <div className="flex justify-between py-2.5">
+                <dt className="text-gray-400">Sealed on</dt>
+                <dd className="font-medium text-gray-900">{sealedDate}</dd>
+              </div>
+              {result.content_version && result.content_version > 1 && (
+                <div className="flex justify-between py-2.5">
+                  <dt className="text-gray-400">Version</dt>
+                  <dd className="font-medium text-gray-900">v{result.content_version}</dd>
+                </div>
+              )}
+              <div className="py-2.5">
+                <dt className="text-gray-400 mb-1">Content hash (SHA-256)</dt>
+                <dd className="font-mono text-[11px] break-all text-gray-600">{hash}</dd>
+              </div>
+            </dl>
+          </div>
+        ) : (
+          <div className="text-center">
+            <span className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-gray-100 text-gray-400 ring-1 ring-inset ring-gray-200">
+              <ShieldX className="h-7 w-7" />
+            </span>
+            <h1 className="mt-4 text-xl font-bold text-gray-900">No matching seal</h1>
+            <p className="mt-1 text-sm text-gray-500">
+              This hash doesn't match any sealed pitch on Pitchey. It may have been mistyped, or the content has changed since it was sealed.
+            </p>
+            <Link to="/" className="mt-6 inline-block text-sm font-medium text-indigo-600 hover:underline">Back to Pitchey</Link>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/db/migrations/109_pitch_provenance.sql
+++ b/src/db/migrations/109_pitch_provenance.sql
@@ -1,0 +1,37 @@
+-- 109_pitch_provenance.sql
+-- Content-hash provenance ("Sealed on [date]"): a tamper-evident timestamp proving
+-- a pitch's substantive content existed on Pitchey at a given date. This is the
+-- creator's priority-of-idea artifact — it protects the IDEA (not the person; that
+-- is the separate verification_tier track).
+--
+-- One row per (pitch, distinct content_hash). Re-publishing identical content is a
+-- no-op (unique gate); changed content adds a new version row, so history is kept.
+-- `prev_hash` chains each new seal to the creator's previous seal → tamper-evident
+-- (you can't backdate or insert a seal without breaking the chain). The verify
+-- endpoint exposes ONLY the hash + date + creator + title, never protected content.
+
+CREATE TABLE IF NOT EXISTS pitch_provenance (
+  id              SERIAL PRIMARY KEY,
+  pitch_id        INTEGER NOT NULL REFERENCES pitches(id) ON DELETE CASCADE,
+  creator_id      INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  content_hash    TEXT NOT NULL,                 -- SHA-256 hex of canonical content
+  algorithm       TEXT NOT NULL DEFAULT 'sha256',
+  content_version INTEGER NOT NULL DEFAULT 1,    -- 1-based, per pitch
+  prev_hash       TEXT,                          -- creator's previous seal hash (chain)
+  sealed_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- content_hash already encodes pitch_id + creator_id, so a single global unique
+-- index both (a) dedups identical re-seals (ON CONFLICT DO NOTHING) and (b) backs
+-- the public verify-by-hash lookup.
+CREATE UNIQUE INDEX IF NOT EXISTS pitch_provenance_hash_uniq
+  ON pitch_provenance (content_hash);
+
+-- "Sealed since" badge reads the earliest seal per pitch.
+CREATE INDEX IF NOT EXISTS pitch_provenance_pitch_sealed_idx
+  ON pitch_provenance (pitch_id, sealed_at);
+
+-- Per-creator chain walk.
+CREATE INDEX IF NOT EXISTS pitch_provenance_creator_sealed_idx
+  ON pitch_provenance (creator_id, sealed_at DESC);

--- a/src/services/pitch-provenance.ts
+++ b/src/services/pitch-provenance.ts
@@ -1,0 +1,131 @@
+// Content-hash provenance for pitches ("Sealed on [date]").
+//
+// Seals the SUBSTANTIVE content of a published pitch with a SHA-256 timestamp so a
+// creator can later prove the material existed on Pitchey before any disclosure.
+// This protects the IDEA — it is independent of `verification_tier`, which is about
+// trusting the PERSON. Uses the Workers global Web Crypto (`crypto.subtle`), NOT the
+// node `crypto` module (the worker build externalises that).
+
+// Loose type: callers pass the Neon tagged-template client (this.db.getSql()).
+type Sql = (strings: TemplateStringsArray, ...values: unknown[]) => Promise<any[]>;
+
+export async function sha256Hex(input: string): Promise<string> {
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(buf)).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// Deterministic, fixed-key-order serialization of the substantive content. Volatile
+// fields (view counts, timestamps, images) are excluded so the seal tracks the idea,
+// not cosmetic churn. pitch_id + creator_id are included so the hash is globally
+// unique (two different pitches can never collide).
+function canonical(p: Record<string, unknown>): string {
+  const norm = (v: unknown) =>
+    v === null || v === undefined ? ''
+    : typeof v === 'object' ? JSON.stringify(v)
+    : String(v);
+  return JSON.stringify({
+    pitch_id: Number(p.id),
+    creator_id: Number(p.user_id),
+    title: norm(p.title),
+    logline: norm(p.logline),
+    short_synopsis: norm(p.short_synopsis),
+    long_synopsis: norm(p.long_synopsis),
+    synopsis: norm(p.synopsis),
+    genre: norm(p.genre),
+    format: norm(p.format),
+    themes: norm(p.themes),
+    budget: norm(p.budget),
+  });
+}
+
+// Seal a pitch's current content. Idempotent (identical content never duplicates;
+// changed content adds a new version row). Only seals PUBLISHED pitches. NEVER
+// throws — provenance must never break publishing.
+export async function sealPitchProvenance(sql: Sql, pitchId: number | string): Promise<void> {
+  try {
+    const rows = await sql`
+      SELECT id, user_id, title, logline, short_synopsis, long_synopsis, synopsis,
+             genre, format, themes, budget, status
+      FROM pitches WHERE id = ${pitchId}
+    `;
+    const p = rows[0];
+    if (!p || p.status !== 'published') return;
+
+    const hash = await sha256Hex(canonical(p));
+
+    // prev_hash chains to the creator's most recent seal → tamper-evident.
+    const prevRows = await sql`
+      SELECT content_hash FROM pitch_provenance
+      WHERE creator_id = ${p.user_id} ORDER BY sealed_at DESC LIMIT 1
+    `;
+    const prevHash = (prevRows[0]?.content_hash as string | undefined) ?? null;
+
+    const verRows = await sql`
+      SELECT COUNT(*)::int AS n FROM pitch_provenance WHERE pitch_id = ${pitchId}
+    `;
+    const version = (Number(verRows[0]?.n) || 0) + 1;
+
+    await sql`
+      INSERT INTO pitch_provenance
+        (pitch_id, creator_id, content_hash, algorithm, content_version, prev_hash, sealed_at)
+      VALUES (${pitchId}, ${p.user_id}, ${hash}, 'sha256', ${version}, ${prevHash}, NOW())
+      ON CONFLICT (content_hash) DO NOTHING
+    `;
+  } catch (err) {
+    console.error('sealPitchProvenance error:', err instanceof Error ? err.message : String(err));
+  }
+}
+
+// Badge data for getPitch: earliest seal date (the priority-of-idea claim) + the
+// current content hash (for the verify link). Returns null if never sealed.
+export async function getPitchSeal(
+  sql: Sql, pitchId: number | string,
+): Promise<{ sealed_at: string; content_hash: string } | null> {
+  try {
+    const rows = await sql`
+      SELECT
+        (SELECT MIN(sealed_at) FROM pitch_provenance WHERE pitch_id = ${pitchId}) AS sealed_at,
+        (SELECT content_hash FROM pitch_provenance WHERE pitch_id = ${pitchId}
+           ORDER BY sealed_at DESC LIMIT 1) AS content_hash
+    `;
+    const r = rows[0];
+    if (!r || !r.sealed_at) return null;
+    return { sealed_at: r.sealed_at as string, content_hash: r.content_hash as string };
+  } catch {
+    return null;
+  }
+}
+
+// Public verify-by-hash. Returns ONLY non-sensitive fields — never the protected
+// synopsis/content. The hash + date + creator + title IS the certificate.
+export async function verifyProvenanceByHash(sql: Sql, hash: string): Promise<{
+  sealed: boolean; sealed_at?: string; content_version?: number;
+  creator_username?: string; pitch_title?: string; pitch_id?: number;
+}> {
+  try {
+    const clean = String(hash || '').trim().toLowerCase();
+    if (!/^[a-f0-9]{64}$/.test(clean)) return { sealed: false };
+    const rows = await sql`
+      SELECT pr.sealed_at, pr.content_version, pr.pitch_id,
+             u.username AS creator_username, p.title AS pitch_title
+      FROM pitch_provenance pr
+      JOIN pitches p ON p.id = pr.pitch_id
+      JOIN users u ON u.id = pr.creator_id
+      WHERE pr.content_hash = ${clean}
+      LIMIT 1
+    `;
+    const r = rows[0];
+    if (!r) return { sealed: false };
+    return {
+      sealed: true,
+      sealed_at: r.sealed_at as string,
+      content_version: Number(r.content_version),
+      creator_username: r.creator_username as string,
+      pitch_title: r.pitch_title as string,
+      pitch_id: Number(r.pitch_id),
+    };
+  } catch (err) {
+    console.error('verifyProvenanceByHash error:', err instanceof Error ? err.message : String(err));
+    return { sealed: false };
+  }
+}

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -2723,6 +2723,19 @@ class RouteRegistry {
     this.register('DELETE', '/api/pitches/:id/save', (req) => realPitchUnsaveHandler(req, this.env));
 
     // Pitch Publish/Archive endpoints (with cache invalidation)
+    // Public provenance certificate — proves a pitch's content was sealed on a
+    // date. No auth (it's a public proof); returns date+creator+title+version
+    // only, NEVER the protected content. 404 if the hash isn't a known seal.
+    this.register('GET', '/api/verify/p/:hash', async (req) => {
+      const hash = new URL(req.url).pathname.split('/').pop() || '';
+      const { verifyProvenanceByHash } = await import('./services/pitch-provenance');
+      const result = await verifyProvenanceByHash(this.db.getSql() as any, hash);
+      return new Response(JSON.stringify(result), {
+        status: result.sealed ? 200 : 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
     this.register('POST', '/api/pitches/:id/publish', async (req) => {
       // Publishing is the paywall: watchers (user_type='viewer') can create
       // drafts but must upgrade to a Creator account to publish. The VIEWER
@@ -2739,6 +2752,18 @@ class RouteRegistry {
       // Invalidate browse cache after publish so new pitch appears immediately
       if (response.status === 200) {
         try { await this.invalidateBrowseCache(); } catch (_) { /* non-blocking */ }
+
+        // Seal content provenance on publish — a hashed timestamp proving the
+        // idea existed on Pitchey at this date (the creator's priority-of-idea
+        // artifact). Fire-and-forget; sealPitchProvenance never throws.
+        try {
+          const sealBody = await response.clone().json() as { data?: { pitch?: { id: number } } };
+          const sealedPitchId = sealBody?.data?.pitch?.id;
+          if (sealedPitchId) {
+            const { sealPitchProvenance } = await import('./services/pitch-provenance');
+            await sealPitchProvenance(this.db.getSql() as any, sealedPitchId);
+          }
+        } catch (e) { console.error('provenance seal on publish failed:', e); }
 
         // Notify followers of newly published pitch
         try {
@@ -4223,6 +4248,7 @@ class RouteRegistry {
       // (Removing it here 401'd cover images for logged-out users — regression.)
       '/api/media/file',
       '/ws',            // WebSocket endpoint handles its own auth
+      '/api/verify/',   // Public provenance certificate (verify-by-hash; no content exposed)
       '/api/config',    // App configuration (genres, formats, etc.)
       '/api/browse/genres',     // Browse by genre
       '/api/browse/top-rated',  // Top rated pitches
@@ -6160,6 +6186,13 @@ pitchey_analytics_datapoints_per_minute 1250
             revenueModel: pitch.revenue_model
           };
         }
+
+        // Provenance seal (public, non-sensitive): drives the "Sealed [date]" badge.
+        // Protects the idea; independent of the creator's verification_tier.
+        try {
+          const { getPitchSeal } = await import('./services/pitch-provenance');
+          response.provenance = await getPitchSeal(this.db.getSql() as any, pitchId);
+        } catch (_) { /* non-critical */ }
 
         return builder.success(response);
       }


### PR DESCRIPTION
First of the two trust features. **Protects the idea** (priority-of-idea proof) — distinct from `verification_tier` (trusting the *person*).

On publish, a pitch's substantive content is hashed (SHA-256 over a canonical serialization) + timestamped. A creator can later prove the material existed on Pitchey before any disclosure via a public certificate.

- **migration 109** `pitch_provenance` — `content_hash` unique (dedup + verify lookup), `prev_hash` chain (tamper-evident), versioned on content change
- **seal hook** in `POST /api/pitches/:id/publish` — fire-and-forget, never breaks publish
- **public** `GET /api/verify/p/:hash` — returns date + creator + title + version only, **never the protected content**
- `getPitch` returns `provenance`; frontend `SealBadge` on PitchDetail + `/verify/p/:hash` certificate page

**No backfill** (SealBadge renders null when unsealed → clean, no broken empty state); existing pitches seal on next publish. Worker-based backfill = clean follow-up.

⚠️ **Migration 109 must be applied to prod before this deploys** (deploy preflight gate). Validated via rollback txn; `build:worker` + frontend `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)