### PR TITLE
fix(provenance): make /api/verify/p/:hash actually public (was 401)

### DIFF
--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -4248,7 +4248,7 @@ class RouteRegistry {
       // (Removing it here 401'd cover images for logged-out users — regression.)
       '/api/media/file',
       '/ws',            // WebSocket endpoint handles its own auth
-      '/api/verify/',   // Public provenance certificate (verify-by-hash; no content exposed)
+      '/api/verify',    // Public provenance certificate (verify-by-hash; no content exposed). NO trailing slash — matcher does startsWith(endpoint + '/').
       '/api/config',    // App configuration (genres, formats, etc.)
       '/api/browse/genres',     // Browse by genre
       '/api/browse/top-rated',  // Top rated pitches


### PR DESCRIPTION
Follow-up to #321. The `publicEndpoints` matcher is `path === e || path.startsWith(e + '/')`. I added the entry as `'/api/verify/'` (trailing slash) → it checked `startsWith('/api/verify//')` and never matched, so the public provenance certificate endpoint 401'd. Dropped the trailing slash. Verified live: endpoint currently returns 401; after this it returns 404 for an unknown hash (public + registered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)