### PR TITLE
feat(identity): creator identity verification via Stripe Identity (Silver tier)

### DIFF
--- a/frontend/src/features/auth/components/IdentityVerificationCard.tsx
+++ b/frontend/src/features/auth/components/IdentityVerificationCard.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from 'react';
+import { ShieldCheck, Loader2, BadgeCheck } from 'lucide-react';
+import { toast } from 'react-hot-toast';
+import { API_URL } from '@/config';
+
+type Status = 'none' | 'requires_input' | 'processing' | 'verified' | 'canceled';
+
+/**
+ * Creator identity verification (Stripe Identity). OPT-IN — never required to
+ * publish. Verifies the PERSON (real, named human) → unlocks the Silver tier;
+ * distinct from pitch provenance, which seals the IDEA. Uses retrieve-on-return:
+ * the backend reads the result on return, so no Stripe webhook is involved.
+ */
+export default function IdentityVerificationCard() {
+  const [loading, setLoading] = useState(true);
+  const [starting, setStarting] = useState(false);
+  const [verified, setVerified] = useState(false);
+  const [status, setStatus] = useState<Status>('none');
+
+  const refresh = async () => {
+    try {
+      const res = await fetch(`${API_URL}/api/identity/refresh`, { method: 'POST', credentials: 'include' });
+      const json = await res.json().catch(() => ({}));
+      const d = json?.data ?? json;
+      setVerified(!!d?.verified);
+      setStatus((d?.status as Status) ?? 'none');
+    } catch {
+      /* non-blocking */
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+    // Returning from the Stripe hosted flow: the session may still be 'processing'
+    // for a beat, so re-check shortly after.
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('identity') === 'return') {
+      const t = setTimeout(() => { void refresh(); }, 1800);
+      return () => clearTimeout(t);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const start = async () => {
+    setStarting(true);
+    try {
+      const res = await fetch(`${API_URL}/api/identity/start`, { method: 'POST', credentials: 'include' });
+      const json = await res.json().catch(() => ({}));
+      const url = (json?.data ?? json)?.url;
+      if (url) { window.location.href = url; return; }
+      toast.error('Could not start identity verification. Please try again.');
+    } catch {
+      toast.error('Could not start identity verification. Please try again.');
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  return (
+    <div className="rounded-xl bg-white p-6 shadow-sm ring-1 ring-gray-100">
+      <div className="mb-1 flex items-center gap-2.5">
+        <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 ring-1 ring-inset ring-indigo-100">
+          <BadgeCheck className="h-5 w-5" aria-hidden />
+        </span>
+        <h3 className="text-xl font-bold tracking-tight text-gray-900">Identity verification</h3>
+      </div>
+      <p className="mb-5 pl-[3.05rem] text-sm text-gray-500">
+        Confirm you're a real person to earn a verified badge. Optional — your pitches stay free to publish either way. We never store your ID; Stripe handles the check.
+      </p>
+
+      {loading ? (
+        <div className="flex items-center gap-2 pl-0.5 text-sm text-gray-400">
+          <Loader2 className="h-4 w-4 animate-spin" /> Checking status…
+        </div>
+      ) : verified ? (
+        <div className="inline-flex items-center gap-2 rounded-lg bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700 ring-1 ring-inset ring-emerald-200">
+          <ShieldCheck className="h-4 w-4" /> Identity verified
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {status === 'processing' && (
+            <p className="text-sm text-amber-600">Your verification is processing — check back shortly.</p>
+          )}
+          {(status === 'requires_input' || status === 'canceled') && (
+            <p className="text-sm text-gray-500">Your last attempt didn't complete. You can try again.</p>
+          )}
+          <button
+            type="button"
+            onClick={start}
+            disabled={starting}
+            className="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-600 to-violet-600 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-indigo-500/25 transition hover:from-indigo-500 hover:to-violet-500 disabled:opacity-60"
+          >
+            {starting && <Loader2 className="h-4 w-4 animate-spin" />}
+            {status === 'processing' || status === 'requires_input' || status === 'canceled' ? 'Try again' : 'Verify my identity'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/portals/creator/pages/CreatorSettingsProfile.tsx
+++ b/frontend/src/portals/creator/pages/CreatorSettingsProfile.tsx
@@ -12,6 +12,7 @@ import { sessionCache } from '@/store/sessionCache';
 import { UserService } from '@/services/user.service';
 import { API_URL } from '@/config';
 import { prepareImageForUpload, PRE_COMPRESSION_MAX_BYTES } from '@/utils/imageUpload';
+import IdentityVerificationCard from '@/features/auth/components/IdentityVerificationCard';
 
 // Creator-facing profile settings. A creator is an individual filmmaker, so this
 // leads with personal identity and a creative statement (the pitch investors and
@@ -361,6 +362,8 @@ export default function CreatorSettingsProfile() {
               </div>
             </CardContent>
           </Card>
+
+          <IdentityVerificationCard />
         </div>
       </div>
     </div>

--- a/src/db/migrations/110_creator_identity_verification.sql
+++ b/src/db/migrations/110_creator_identity_verification.sql
@@ -1,0 +1,18 @@
+-- 110_creator_identity_verification.sql
+-- Creator identity verification via Stripe Identity (anti-impersonation "real
+-- person" check). Verifies the PERSON — complements pitch_provenance, which seals
+-- the IDEA. On a 'verified' result the creator's verification_tier is promoted to
+-- 'silver' (we never downgrade a 'gold').
+--
+-- Result is read via retrieve-on-return (the stored session id), NOT a webhook —
+-- so this requires ZERO change to the live Stripe webhook config and cannot
+-- disturb subscription billing. Additive columns only.
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS identity_session_id   TEXT,       -- Stripe vs_… id of the latest session
+  ADD COLUMN IF NOT EXISTS identity_status       TEXT,       -- requires_input | processing | verified | canceled
+  ADD COLUMN IF NOT EXISTS identity_verified_at  TIMESTAMPTZ;
+
+-- Look up a user by their in-flight session on return.
+CREATE INDEX IF NOT EXISTS idx_users_identity_session
+  ON users (identity_session_id) WHERE identity_session_id IS NOT NULL;

--- a/src/services/stripe.service.ts
+++ b/src/services/stripe.service.ts
@@ -298,4 +298,34 @@ export class StripeService {
     }
     return mismatch === 0;
   }
+
+  // ── Identity (creator verification) ───────────────────────────────────────
+  // Deliberately ISOLATED from the subscription/checkout/webhook paths above.
+  // The verification result is read via retrieve-on-return (see the identity
+  // handlers), NOT a webhook — so adding this requires ZERO change to the live
+  // Stripe webhook config and cannot disturb billing.
+
+  // Creates a hosted document+selfie verification session. Returns the redirect
+  // URL the creator completes the flow at.
+  async createIdentityVerificationSession(params: {
+    userId: number;
+    returnUrl: string;
+  }): Promise<{ id: string; url: string; client_secret: string; status: string }> {
+    return this.request('POST', '/identity/verification_sessions', {
+      type: 'document',
+      'metadata[userId]': String(params.userId),
+      'metadata[purpose]': 'creator_identity',
+      return_url: params.returnUrl,
+    });
+  }
+
+  // Reads back a session's status on return: 'requires_input' | 'processing' |
+  // 'verified' | 'canceled'. metadata.userId lets the handler bind it to the user.
+  async retrieveIdentityVerificationSession(sessionId: string): Promise<{
+    id: string;
+    status: string;
+    metadata?: Record<string, string>;
+  }> {
+    return this.request('GET', `/identity/verification_sessions/${sessionId}`);
+  }
 }

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -2950,6 +2950,11 @@ class RouteRegistry {
     this.register('PUT', '/api/payments/payment-methods', this.setDefaultPaymentMethod.bind(this));
     this.register('POST', '/api/webhooks/stripe', this.handleStripeWebhook.bind(this));
 
+    // Creator identity verification (Stripe Identity). Self-gated to creator/
+    // production inside the handlers. Retrieve-on-return — no webhook config.
+    this.register('POST', '/api/identity/start', this.startIdentityVerification.bind(this));
+    this.register('POST', '/api/identity/refresh', this.refreshIdentityVerification.bind(this));
+
     // Pitch Validation Routes
     this.register('POST', '/api/validation/analyze', (req) => validationHandlers.analyze(req));
     this.register('GET', '/api/validation/score/:pitchId', (req) => validationHandlers.getScore(req));
@@ -11031,6 +11036,86 @@ pitchey_analytics_datapoints_per_minute 1250
         ErrorCode.INTERNAL_ERROR,
         'Failed to open billing portal'
       );
+    }
+  }
+
+  // ── Creator Identity Verification (Stripe Identity) ──
+  // ISOLATED from billing: result is read via retrieve-on-return (the stored
+  // session id), NOT a webhook — so this adds ZERO Stripe webhook config and
+  // cannot disturb subscriptions. Promotes verification_tier → silver on verified.
+
+  private async startIdentityVerification(request: Request): Promise<Response> {
+    const builder = new ApiResponseBuilder(request);
+    const authResult = await this.requireAuth(request);
+    if (!authResult.authorized) return authResult.response!;
+    const userId = authResult.user.id;
+
+    const sql = this.db.getSql() as any;
+    const [me] = await sql`SELECT user_type FROM users WHERE id = ${userId}`;
+    if (!me || (me.user_type !== 'creator' && me.user_type !== 'production')) {
+      return builder.error(ErrorCode.FORBIDDEN, 'Only creators and production companies can verify identity');
+    }
+
+    const stripeKey = (this.env as any).STRIPE_SECRET_KEY;
+    if (!stripeKey) return builder.error(ErrorCode.INTERNAL_ERROR, 'Identity verification is not configured');
+
+    try {
+      const { StripeService } = await import('./services/stripe.service');
+      const stripe = new StripeService(stripeKey);
+      const origin = request.headers.get('Origin') || (this.env as any).FRONTEND_URL || 'https://pitchey-5o8.pages.dev';
+      const returnUrl = `${origin}/creator/settings/profile?identity=return`;
+      const session = await stripe.createIdentityVerificationSession({ userId: Number(userId), returnUrl });
+      await sql`UPDATE users SET identity_session_id = ${session.id}, identity_status = ${session.status} WHERE id = ${userId}`;
+      return builder.success({ url: session.url, status: session.status });
+    } catch (err) {
+      console.error('startIdentityVerification error:', err instanceof Error ? err.message : String(err));
+      return builder.error(ErrorCode.INTERNAL_ERROR, 'Could not start identity verification');
+    }
+  }
+
+  // Read back the stored session on return; promote tier on a verified result.
+  private async refreshIdentityVerification(request: Request): Promise<Response> {
+    const builder = new ApiResponseBuilder(request);
+    const authResult = await this.requireAuth(request);
+    if (!authResult.authorized) return authResult.response!;
+    const userId = authResult.user.id;
+
+    const sql = this.db.getSql() as any;
+    const [me] = await sql`
+      SELECT identity_session_id, identity_status, identity_verified_at, verification_tier
+      FROM users WHERE id = ${userId}
+    `;
+    if (!me?.identity_session_id) {
+      return builder.success({ status: me?.identity_status ?? 'none', verified: !!me?.identity_verified_at });
+    }
+
+    const stripeKey = (this.env as any).STRIPE_SECRET_KEY;
+    if (!stripeKey) return builder.error(ErrorCode.INTERNAL_ERROR, 'Identity verification is not configured');
+
+    try {
+      const { StripeService } = await import('./services/stripe.service');
+      const stripe = new StripeService(stripeKey);
+      const session = await stripe.retrieveIdentityVerificationSession(me.identity_session_id);
+      // Bind: the session must belong to this user.
+      if (session.metadata?.userId && String(session.metadata.userId) !== String(userId)) {
+        return builder.error(ErrorCode.FORBIDDEN, 'Verification session mismatch');
+      }
+      if (session.status === 'verified' && !me.identity_verified_at) {
+        // Promote to silver — but NEVER downgrade an existing gold tier.
+        await sql`
+          UPDATE users SET
+            identity_status = ${session.status},
+            identity_verified_at = NOW(),
+            verification_tier = CASE WHEN verification_tier = 'gold' THEN 'gold' ELSE 'silver' END
+          WHERE id = ${userId}
+        `;
+      } else {
+        await sql`UPDATE users SET identity_status = ${session.status} WHERE id = ${userId}`;
+      }
+      return builder.success({ status: session.status, verified: session.status === 'verified' });
+    } catch (err) {
+      console.error('refreshIdentityVerification error:', err instanceof Error ? err.message : String(err));
+      return builder.error(ErrorCode.INTERNAL_ERROR, 'Could not check identity verification');
     }
   }
 


### PR DESCRIPTION
Second of the two trust features. **Verifies the person** (real, named human via Stripe document + selfie) — the anti-impersonation floor for solo creators who have no company to verify. Complements #321 provenance, which seals the *idea*. On a verified result, `verification_tier` → **silver** (never downgrades a gold). **Opt-in** — never required to publish.

### Stripe safety (the explicit constraint)
Deliberately **isolated from billing**: the result is read via **retrieve-on-return** (stored session id), **not a webhook** — so this adds **zero change to the live Stripe webhook config** and cannot disturb subscriptions. The existing webhook handler is untouched; the two `StripeService` methods are purely additive.

- **migration 110**: `users.identity_session_id / identity_status / identity_verified_at`
- `StripeService`: `createIdentityVerificationSession` + `retrieveIdentityVerificationSession`
- `POST /api/identity/start` (create session → hosted URL) + `POST /api/identity/refresh` (read status on return, promote tier) — self-gated to creator/production
- frontend: `IdentityVerificationCard` on CreatorSettingsProfile (opt-in button + return handler + verified badge)

Mode-agnostic (works in Stripe test + live; the ~$1.50 cost applies in live mode only — no credit charge to the user).

⚠️ **Migration 110 must be applied to prod before deploy.** Validated migration + tier logic via rollback txn; `build:worker` + frontend `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)