### PR TITLE
feat(creator): "Who viewed your deck" tier-gate (moat #2)

### DIFF
--- a/frontend/src/features/analytics/components/WhoViewedPanel.tsx
+++ b/frontend/src/features/analytics/components/WhoViewedPanel.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Eye, Lock, ShieldCheck, Sparkles } from 'lucide-react';
+import apiClient from '../../../lib/api-client';
+
+// "Who viewed your protected deck" (moat #2) — owner-only per-viewer detail, gated
+// behind a paid Creator subscription. Free creators see the count + role breakdown
+// and an upsell; paid creators see the named list. Self-contained + degrades to
+// null so it can never break the pitch view.
+
+interface ViewerDetail {
+  viewerId: number | string;
+  name: string;
+  role: string;
+  viewCount: number;
+  lastViewedAt: string | null;
+  totalDuration: number;
+  ndaSigned: boolean;
+}
+interface WhoViewedData {
+  viewers: ViewerDetail[];
+  isOwner: boolean;
+  locked: boolean;
+  totalViewers: number;
+  breakdown: Record<string, number>;
+}
+
+const ROLE_LABEL: Record<string, string> = {
+  creator: 'Creator', investor: 'Investor', production: 'Production', viewer: 'Watcher',
+};
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return '';
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return '';
+  const mins = Math.max(0, Math.round((Date.now() - then) / 60000));
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.round(hrs / 24)}d ago`;
+}
+
+function Breakdown({ breakdown, total }: { breakdown: Record<string, number>; total: number }) {
+  const entries = Object.entries(breakdown || {}).filter(([, n]) => n > 0);
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-2xl font-bold text-gray-900">{total}</span>
+      <span className="text-sm text-gray-500 mr-2">unique viewer{total === 1 ? '' : 's'}</span>
+      {entries.map(([role, n]) => (
+        <span key={role} className="text-xs font-medium text-gray-600 bg-gray-100 rounded-full px-2.5 py-1">
+          {n} {ROLE_LABEL[role] ?? role}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export default function WhoViewedPanel({ pitchId }: { pitchId: number }) {
+  const navigate = useNavigate();
+  const [data, setData] = useState<WhoViewedData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const res = await apiClient.get<WhoViewedData>(`/api/views/pitch/${pitchId}`);
+        if (active && res?.success && res.data) setData(res.data);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn('WhoViewedPanel: failed to load', err);
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => { active = false; };
+  }, [pitchId]);
+
+  if (loading) return <div data-testid="who-viewed-skeleton" className="bg-white rounded-xl shadow-sm h-40 animate-pulse" />;
+  if (!data || !data.isOwner) return null; // only the owner sees this panel
+
+  return (
+    <section data-testid="who-viewed-panel" className="bg-white rounded-xl shadow-sm ring-1 ring-gray-100 p-5">
+      <div className="flex items-center gap-2 mb-4">
+        <Eye className="w-5 h-5 text-purple-600" />
+        <h3 className="font-bold text-gray-900">Who viewed your deck</h3>
+      </div>
+
+      <div className="mb-4">
+        <Breakdown breakdown={data.breakdown} total={data.totalViewers} />
+      </div>
+
+      {data.locked ? (
+        <div data-testid="who-viewed-upsell" className="relative rounded-xl border border-purple-100 bg-gradient-to-br from-purple-50 to-indigo-50 p-5 text-center">
+          <Lock className="w-6 h-6 text-purple-500 mx-auto mb-2" />
+          <p className="font-semibold text-gray-900">See exactly who viewed your deck</p>
+          <p className="text-sm text-gray-500 mt-1 mb-4 max-w-md mx-auto">
+            Unlock named viewers, their role, how many times they returned, and whether they've signed your NDA.
+          </p>
+          <button
+            type="button"
+            onClick={() => navigate('/creator/billing')}
+            className="inline-flex items-center gap-1.5 bg-purple-600 hover:bg-purple-700 text-white text-sm font-medium rounded-lg px-4 py-2"
+          >
+            <Sparkles className="w-4 h-4" />
+            Upgrade to unlock
+          </button>
+        </div>
+      ) : data.viewers.length === 0 ? (
+        <p className="text-sm text-gray-400 py-4 text-center">No identified viewers yet.</p>
+      ) : (
+        <ul className="divide-y divide-gray-100">
+          {data.viewers.map((v) => (
+            <li key={String(v.viewerId)} className="flex items-center justify-between gap-3 py-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-gray-900 truncate">{v.name}</span>
+                  {v.ndaSigned && (
+                    <span className="inline-flex items-center gap-1 text-[11px] font-medium text-green-700 bg-green-50 rounded-full px-2 py-0.5">
+                      <ShieldCheck className="w-3 h-3" /> NDA
+                    </span>
+                  )}
+                </div>
+                <div className="text-xs text-gray-500">
+                  {ROLE_LABEL[v.role] ?? v.role} · viewed {v.viewCount}×
+                  {v.lastViewedAt ? ` · ${relativeTime(v.lastViewedAt)}` : ''}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/features/analytics/components/__tests__/WhoViewedPanel.test.tsx
+++ b/frontend/src/features/analytics/components/__tests__/WhoViewedPanel.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const mockGet = vi.fn();
+vi.mock('../../../../lib/api-client', () => ({ default: { get: (...a: unknown[]) => mockGet(...a) } }));
+
+import WhoViewedPanel from '../WhoViewedPanel';
+
+const renderPanel = () => render(<MemoryRouter><WhoViewedPanel pitchId={229} /></MemoryRouter>);
+
+beforeEach(() => { mockGet.mockReset(); mockNavigate.mockReset(); });
+
+describe('WhoViewedPanel', () => {
+  it('shows a skeleton while loading', () => {
+    mockGet.mockReturnValue(new Promise(() => {}));
+    renderPanel();
+    expect(screen.getByTestId('who-viewed-skeleton')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the caller is not the owner', async () => {
+    mockGet.mockResolvedValue({ success: true, data: { isOwner: false, locked: true, totalViewers: 0, breakdown: {}, viewers: [] } });
+    const { container } = renderPanel();
+    await waitFor(() => expect(screen.queryByTestId('who-viewed-skeleton')).not.toBeInTheDocument());
+    expect(screen.queryByTestId('who-viewed-panel')).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the counts + upsell when locked (free tier), and upgrades on click', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: { isOwner: true, locked: true, totalViewers: 3, breakdown: { investor: 2, production: 1 }, viewers: [] },
+    });
+    renderPanel();
+    await waitFor(() => expect(screen.getByTestId('who-viewed-panel')).toBeInTheDocument());
+    expect(mockGet).toHaveBeenCalledWith('/api/views/pitch/229');
+    // teaser counts always visible
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('2 Investor')).toBeInTheDocument();
+    // upsell shown, no names
+    expect(screen.getByTestId('who-viewed-upsell')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /upgrade to unlock/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/creator/billing');
+  });
+
+  it('shows named viewers + NDA badge when unlocked (paid tier)', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: {
+        isOwner: true, locked: false, totalViewers: 2,
+        breakdown: { investor: 1, production: 1 },
+        viewers: [
+          { viewerId: 7, name: 'Dana Investor', role: 'investor', viewCount: 4, lastViewedAt: new Date().toISOString(), totalDuration: 120, ndaSigned: true },
+          { viewerId: 9, name: 'Pat Producer', role: 'production', viewCount: 1, lastViewedAt: null, totalDuration: 0, ndaSigned: false },
+        ],
+      },
+    });
+    renderPanel();
+    await waitFor(() => expect(screen.getByTestId('who-viewed-panel')).toBeInTheDocument());
+    expect(screen.queryByTestId('who-viewed-upsell')).not.toBeInTheDocument();
+    expect(screen.getByText('Dana Investor')).toBeInTheDocument();
+    expect(screen.getByText('Pat Producer')).toBeInTheDocument();
+    expect(screen.getByText('NDA')).toBeInTheDocument(); // only Dana signed
+    expect(screen.getByText(/viewed 4×/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/portals/creator/pages/CreatorPitchView.tsx
+++ b/frontend/src/portals/creator/pages/CreatorPitchView.tsx
@@ -26,6 +26,7 @@ import apiClient from '@/lib/api-client';
 import { useBetterAuthStore } from '@/store/betterAuthStore';
 import FormatDisplay from '@/components/FormatDisplay';
 import FeedbackDisplay from '@/components/feedback/FeedbackDisplay';
+import WhoViewedPanel from '@features/analytics/components/WhoViewedPanel';
 import FollowButton from '@features/browse/components/FollowButton';
 import InterestedCard from '@features/pitches/components/InterestedCard';
 import CollaborationWorkspace from '@features/pitches/components/CollaborationWorkspace';
@@ -541,6 +542,13 @@ const CreatorPitchView: React.FC = () => {
                     ))}
                   </div>
                 </div>
+              </div>
+            )}
+
+            {/* "Who viewed your deck" — owner-only, tier-gated (moat #2) */}
+            {activeTab === 'analytics' && isOwner && id && (
+              <div className="mt-6">
+                <WhoViewedPanel pitchId={parseInt(id)} />
               </div>
             )}
 

--- a/src/handlers/views.ts
+++ b/src/handlers/views.ts
@@ -200,41 +200,106 @@ export async function getPitchViewersHandler(request: Request, env: Env): Promis
 
     const userId = await getUserId(request, env);
     const sql = getDb(env);
+    const id = parseInt(pitchId);
     if (!sql) {
-      return new Response(JSON.stringify({ success: true, data: { viewers: [], isOwner: false } }), { headers });
+      return new Response(JSON.stringify({ success: true, data: { viewers: [], isOwner: false, locked: true, totalViewers: 0, breakdown: {} } }), { headers });
     }
 
-    // Check ownership
+    // Ownership — only the pitch owner may see who viewed it (moat #2). creator_id
+    // OR user_id (both coexist due to drift). Previously this handler leaked named
+    // viewers to ANY caller; the gate below fixes that.
     const [pitch] = await sql`
-      SELECT id, user_id FROM pitches WHERE id = ${parseInt(pitchId)}
+      SELECT id, user_id, creator_id FROM pitches WHERE id = ${id}
     `;
-
     if (!pitch) {
       return new Response(JSON.stringify({ success: false, error: 'Pitch not found' }), {
         status: 404, headers
       });
     }
+    const isOwner =
+      String(pitch.user_id ?? '') === String(userId) || String(pitch.creator_id ?? '') === String(userId);
 
-    const isOwner = String(pitch.user_id) === userId;
+    // Role breakdown + total unique viewers — counts only, no identities. Safe to
+    // compute always; returned to the owner regardless of tier (the teaser).
+    const breakdown: Record<string, number> = { creator: 0, investor: 0, production: 0, viewer: 0 };
+    let totalViewers = 0;
+    try {
+      const rows = await sql`
+        SELECT u.user_type, COUNT(DISTINCT v.viewer_id)::int AS count
+        FROM views v JOIN users u ON u.id = v.viewer_id
+        WHERE v.pitch_id = ${id} AND v.viewer_id IS NOT NULL
+        GROUP BY u.user_type
+      `;
+      for (const r of rows as Array<Record<string, unknown>>) {
+        breakdown[String(r.user_type ?? 'viewer')] = Number(r.count) || 0;
+        totalViewers += Number(r.count) || 0;
+      }
+    } catch { /* drift → zero counts, still renders */ }
 
-    const viewers = await sql`
+    // Non-owners never see names or counts detail.
+    if (!userId || !isOwner) {
+      return new Response(JSON.stringify({
+        success: true,
+        data: { viewers: [], isOwner: false, locked: true, totalViewers, breakdown }
+      }), { headers });
+    }
+
+    // The gate: per-viewer DETAIL is unlocked only for a paid Creator subscription.
+    const PAID_TIERS = new Set(['creator', 'creator_plus', 'creator_unlimited']);
+    let isPaid = false;
+    try {
+      const [u] = await sql`SELECT subscription_tier FROM users WHERE id::text = ${String(userId)}`;
+      isPaid = PAID_TIERS.has(String((u as Record<string, unknown>)?.subscription_tier ?? ''));
+    } catch { isPaid = false; }
+
+    if (!isPaid) {
+      // Free owner — counts + breakdown, but no names. Frontend shows the upsell.
+      return new Response(JSON.stringify({
+        success: true,
+        data: { viewers: [], isOwner: true, locked: true, totalViewers, breakdown }
+      }), { headers });
+    }
+
+    // NDA-signed viewer ids (guarded — ndas.signer_id has documented drift).
+    const ndaSigners = new Set<string>();
+    try {
+      const ndaRows = await sql`
+        SELECT DISTINCT signer_id FROM ndas
+        WHERE pitch_id = ${id} AND status IN ('approved', 'signed', 'completed')
+      `;
+      for (const r of ndaRows as Array<Record<string, unknown>>) {
+        if (r.signer_id != null) ndaSigners.add(String(r.signer_id));
+      }
+    } catch { /* no NDA badges on drift */ }
+
+    // Paid owner — named per-viewer detail aggregated per unique viewer.
+    const rows = await sql`
       SELECT
-        v.id,
-        v.viewed_at,
-        v.view_type,
-        u.id AS user_id,
-        u.name,
-        u.user_type
-      FROM views v
-      LEFT JOIN users u ON u.id = v.viewer_id
-      WHERE v.pitch_id = ${parseInt(pitchId)}
-      ORDER BY v.viewed_at DESC
-      LIMIT 100
+        v.viewer_id,
+        COALESCE(NULLIF(TRIM(CONCAT(u.first_name, ' ', u.last_name)), ''), u.username, 'Unknown viewer') AS name,
+        u.user_type,
+        COUNT(*)::int AS view_count,
+        MAX(v.viewed_at) AS last_viewed_at,
+        COALESCE(SUM(v.view_duration), 0)::int AS total_duration
+      FROM views v JOIN users u ON u.id = v.viewer_id
+      WHERE v.pitch_id = ${id} AND v.viewer_id IS NOT NULL
+      GROUP BY v.viewer_id, u.first_name, u.last_name, u.username, u.user_type
+      ORDER BY MAX(v.viewed_at) DESC
+      LIMIT 200
     `;
+    const viewers = (rows as Array<Record<string, unknown>>).map((r) => ({
+      viewerId: r.viewer_id,
+      name: r.name,
+      role: r.user_type,
+      viewCount: Number(r.view_count) || 0,
+      lastViewedAt: r.last_viewed_at ? String(r.last_viewed_at) : null,
+      totalDuration: Number(r.total_duration) || 0,
+      ndaSigned: ndaSigners.has(String(r.viewer_id)),
+    }));
 
     return new Response(JSON.stringify({
       success: true,
-      data: { viewers, isOwner }
+      data: { viewers, isOwner: true, locked: false, totalViewers, breakdown }
     }), { headers });
   } catch (error: any) {
     console.error('Get pitch viewers error:', error);

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -2998,7 +2998,10 @@ class RouteRegistry {
     // View tracking endpoints
     this.register('POST', '/api/views/track', (req) => this.trackViewWithRealtimePush(req));
     this.register('GET', '/api/views/analytics', (req) => getViewAnalyticsHandler(req, this.env));
-    this.register('GET', '/api/views/pitch/*', (req) => getPitchViewersHandler(req, this.env));
+    // NOTE: was '/api/views/pitch/*' — the router's pathToRegex only supports :params,
+    // not '*' (the star quantified the slash), so the wildcard form never matched a
+    // real pitch id and the route was dead. Fixed to :id (moat #2 needs it live).
+    this.register('GET', '/api/views/pitch/:id', (req) => getPitchViewersHandler(req, this.env));
 
     // Pitch engagement (social proof) — registered with view routes, but needs to be before /api/pitches/:id catch-all
 

--- a/test/integration/who-viewed.test.ts
+++ b/test/integration/who-viewed.test.ts
@@ -1,0 +1,64 @@
+// "Who viewed your protected deck" (moat #2) — integration coverage for the
+// gated GET /api/views/pitch/:id. Verifies: the owner-gate (privacy-leak fix —
+// non-owners NEVER receive named viewers), the subscription_tier gate, and the
+// route fix (was '/api/views/pitch/*', a dead wildcard the router couldn't match).
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { TestClient, json } from './client';
+
+function digArray(body: any): any[] {
+  const c = body?.data?.pitches ?? body?.pitches ?? body?.data?.recentPitches ?? body?.recentPitches ?? body?.data ?? body;
+  return Array.isArray(c) ? c : (Array.isArray(c?.pitches) ? c.pitches : []);
+}
+
+// A real pitch owned by the creator demo account — discovered once, reused by all
+// three perspectives so none of the assertions silently skip.
+let pitchId: number | null = null;
+const owner = new TestClient();
+
+beforeAll(async () => {
+  await owner.login('alex.creator@demo.com', 'Demo123', 'creator');
+  const res = await owner.get('/api/creator/pitches');
+  if (res.status === 200) pitchId = digArray(await json(res))[0]?.id ?? null;
+});
+
+describe('GET /api/views/pitch/:id (who-viewed gate)', () => {
+  it('route is live (was a dead /* wildcard) — owner gets a 200, not a router 404', async () => {
+    expect(pitchId, 'precondition: creator demo account owns a pitch').not.toBeNull();
+    const res = await owner.get(`/api/views/pitch/${pitchId}`);
+    expect(res.status, await res.clone().text().catch(() => '')).toBe(200);
+    const d = (await json(res)).data;
+    expect(d.isOwner).toBe(true);
+    expect(typeof d.locked).toBe('boolean');
+    expect(typeof d.totalViewers).toBe('number');
+    expect(d.breakdown).toBeTruthy();
+    // Demo creator is on the free tier → detail locked, no names leaked.
+    if (d.locked) expect(d.viewers.length).toBe(0);
+  });
+
+  it('unauthenticated callers get no names (auth-gated or locked)', async () => {
+    const res = await new TestClient().get(`/api/views/pitch/${pitchId}`);
+    expect(res.status).not.toBe(500);
+    if (res.status === 200) {
+      // If the route were public, the handler must still withhold names.
+      const d = (await json(res)).data;
+      expect(d.isOwner).toBe(false);
+      expect(d.locked).toBe(true);
+      expect(d.viewers.length).toBe(0);
+    } else {
+      // Otherwise the auth middleware blocks it — also no names.
+      expect([401, 403]).toContain(res.status);
+    }
+  });
+
+  it('a non-owner (investor) never sees named viewers — the privacy-leak fix', async () => {
+    const investor = new TestClient();
+    await investor.login('sarah.investor@demo.com', 'Demo123', 'investor');
+    const res = await investor.get(`/api/views/pitch/${pitchId}`);
+    expect(res.status).not.toBe(500);
+    const d = (await json(res)).data;
+    expect(d.isOwner).toBe(false);
+    expect(d.locked).toBe(true);
+    expect(d.viewers.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

Moat item **#2** — monetize already-captured viewer data. Per-viewer detail for a creator's pitch, **gated behind a paid Creator subscription** (the value-based-pricing upsell). Free creators see the count + role breakdown + an upsell; paid creators see the named list.

> ⚠️ **Stacked on #327** (base = `test/backend-integration-tier`) — the integration test reuses that PR's harness. Merge #327 first.

## Fixes two pre-existing bugs in the same pass
1. **Dead route**: `GET /api/views/pitch/*` — the router's `pathToRegex` only supports `:params`; `*` quantified the slash, so the route **never matched a real pitch id**. No UI consumed it, so it went unnoticed. → `/api/views/pitch/:id`.
2. **Privacy leak**: the handler returned **named viewers to any caller** (`isOwner` was computed but never gated the list). → owner-only.

## The gate
Per-viewer detail unlocked only for `subscription_tier ∈ {creator, creator_plus, creator_unlimited}`; free → `locked` + counts only. Per-viewer aggregation (name/role/viewCount/lastViewed/dwell/`ndaSigned`), each sub-query guarded (`ndas.signer_id` has documented drift).

## Frontend
`WhoViewedPanel` on the `CreatorPitchView` analytics tab — counts + role breakdown always; named list when unlocked; upsell CTA → `/creator/billing` when locked. Self-contained, degrades to null.

## Verified
- **Integration** (`test/integration/who-viewed.test.ts`, vs Neon branch): route-is-live, owner gate, tier gate, and the **privacy-leak fix** (authenticated non-owner gets no names). Full integration suite **7 files / 36 tests**.
- **Unit** (`WhoViewedPanel.test.tsx`): loading / not-owner / locked-upsell / unlocked. `CreatorPitchView` still 6/6.
- Worker builds; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)