### PR TITLE
feat(creator): tracked slate share links + role-aware CTA (moat #5)

### DIFF
--- a/frontend/src/pages/PublicSlate.tsx
+++ b/frontend/src/pages/PublicSlate.tsx
@@ -1,7 +1,48 @@
 import { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { Layers, Film, Eye, Heart, BadgeCheck } from 'lucide-react';
+import { Layers, Film, Eye, Heart, BadgeCheck, Sparkles, UserPlus } from 'lucide-react';
 import { API_URL } from '../config';
+import { useBetterAuthStore } from '../store/betterAuthStore';
+
+// Role-aware conversion CTA on the public slate landing (moat #5). The whole point
+// of a tracked share is to convert the recipient — so we tailor the call to action
+// to who's viewing: logged-out → join; signed-in non-owner → follow/browse; the
+// owner sees nothing.
+function SlateConversionCTA({ creator }: { creator: Creator }) {
+  const { user } = useBetterAuthStore();
+  if (user && String(user.id) === String(creator.id)) return null; // owner
+
+  if (!user) {
+    return (
+      <div data-testid="slate-cta" className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-8">
+        <div className="rounded-2xl bg-gradient-to-br from-purple-600 to-indigo-700 text-white p-6 sm:p-8 flex flex-col sm:flex-row sm:items-center gap-4 justify-between">
+          <div>
+            <h2 className="text-xl font-bold flex items-center gap-2"><Sparkles className="w-5 h-5" /> Discover more on Pitchey</h2>
+            <p className="text-purple-100 mt-1">Create a free account to follow {creator.name} and request access to their work.</p>
+          </div>
+          <div className="flex gap-3 shrink-0">
+            <Link to="/register" className="bg-white text-purple-700 font-medium rounded-lg px-5 py-2.5 hover:bg-purple-50">Join free</Link>
+            <Link to="/login" className="ring-1 ring-white/40 text-white font-medium rounded-lg px-5 py-2.5 hover:bg-white/10">Sign in</Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Signed-in non-owner (investor / production / watcher).
+  return (
+    <div data-testid="slate-cta" className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-8">
+      <div className="rounded-2xl bg-white ring-1 ring-purple-100 p-5 flex items-center gap-4 justify-between">
+        <p className="text-gray-700">
+          Interested in {creator.name}'s work? Follow them to get notified about new pitches.
+        </p>
+        <Link to={`/user/${creator.id}`} className="inline-flex items-center gap-1.5 bg-purple-600 hover:bg-purple-700 text-white font-medium rounded-lg px-4 py-2 shrink-0">
+          <UserPlus className="w-4 h-4" /> View creator
+        </Link>
+      </div>
+    </div>
+  );
+}
 
 interface Creator {
   id: number;
@@ -47,7 +88,10 @@ export default function PublicSlate() {
     if (!id) return;
     (async () => {
       try {
-        const res = await fetch(`${API_URL}/api/slates/${id}/public`);
+        // A purely-numeric param is a legacy slate id; anything else is a tracked
+        // share token (moat #5) — the token endpoint also records the view.
+        const endpoint = /^\d+$/.test(id) ? `/api/slates/${id}/public` : `/api/slates/s/${id}`;
+        const res = await fetch(`${API_URL}${endpoint}`);
         if (res.status === 404) {
           setNotFound(true);
           return;
@@ -135,6 +179,9 @@ export default function PublicSlate() {
           </div>
         </div>
       </div>
+
+      {/* Role-aware conversion CTA (moat #5) */}
+      <SlateConversionCTA creator={slate.creator} />
 
       {/* Pitches */}
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/frontend/src/portals/creator/components/SlateShareLinks.tsx
+++ b/frontend/src/portals/creator/components/SlateShareLinks.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Link2, Copy, Check, Trash2, Eye, Plus } from 'lucide-react';
+import { SlateService, type SlateShareLink } from '../../../services/slate.service';
+
+// Tracked slate share links panel (moat #5) — mint per-share tokens with view
+// counts + revocation. Lives in the slate editor.
+
+function shareUrl(token: string): string {
+  const origin = typeof window !== 'undefined' ? window.location.origin : '';
+  return `${origin}/slates/s/${token}`;
+}
+
+export default function SlateShareLinks({ slateId, published }: { slateId: number; published: boolean }) {
+  const [links, setLinks] = useState<SlateShareLink[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [label, setLabel] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLinks(await SlateService.listShareLinks(slateId));
+    setLoading(false);
+  }, [slateId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const create = useCallback(async () => {
+    setCreating(true);
+    const link = await SlateService.createShareLink(slateId, label.trim() || undefined);
+    if (link) { setLabel(''); await load(); }
+    setCreating(false);
+  }, [slateId, label, load]);
+
+  const revoke = useCallback(async (id: number) => {
+    if (await SlateService.revokeShareLink(id)) await load();
+  }, [load]);
+
+  const copy = useCallback(async (token: string) => {
+    try { await navigator.clipboard.writeText(shareUrl(token)); setCopied(token); setTimeout(() => setCopied(null), 1500); }
+    catch { /* clipboard blocked — no-op */ }
+  }, []);
+
+  const active = links.filter((l) => !l.revoked_at);
+
+  return (
+    <section data-testid="slate-share-links" className="bg-white rounded-xl ring-1 ring-gray-100 p-5">
+      <div className="flex items-center gap-2 mb-1">
+        <Link2 className="w-5 h-5 text-purple-600" />
+        <h3 className="font-bold text-gray-900">Share this slate</h3>
+      </div>
+      <p className="text-sm text-gray-500 mb-4">
+        Create tracked links to send to investors &amp; producers — see how many times each was opened.
+      </p>
+
+      {!published && (
+        <p className="text-sm text-amber-700 bg-amber-50 border border-amber-100 rounded-lg px-3 py-2 mb-4">
+          Publish this slate to make shared links viewable.
+        </p>
+      )}
+
+      <div className="flex items-center gap-2 mb-4">
+        <input
+          value={label} onChange={(e) => setLabel(e.target.value)}
+          placeholder="Label (e.g. Investor outreach)" aria-label="Share link label"
+          className="flex-1 border border-gray-200 rounded-lg px-3 py-1.5 text-sm"
+        />
+        <button
+          type="button" onClick={create} disabled={creating}
+          className="inline-flex items-center gap-1 bg-purple-600 hover:bg-purple-700 disabled:opacity-50 text-white text-sm font-medium rounded-lg px-3 py-1.5"
+        >
+          <Plus className="w-4 h-4" /> New link
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="h-12 bg-gray-50 rounded-lg animate-pulse" />
+      ) : active.length === 0 ? (
+        <p className="text-sm text-gray-400 text-center py-3">No share links yet.</p>
+      ) : (
+        <ul className="divide-y divide-gray-100">
+          {active.map((l) => (
+            <li key={l.id} className="flex items-center justify-between gap-3 py-3">
+              <div className="min-w-0">
+                <div className="font-medium text-gray-800 truncate">{l.label || 'Untitled link'}</div>
+                <div className="text-xs text-gray-400 flex items-center gap-1">
+                  <Eye className="w-3 h-3" /> {l.view_count} view{l.view_count === 1 ? '' : 's'}
+                </div>
+              </div>
+              <div className="flex items-center gap-1 shrink-0">
+                <button
+                  type="button" onClick={() => copy(l.token)} aria-label="Copy link"
+                  className="inline-flex items-center gap-1 text-sm text-gray-600 hover:text-purple-600 rounded-lg px-2 py-1"
+                >
+                  {copied === l.token ? <><Check className="w-4 h-4 text-green-600" /> Copied</> : <><Copy className="w-4 h-4" /> Copy</>}
+                </button>
+                <button
+                  type="button" onClick={() => revoke(l.id)} aria-label="Revoke link"
+                  className="text-gray-400 hover:text-red-600 rounded-lg p-1"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/portals/creator/components/__tests__/SlateShareLinks.test.tsx
+++ b/frontend/src/portals/creator/components/__tests__/SlateShareLinks.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+const list = vi.fn();
+const create = vi.fn();
+const revoke = vi.fn();
+vi.mock('../../../../services/slate.service', () => ({
+  SlateService: {
+    listShareLinks: (...a: unknown[]) => list(...a),
+    createShareLink: (...a: unknown[]) => create(...a),
+    revokeShareLink: (...a: unknown[]) => revoke(...a),
+  },
+}));
+
+import SlateShareLinks from '../SlateShareLinks';
+
+const link = (over = {}) => ({ id: 1, token: 'tok-abc', label: 'Investor outreach', view_count: 3, revoked_at: null, created_at: '2026-01-01' , ...over });
+
+beforeEach(() => {
+  list.mockReset(); create.mockReset(); revoke.mockReset();
+  list.mockResolvedValue([]);
+  Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+});
+
+describe('SlateShareLinks', () => {
+  it('shows the publish hint when the slate is not published', async () => {
+    render(<SlateShareLinks slateId={5} published={false} />);
+    await waitFor(() => expect(list).toHaveBeenCalledWith(5));
+    expect(screen.getByText(/Publish this slate/i)).toBeInTheDocument();
+  });
+
+  it('lists existing links with their view counts', async () => {
+    list.mockResolvedValue([link()]);
+    render(<SlateShareLinks slateId={5} published />);
+    await waitFor(() => expect(screen.getByText('Investor outreach')).toBeInTheDocument());
+    expect(screen.getByText(/3 views/)).toBeInTheDocument();
+    expect(screen.queryByText(/Publish this slate/i)).not.toBeInTheDocument();
+  });
+
+  it('creates a new link with the typed label, then reloads', async () => {
+    list.mockResolvedValueOnce([]).mockResolvedValueOnce([link({ label: 'Cannes' })]);
+    create.mockResolvedValue(link({ label: 'Cannes' }));
+    render(<SlateShareLinks slateId={5} published />);
+    await waitFor(() => expect(list).toHaveBeenCalled());
+    fireEvent.change(screen.getByLabelText('Share link label'), { target: { value: 'Cannes' } });
+    fireEvent.click(screen.getByRole('button', { name: /new link/i }));
+    await waitFor(() => expect(create).toHaveBeenCalledWith(5, 'Cannes'));
+    await waitFor(() => expect(screen.getByText('Cannes')).toBeInTheDocument());
+  });
+
+  it('copies the share URL to the clipboard', async () => {
+    list.mockResolvedValue([link()]);
+    render(<SlateShareLinks slateId={5} published />);
+    await waitFor(() => expect(screen.getByText('Investor outreach')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /copy link/i }));
+    await waitFor(() => expect((navigator.clipboard.writeText as any)).toHaveBeenCalledWith(expect.stringContaining('/slates/s/tok-abc')));
+    expect(await screen.findByText('Copied')).toBeInTheDocument();
+  });
+
+  it('revokes a link and reloads', async () => {
+    list.mockResolvedValueOnce([link()]).mockResolvedValueOnce([]);
+    revoke.mockResolvedValue(true);
+    render(<SlateShareLinks slateId={5} published />);
+    await waitFor(() => expect(screen.getByText('Investor outreach')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /revoke link/i }));
+    await waitFor(() => expect(revoke).toHaveBeenCalledWith(1));
+    await waitFor(() => expect(screen.getByText(/No share links yet/i)).toBeInTheDocument());
+  });
+});

--- a/frontend/src/portals/creator/pages/CreatorSlateDetail.tsx
+++ b/frontend/src/portals/creator/pages/CreatorSlateDetail.tsx
@@ -3,9 +3,10 @@ import { useParams, useNavigate } from 'react-router-dom';
 import {
   ArrowLeft, Pencil, Check, X, Trash2,
   GripVertical, Film, Eye, Heart, Plus, Globe,
-  EyeOff, Search, ExternalLink, Camera, Loader2
+  EyeOff, Search, Camera, Loader2
 } from 'lucide-react';
 import { SlateService, type SlateDetail } from '@/services/slate.service';
+import SlateShareLinks from '../components/SlateShareLinks';
 import { apiClient } from '@/lib/api-client';
 import { API_URL } from '@/config';
 import { prepareImageForUpload, PRE_COMPRESSION_MAX_BYTES } from '@/utils/imageUpload';
@@ -364,21 +365,8 @@ export default function CreatorSlateDetailPage() {
         </div>
       </div>
 
-      {/* Public link (if published) */}
-      {slate.status === 'published' && (
-        <div className="bg-green-50 border border-green-200 rounded-lg px-4 py-3 flex items-center gap-2 text-sm">
-          <Globe className="h-4 w-4 text-green-600 shrink-0" />
-          <span className="text-green-700">Public link:</span>
-          <code className="text-green-700 truncate font-mono">/slates/s/{slate.id}</code>
-          <button
-            onClick={() => navigator.clipboard.writeText(`${window.location.origin}/slates/s/${slate.id}`)}
-            className="ml-auto text-green-700 hover:text-green-800 shrink-0"
-            title="Copy link"
-          >
-            <ExternalLink className="h-4 w-4" />
-          </button>
-        </div>
-      )}
+      {/* Tracked share links (moat #5) — replaces the old raw, untracked link */}
+      <SlateShareLinks slateId={slate.id} published={slate.status === 'published'} />
 
       {/* Pitches */}
       {slate.pitches.length === 0 ? (

--- a/frontend/src/portals/creator/pages/__tests__/CreatorSlateDetail.test.tsx
+++ b/frontend/src/portals/creator/pages/__tests__/CreatorSlateDetail.test.tsx
@@ -46,6 +46,10 @@ vi.mock('@/services/slate.service', () => ({
     addPitch: (...args: any[]) => mockSlateAddPitch(...args),
     removePitch: (...args: any[]) => mockSlateRemovePitch(...args),
     reorderPitches: (...args: any[]) => mockSlateReorderPitches(...args),
+    // SlateShareLinks panel (moat #5) — stubbed so the editor renders cleanly.
+    listShareLinks: vi.fn().mockResolvedValue([]),
+    createShareLink: vi.fn().mockResolvedValue(null),
+    revokeShareLink: vi.fn().mockResolvedValue(true),
   },
 }))
 
@@ -383,19 +387,20 @@ describe('CreatorSlateDetail', () => {
   })
 
   // ─── Published slate public link ──────────────────────────────────
-  it('shows public link section when slate is published', async () => {
+  it('shows the tracked share panel without a publish hint when published', async () => {
     mockSlateGet.mockResolvedValue(mockPublishedSlate)
     renderComponent()
     await waitFor(() => {
-      expect(screen.getByText('Public link:')).toBeInTheDocument()
-      expect(screen.getByText('/slates/s/42')).toBeInTheDocument()
+      expect(screen.getByText('Share this slate')).toBeInTheDocument()
+      expect(screen.queryByText(/Publish this slate/i)).not.toBeInTheDocument()
     })
   })
 
-  it('does not show public link section when slate is draft', async () => {
+  it('shows the share panel with a publish hint when the slate is draft', async () => {
     renderComponent()
     await waitFor(() => screen.getByText('My Best Pitches'))
-    expect(screen.queryByText('Public link:')).not.toBeInTheDocument()
+    expect(screen.getByText('Share this slate')).toBeInTheDocument()
+    expect(screen.getByText(/Publish this slate/i)).toBeInTheDocument()
   })
 
   // ─── Edit title/description ───────────────────────────────────────

--- a/frontend/src/services/slate.service.ts
+++ b/frontend/src/services/slate.service.ts
@@ -160,4 +160,38 @@ export class SlateService {
       return false;
     }
   }
+
+  // ── Tracked share links (moat #5) ──────────────────────────────────────────
+  static async listShareLinks(slateId: number): Promise<SlateShareLink[]> {
+    try {
+      const res = await apiClient.get<{ links: SlateShareLink[] }>(`/api/slates/${slateId}/share-links`);
+      if (isFailure(res)) return [];
+      return res.data?.links ?? [];
+    } catch { return []; }
+  }
+
+  static async createShareLink(slateId: number, label?: string): Promise<SlateShareLink | null> {
+    try {
+      const res = await apiClient.post<{ link: SlateShareLink }>(`/api/slates/${slateId}/share-links`, { label });
+      if (isFailure(res)) return null;
+      return res.data?.link ?? null;
+    } catch { return null; }
+  }
+
+  static async revokeShareLink(linkId: number): Promise<boolean> {
+    try {
+      const res = await apiClient.delete(`/api/slates/share-links/${linkId}`);
+      return !isFailure(res);
+    } catch { return false; }
+  }
+}
+
+export interface SlateShareLink {
+  id: number;
+  token: string;
+  label: string | null;
+  view_count: number;
+  last_viewed_at?: string | null;
+  revoked_at?: string | null;
+  created_at: string;
 }

--- a/src/db/migrations/112_slate_share_links.sql
+++ b/src/db/migrations/112_slate_share_links.sql
@@ -1,0 +1,24 @@
+-- 112_slate_share_links.sql
+--
+-- Tokenized, tracked share links for slates (moat #5). Today the public slate URL
+-- is `/slates/s/{id}` — a raw, guessable, untracked id. This adds per-share tokens
+-- with view tracking + revocation, mirroring the proven `portfolio_share_links`
+-- design, so creators get a real outbound distribution surface with feedback.
+--
+-- Additive + idempotent.
+
+CREATE TABLE IF NOT EXISTS slate_share_links (
+  id              SERIAL PRIMARY KEY,
+  token           VARCHAR(36) NOT NULL UNIQUE,
+  slate_id        INTEGER NOT NULL,
+  creator_id      INTEGER NOT NULL,
+  label           VARCHAR(100),
+  view_count      INTEGER DEFAULT 0,
+  last_viewed_at  TIMESTAMPTZ,
+  revoked_at      TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ssl_token ON slate_share_links(token);
+CREATE INDEX IF NOT EXISTS idx_ssl_slate ON slate_share_links(slate_id);
+CREATE INDEX IF NOT EXISTS idx_ssl_creator ON slate_share_links(creator_id);

--- a/src/handlers/slate-share.ts
+++ b/src/handlers/slate-share.ts
@@ -1,0 +1,187 @@
+/**
+ * Tokenized, tracked slate share links (moat #5).
+ *
+ * Replaces the raw, untracked `/slates/s/{id}` link with per-share tokens that
+ * carry view tracking + revocation — the same model as portfolio_share_links —
+ * so a creator's slate becomes a real outbound distribution surface with feedback.
+ *
+ *   POST   /api/slates/:id/share-links       create a tracked link (owner)
+ *   GET    /api/slates/:id/share-links        list a slate's links + view counts (owner)
+ *   DELETE /api/slates/share-links/:linkId    revoke a link (owner)
+ *   GET    /api/slates/s/:token               public tracked view (no auth)
+ */
+
+import { getDb } from '../db/connection';
+import type { Env } from '../db/connection';
+import { getCorsHeaders } from '../utils/response';
+import { getUserId } from '../utils/auth-extract';
+
+function jsonResponse(data: unknown, origin: string | null, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...getCorsHeaders(origin) },
+  });
+}
+function errorResponse(message: string, origin: string | null, status = 400): Response {
+  return jsonResponse({ success: false, error: message }, origin, status);
+}
+
+function paramId(request: Request, key: string, idx: number): string | undefined {
+  const fromRouter = (request as any).params?.[key];
+  if (fromRouter) return String(fromRouter);
+  const parts = new URL(request.url).pathname.split('/');
+  return parts[parts.length - idx];
+}
+
+/** POST /api/slates/:id/share-links */
+export async function createSlateShareLinkHandler(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+  const userId = await getUserId(request, env);
+  if (!userId) return errorResponse('Unauthorized', origin, 401);
+  const sql = getDb(env);
+  if (!sql) return errorResponse('Database unavailable', origin, 503);
+
+  try {
+    const slateId = parseInt(paramId(request, 'id', 2) || '', 10); // /api/slates/:id/share-links
+    if (!slateId || Number.isNaN(slateId)) return errorResponse('Invalid slate id', origin);
+
+    const [owned] = await sql`SELECT id FROM slates WHERE id = ${slateId} AND user_id::text = ${String(userId)}`;
+    if (!owned) return errorResponse('Slate not found', origin, 404);
+
+    const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+    const label = typeof body.label === 'string' ? body.label.slice(0, 100) : null;
+    const token = crypto.randomUUID();
+
+    const [link] = await sql`
+      INSERT INTO slate_share_links (token, slate_id, creator_id, label)
+      VALUES (${token}, ${slateId}, ${Number(userId)}, ${label})
+      RETURNING id, token, label, view_count, created_at
+    `;
+    return jsonResponse({ success: true, data: { link } }, origin, 201);
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error('createSlateShareLinkHandler error:', e.message);
+    return errorResponse('Failed to create share link', origin, 500);
+  }
+}
+
+/** GET /api/slates/:id/share-links */
+export async function listSlateShareLinksHandler(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+  const userId = await getUserId(request, env);
+  if (!userId) return errorResponse('Unauthorized', origin, 401);
+  const sql = getDb(env);
+  if (!sql) return jsonResponse({ success: true, data: { links: [] } }, origin);
+
+  try {
+    const slateId = parseInt(paramId(request, 'id', 2) || '', 10);
+    if (!slateId || Number.isNaN(slateId)) return errorResponse('Invalid slate id', origin);
+
+    const links = await sql`
+      SELECT id, token, label, view_count, last_viewed_at, revoked_at, created_at
+      FROM slate_share_links
+      WHERE slate_id = ${slateId} AND creator_id::text = ${String(userId)}
+      ORDER BY created_at DESC
+    `;
+    return jsonResponse({ success: true, data: { links } }, origin);
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error('listSlateShareLinksHandler error:', e.message);
+    return jsonResponse({ success: true, data: { links: [] } }, origin);
+  }
+}
+
+/** DELETE /api/slates/share-links/:linkId */
+export async function revokeSlateShareLinkHandler(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+  const userId = await getUserId(request, env);
+  if (!userId) return errorResponse('Unauthorized', origin, 401);
+  const sql = getDb(env);
+  if (!sql) return errorResponse('Database unavailable', origin, 503);
+
+  try {
+    const linkId = parseInt(paramId(request, 'linkId', 1) || '', 10); // /api/slates/share-links/:linkId
+    if (!linkId || Number.isNaN(linkId)) return errorResponse('Invalid link id', origin);
+
+    const [revoked] = await sql`
+      UPDATE slate_share_links SET revoked_at = NOW()
+      WHERE id = ${linkId} AND creator_id::text = ${String(userId)} AND revoked_at IS NULL
+      RETURNING id
+    `;
+    if (!revoked) return errorResponse('Link not found', origin, 404);
+    return jsonResponse({ success: true }, origin);
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error('revokeSlateShareLinkHandler error:', e.message);
+    return errorResponse('Failed to revoke link', origin, 500);
+  }
+}
+
+/** GET /api/slates/s/:token — public tracked view (no auth). */
+export async function publicSlateByTokenHandler(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+  const sql = getDb(env);
+  if (!sql) return errorResponse('Service unavailable', origin, 503);
+
+  try {
+    const token = paramId(request, 'token', 1);
+    if (!token) return errorResponse('Slate not found', origin, 404);
+
+    const [link] = await sql`
+      SELECT id, slate_id FROM slate_share_links WHERE token = ${token} AND revoked_at IS NULL
+    `;
+    if (!link) return errorResponse('Slate not found', origin, 404);
+
+    const slateId = Number(link.slate_id);
+
+    const slateResult = await sql`
+      SELECT s.id, s.title, s.description, s.cover_image, s.created_at, s.updated_at,
+             u.id AS creator_id, u.name AS creator_name, u.username AS creator_username,
+             u.profile_image AS creator_avatar
+      FROM slates s JOIN users u ON u.id = s.user_id
+      WHERE s.id = ${slateId} AND s.status = 'published'
+    `;
+    if (slateResult.length === 0) return errorResponse('Slate not found', origin, 404);
+
+    const pitches = await sql`
+      SELECT sp.position, p.id, p.title, p.logline, p.genre, p.format,
+             p.title_image AS cover_image,
+             COALESCE(p.view_count, 0)::int AS view_count,
+             COALESCE(p.like_count, 0)::int AS like_count,
+             p.created_at, p.updated_at
+      FROM slate_pitches sp JOIN pitches p ON p.id = sp.pitch_id
+      WHERE sp.slate_id = ${slateId} AND p.status = 'published'
+      ORDER BY sp.position ASC
+    `;
+
+    // Track the view (indexed single-row update; cheap to await).
+    await sql`
+      UPDATE slate_share_links SET view_count = view_count + 1, last_viewed_at = NOW()
+      WHERE id = ${link.id}
+    `;
+
+    const slate = slateResult[0] as Record<string, any>;
+    return jsonResponse({
+      success: true,
+      data: {
+        id: slate.id,
+        title: slate.title,
+        description: slate.description,
+        cover_image: slate.cover_image,
+        created_at: slate.created_at,
+        shareToken: token,
+        creator: {
+          id: slate.creator_id,
+          name: slate.creator_name,
+          username: slate.creator_username,
+          avatar_url: slate.creator_avatar,
+        },
+        pitches,
+      },
+    }, origin);
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error('publicSlateByTokenHandler error:', e.message);
+    return errorResponse('Failed to load slate', origin, 500);
+  }
+}

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -3662,6 +3662,24 @@ class RouteRegistry {
       const { publicSlateHandler } = await import('./handlers/slates');
       return publicSlateHandler(req, this.env);
     });
+    // Tokenized tracked slate shares (moat #5)
+    this.register('POST', '/api/slates/:id/share-links', async (req) => {
+      const { createSlateShareLinkHandler } = await import('./handlers/slate-share');
+      return createSlateShareLinkHandler(req, this.env);
+    });
+    this.register('GET', '/api/slates/:id/share-links', async (req) => {
+      const { listSlateShareLinksHandler } = await import('./handlers/slate-share');
+      return listSlateShareLinksHandler(req, this.env);
+    });
+    this.register('DELETE', '/api/slates/share-links/:linkId', async (req) => {
+      const { revokeSlateShareLinkHandler } = await import('./handlers/slate-share');
+      return revokeSlateShareLinkHandler(req, this.env);
+    });
+    // Public tracked slate view by token (no auth — listed in publicEndpoints)
+    this.register('GET', '/api/slates/s/:token', async (req) => {
+      const { publicSlateByTokenHandler } = await import('./handlers/slate-share');
+      return publicSlateByTokenHandler(req, this.env);
+    });
 
     // Heat Score — admin recalculate
     this.register('POST', '/api/admin/heat-scores/recalculate', async (req) => {
@@ -4277,6 +4295,7 @@ class RouteRegistry {
       '/api/demos/request',     // Demo request (anonymous OK)
       '/api/analytics/track-view', // View tracking (anonymous views)
       '/api/portfolio/s',  // Public shared portfolio (token-based)
+      '/api/slates/s',     // Public tracked slate share (token-based, moat #5)
       '/api/webhooks/stripe'  // Stripe webhooks (HMAC-SHA256 signature auth inside the handler, not session-based)
     ];
 

--- a/test/integration/slate-share.test.ts
+++ b/test/integration/slate-share.test.ts
@@ -1,0 +1,70 @@
+// Tracked slate share links (moat #5) — integration coverage for the full
+// lifecycle: create slate → publish → mint a tracked link → anonymous public view
+// (increments view_count) → revoke → 404. Drives the real handlers vs a Neon branch.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { TestClient, json } from './client';
+
+describe('Tracked slate share links (moat #5)', () => {
+  const creator = new TestClient();
+  let slateId: number | null = null;
+
+  beforeAll(async () => {
+    await creator.login('alex.creator@demo.com', 'Demo123', 'creator');
+    const created = await creator.post('/api/slates', { title: 'Share-test slate', description: 'integration' });
+    if (created.status < 300) {
+      const body = await json(created);
+      slateId = body.data?.slate?.id ?? body.data?.id ?? body.slate?.id ?? null;
+      if (slateId) await creator.put(`/api/slates/${slateId}`, { status: 'published' });
+    }
+  });
+
+  it('POST /api/slates/:id/share-links requires auth', async () => {
+    const res = await new TestClient().post('/api/slates/1/share-links', {});
+    expect([401, 403]).toContain(res.status);
+  });
+
+  it('mints a tracked link, the anonymous public view increments the count, then revoke 404s', async () => {
+    expect(slateId, 'precondition: created a published slate').not.toBeNull();
+
+    // Mint
+    const mk = await creator.post(`/api/slates/${slateId}/share-links`, { label: 'Investor outreach' });
+    expect(mk.status, await mk.clone().text().catch(() => '')).toBe(201);
+    const link = (await json(mk)).data.link;
+    expect(link.token).toBeTruthy();
+    expect(link.view_count).toBe(0);
+
+    // Anonymous public view by token (no auth) — returns the slate + tracks the view.
+    const pub = await new TestClient().get(`/api/slates/s/${link.token}`);
+    expect(pub.status, await pub.clone().text().catch(() => '')).toBe(200);
+    const data = (await json(pub)).data;
+    expect(data.title).toBe('Share-test slate');
+    expect(data.shareToken).toBe(link.token);
+    expect(data.creator?.username).toBeTruthy();
+
+    // The owner's link list now shows view_count >= 1.
+    const list = await creator.get(`/api/slates/${slateId}/share-links`);
+    expect(list.status).toBe(200);
+    const listed = (await json(list)).data.links.find((l: any) => l.id === link.id);
+    expect(listed.view_count).toBeGreaterThanOrEqual(1);
+
+    // Revoke → the token stops resolving.
+    const rev = await creator.delete(`/api/slates/share-links/${link.id}`);
+    expect(rev.status).toBe(200);
+    const after = await new TestClient().get(`/api/slates/s/${link.token}`);
+    expect(after.status).toBe(404);
+  });
+
+  it('an unknown token 404s', async () => {
+    const res = await new TestClient().get('/api/slates/s/00000000-0000-0000-0000-000000000000');
+    expect(res.status).toBe(404);
+  });
+
+  it('a non-owner cannot mint a link on someone else\'s slate', async () => {
+    if (slateId == null) { expect(true).toBe(true); return; }
+    const investor = new TestClient();
+    await investor.login('sarah.investor@demo.com', 'Demo123', 'investor');
+    const res = await investor.post(`/api/slates/${slateId}/share-links`, {});
+    expect([403, 404]).toContain(res.status);
+  });
+});


### PR DESCRIPTION
## What

Moat item **#5** — turn the slate into a real outbound distribution surface. Replaces the raw, untracked `/slates/s/{id}` link with **tokenized, tracked share links** (view counts + revocation) and a **role-aware conversion CTA** on the public landing. Mirrors the proven `portfolio_share_links` design.

## Backend
- **Migration 112** — `slate_share_links` (token, slate_id, creator_id, label, view_count, last_viewed_at, revoked_at). **Already applied + verified on prod.**
- `src/handlers/slate-share.ts`:
  - `POST /api/slates/:id/share-links` — mint a tracked link (owner)
  - `GET /api/slates/:id/share-links` — list a slate's links + view counts (owner)
  - `DELETE /api/slates/share-links/:id` — revoke (owner)
  - `GET /api/slates/s/:token` — public tracked view (no auth; increments `view_count` + `last_viewed_at`). Added `/api/slates/s` to `publicEndpoints`.

## Frontend
- `SlateService`: `listShareLinks` / `createShareLink` / `revokeShareLink`.
- `SlateShareLinks` panel in the slate editor (replaces the raw link) — mint, copy, view counts, revoke; publish hint when draft.
- `PublicSlate` loads by token (numeric param = legacy id) and shows a **role-aware CTA**: logged-out → join / sign-in; signed-in non-owner → follow the creator; owner → nothing.

## Verified
- **Integration** (`slate-share.test.ts`, vs Neon branch): mint → anonymous tracked view → `view_count++` → revoke → 404. Full integration suite **10 files / 47 tests**.
- **Unit**: `SlateShareLinks` 5; `CreatorSlateDetail` updated for the new panel (64 green). Worker builds; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)