### PR TITLE
feat(trust): platform-earned GOLD tier for creators (sealed catalogue + honored NDAs)

### DIFF
--- a/src/services/creator-reputation.ts
+++ b/src/services/creator-reputation.ts
@@ -1,0 +1,60 @@
+// Platform-earned GOLD tier for creators — the moat-native trust signal.
+//
+// A creator can't do company verification (no company). Their top trust tier is
+// EARNED from on-platform history that only exists because of Pitchey:
+//   - a real sealed catalogue (>= 2 sealed pitches — provenance), and
+//   - sustained, un-withdrawn buyer interest (>= 3 honored NDAs from OTHER users:
+//     status='signed' AND not revoked).
+// This reputation is non-transferable and hard to fake — exactly the asset that
+// makes Pitchey the venue rather than a listing site.
+//
+// PROMOTE-ONLY by design: it only ever sets verification_tier='gold', and only for
+// creators not already gold. It never downgrades, and never touches production/
+// investor (who earn gold via company-verification) or admin-granted gold. So it
+// cannot conflict with the company-verification / admin / identity tier writers.
+//
+// NOTE: gold does NOT require identity (silver) in v1 — the catalogue + honored-NDA
+// signals stand on their own and are hard to fake. To tighten once Stripe Identity
+// is enabled, add `AND u.identity_verified_at IS NOT NULL` to the WHERE.
+
+import { neon } from '@neondatabase/serverless';
+
+const MIN_SEALED_PITCHES = 2;
+const MIN_HONORED_NDAS = 3;
+
+export async function recomputeCreatorReputationTiers(env: any, _ctx?: any): Promise<{ promoted: number }> {
+  const url = env?.DATABASE_URL;
+  if (!url) return { promoted: 0 };
+  const sql = neon(url);
+  try {
+    const rows = await sql`
+      UPDATE users u SET verification_tier = 'gold', updated_at = NOW()
+      WHERE u.user_type = 'creator'
+        AND COALESCE(u.verification_tier, 'grey') <> 'gold'
+        AND (
+          SELECT COUNT(*) FROM pitch_provenance pr WHERE pr.creator_id = u.id
+        ) >= ${MIN_SEALED_PITCHES}
+        AND (
+          SELECT COUNT(*) FROM ndas n
+          JOIN pitches p ON p.id = n.pitch_id
+          WHERE p.user_id = u.id
+            AND n.status = 'signed'
+            AND n.signer_id <> u.id
+            AND n.revoked_at IS NULL
+            AND n.access_revoked_at IS NULL
+        ) >= ${MIN_HONORED_NDAS}
+      RETURNING u.id
+    `;
+    const promoted = rows.length;
+    console.log(JSON.stringify({
+      level: 'info',
+      category: 'reputation',
+      action: 'creator_gold_recompute',
+      promoted,
+    }));
+    return { promoted };
+  } catch (err) {
+    console.error('recomputeCreatorReputationTiers error:', err instanceof Error ? err.message : String(err));
+    return { promoted: 0 };
+  }
+}

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -21981,6 +21981,12 @@ const websocketSafeHandler = {
           await Promise.all([
             sweepExpiredSubscriptionGrants(env, ctx),
             topUpDemoAccountCredits(env, ctx),
+            // Platform-earned GOLD: promote creators with a sealed catalogue +
+            // honored NDAs. Promote-only; never downgrades. See creator-reputation.ts.
+            (async () => {
+              const { recomputeCreatorReputationTiers } = await import('./services/creator-reputation');
+              await recomputeCreatorReputationTiers(env, ctx);
+            })(),
           ]);
           break;
 


### PR DESCRIPTION
The capstone of the trust pillar — the **moat-native** top tier for creators who have no company to verify. GOLD is **earned** from on-platform history that only exists because of Pitchey: ≥2 sealed pitches (provenance) + ≥3 honored NDAs from other users (signed, not revoked).

- `recomputeCreatorReputationTiers` — a single **promote-only** UPDATE: only ever sets gold, only for non-gold creators; never downgrades, never touches company-verified / admin / identity tier writers, so it can't conflict.
- Wired into the daily `0 0 * * *` cron.
- v1 does **not** require identity (the catalogue + honored-NDA signals stand alone); one-line tightening (`AND identity_verified_at IS NOT NULL`) once Stripe Identity is enabled.

Validated via rollback txn: alex.creator (3 sealed + 3 honored NDAs) → gold; nobody else qualifies (threshold is meaningful). No migration. `build:worker` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)