### PR TITLE
Provenance: downloadable certificate + OpenTimestamps Bitcoin anchor (IP-theft evidence)

### DIFF
--- a/frontend/src/pages/PitchDetail.tsx
+++ b/frontend/src/pages/PitchDetail.tsx
@@ -460,6 +460,19 @@ export default function PitchDetail() {
                     </span>
                     <VerificationBadge tier={(pitch as any).creator_verification_tier || (pitch.creator as any)?.verificationTier} />
                     <SealBadge provenance={(pitch as any).provenance} />
+                    {isOwner && (pitch as any).provenance?.content_hash && (
+                      <button
+                        onClick={async () => {
+                          const { API_URL } = await import('../config');
+                          window.open(`${API_URL}/api/pitches/${id}/certificate`, '_blank');
+                        }}
+                        title="Download a printable Certificate of Provenance — your evidence of authorship and date"
+                        className="inline-flex items-center gap-1.5 rounded-full bg-gray-50 px-2.5 py-1 text-xs font-medium text-gray-700 ring-1 ring-inset ring-gray-200 transition hover:bg-gray-100"
+                      >
+                        <FileText className="h-3.5 w-3.5" aria-hidden />
+                        Certificate
+                      </button>
+                    )}
                     {/* Follow lives in the unified InterestedCard below — no inline duplicate */}
                   </div>
                 ) : (

--- a/src/db/migrations/113_provenance_ots_anchor.sql
+++ b/src/db/migrations/113_provenance_ots_anchor.sql
@@ -1,0 +1,25 @@
+-- 113_provenance_ots_anchor.sql
+-- OpenTimestamps anchor for pitch provenance (Phase 2 of the IP-theft evidence work).
+--
+-- The DB `sealed_at` timestamp is on a clock WE control — in a dispute the other side
+-- argues we backdated it. OpenTimestamps fixes that: at seal we submit the content
+-- hash to public OTS calendars, which fold it into a Bitcoin transaction. The
+-- resulting .ots proof shows the hash existed before a Bitcoin block — a timestamp
+-- nobody (not even us) can forge or backdate.
+--
+-- Proof lifecycle: PENDING (submitted, awaiting Bitcoin confirmation, still valid
+-- evidence — the anchor is fixed at submit) -> COMPLETE (Bitcoin attestation merged
+-- in, ots_upgraded_at + ots_block_height set). We store the .ots as base64 TEXT to
+-- avoid bytea binding quirks with the Neon serverless client.
+
+ALTER TABLE pitch_provenance
+  ADD COLUMN IF NOT EXISTS ots_proof        TEXT,         -- base64-encoded .ots file
+  ADD COLUMN IF NOT EXISTS ots_calendars    TEXT,         -- comma-separated calendars that accepted it
+  ADD COLUMN IF NOT EXISTS ots_submitted_at TIMESTAMPTZ,  -- when the digest was submitted
+  ADD COLUMN IF NOT EXISTS ots_upgraded_at  TIMESTAMPTZ,  -- when a Bitcoin attestation was confirmed
+  ADD COLUMN IF NOT EXISTS ots_block_height INTEGER;      -- Bitcoin block height (once complete)
+
+-- Lets the lazy-upgrade path cheaply find proofs still awaiting Bitcoin confirmation.
+CREATE INDEX IF NOT EXISTS pitch_provenance_ots_pending_idx
+  ON pitch_provenance (ots_submitted_at)
+  WHERE ots_proof IS NOT NULL AND ots_upgraded_at IS NULL;

--- a/src/services/__tests__/opentimestamps.test.ts
+++ b/src/services/__tests__/opentimestamps.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  createOtsForDigest, upgradeOts, hex, fromBase64, __testing,
+} from '../opentimestamps';
+
+const { applyOp, buildDetached, parseDetached, serializeTimestampBytes, collectPending, mergeTimestamp, anyBitcoin, OP_SHA256, OP_APPEND } = __testing;
+
+// Build a realistic tree: digest --append(nonce)--> --sha256--> [pending @ alice]
+async function makePendingTree() {
+  const digest = new Uint8Array(32).fill(1);
+  const nonce = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+  const m1 = await applyOp({ tag: OP_APPEND, arg: nonce }, digest);
+  const m2 = await applyOp({ tag: OP_SHA256 }, m1);
+  const uri = 'https://alice.btc.calendar.opentimestamps.org';
+  const pendingNode = { msg: m2, attestations: [{ kind: 'pending' as const, uri }], ops: [] };
+  const root = {
+    msg: digest, attestations: [], ops: [
+      { op: { tag: OP_APPEND, arg: nonce }, child: {
+        msg: m1, attestations: [], ops: [
+          { op: { tag: OP_SHA256 }, child: pendingNode },
+        ],
+      } },
+    ],
+  };
+  return { digest, root, pendingNode, commitment: m2, uri };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('OpenTimestamps binary codec', () => {
+  it('round-trips a detached .ots byte-for-byte', async () => {
+    const { digest, root } = await makePendingTree();
+    const bytes = buildDetached(digest, root);
+    const parsed = await parseDetached(bytes);
+    const rebuilt = buildDetached(parsed.digest, parsed.root);
+    expect(hex(rebuilt)).toBe(hex(bytes));            // exact round-trip
+    expect(hex(parsed.digest)).toBe(hex(digest));
+  });
+
+  it('locates the pending attestation and its commitment digest', async () => {
+    const { digest, root, commitment, uri } = await makePendingTree();
+    const parsed = await parseDetached(buildDetached(digest, root));
+    const pending = collectPending(parsed.root);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].uri).toBe(uri);
+    expect(hex(pending[0].commitment)).toBe(hex(commitment));  // ops were executed correctly
+    expect(anyBitcoin(parsed.root).found).toBe(false);
+  });
+
+  it('grafts a Bitcoin attestation onto a pending node', async () => {
+    const { digest, root, commitment } = await makePendingTree();
+    const parsed = await parseDetached(buildDetached(digest, root));
+    const node = collectPending(parsed.root)[0].node;
+    mergeTimestamp(node, { msg: commitment, attestations: [{ kind: 'bitcoin', height: 800123 }], ops: [] });
+    const btc = anyBitcoin(parsed.root);
+    expect(btc.found).toBe(true);
+    expect(btc.height).toBe(800123);
+    // survives a re-serialize → re-parse (the upgraded file is still well-formed)
+    const reparsed = await parseDetached(buildDetached(parsed.digest, parsed.root));
+    expect(anyBitcoin(reparsed.root).found).toBe(true);
+  });
+});
+
+describe('OpenTimestamps network glue', () => {
+  it('createOtsForDigest submits and returns a parseable pending proof', async () => {
+    const digest = new Uint8Array(32).fill(7);
+    const respBody = serializeTimestampBytes({ msg: digest, attestations: [{ kind: 'pending', uri: 'https://x' }], ops: [] });
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, arrayBuffer: async () => respBody.buffer })));
+
+    const out = await createOtsForDigest(hex(digest), ['https://x']);
+    expect(out).not.toBeNull();
+    expect(out!.calendars).toEqual(['https://x']);
+    const parsed = await parseDetached(fromBase64(out!.otsBase64));
+    expect(hex(parsed.digest)).toBe(hex(digest));
+    expect(collectPending(parsed.root)[0].uri).toBe('https://x');
+  });
+
+  it('createOtsForDigest returns null when every calendar fails', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false })));
+    expect(await createOtsForDigest('00'.repeat(32), ['https://x'])).toBeNull();
+  });
+
+  it('upgradeOts grafts a Bitcoin attestation from the calendar response', async () => {
+    const digest = new Uint8Array(32).fill(9);
+    const uri = 'https://cal.example';
+    // pending proof committed directly at the digest (uri = cal.example)
+    const pendingOts = buildDetached(digest, { msg: digest, attestations: [{ kind: 'pending', uri }], ops: [] });
+    const { toBase64 } = await import('../opentimestamps');
+    const pendingB64 = toBase64(pendingOts);
+
+    // calendar's /timestamp/<commitment> returns a Bitcoin attestation at the digest
+    const upgradeBody = serializeTimestampBytes({ msg: digest, attestations: [{ kind: 'bitcoin', height: 815000 }], ops: [] });
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      expect(url).toBe(`${uri}/timestamp/${hex(digest)}`);
+      return { ok: true, arrayBuffer: async () => upgradeBody.buffer };
+    }));
+
+    const res = await upgradeOts(pendingB64);
+    expect(res).not.toBeNull();
+    expect(res!.complete).toBe(true);
+    expect(res!.blockHeight).toBe(815000);
+  });
+
+  it('upgradeOts stays pending (complete:false) on 404', async () => {
+    const digest = new Uint8Array(32).fill(3);
+    const pendingOts = buildDetached(digest, { msg: digest, attestations: [{ kind: 'pending', uri: 'https://c' }], ops: [] });
+    const { toBase64 } = await import('../opentimestamps');
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false })));
+    const res = await upgradeOts(toBase64(pendingOts));
+    expect(res!.complete).toBe(false);
+  });
+});

--- a/src/services/email/index.ts
+++ b/src/services/email/index.ts
@@ -145,3 +145,71 @@ export async function sendNewPitchFromFollowedEmail(to: string, data: {
     subject: `${data.creatorName} published a new pitch: ${data.pitchTitle}`
   });
 }
+
+/**
+ * Send "Your pitch was sealed" provenance email. Doubles as an independent,
+ * third-party-dated record of the content hash (kept in the creator's inbox,
+ * outside our database) — the Phase-1 timestamp anchor for IP-theft evidence.
+ * Sent inline (not via a registered template) so it's fully self-contained.
+ * @param apiKey - Pass env.RESEND_API_KEY from Worker env
+ */
+export async function sendPitchSealedEmail(to: string, data: {
+  creatorName: string;
+  pitchTitle: string;
+  contentHash: string;
+  sealedAt: string;
+  verifyUrl: string;
+}, apiKey?: string) {
+  const service = getEmailService(apiKey);
+
+  const esc = (v: string) => String(v ?? '')
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  let sealedDate = data.sealedAt;
+  try {
+    sealedDate = new Date(data.sealedAt).toLocaleString('en-US', {
+      year: 'numeric', month: 'long', day: 'numeric',
+      hour: '2-digit', minute: '2-digit', timeZoneName: 'short',
+    });
+  } catch { /* keep raw */ }
+
+  const subject = `Your pitch "${data.pitchTitle}" is sealed — keep this email as proof`;
+  const html = `
+    <div style="font-family: system-ui, sans-serif; max-width: 560px; margin: 0 auto; color: #1a1a2e;">
+      <h2 style="color: #059669;">🛡️ Your pitch is sealed</h2>
+      <p>Hi ${esc(data.creatorName)},</p>
+      <p>The content of your pitch <strong>"${esc(data.pitchTitle)}"</strong> has been
+      cryptographically sealed (SHA-256) on Pitchey. This is your timestamped proof
+      that the idea existed in this form on this date.</p>
+      <p style="background:#f9fafb;border-left:3px solid #059669;padding:12px 16px;">
+        <strong>Sealed on:</strong> ${esc(sealedDate)}<br>
+        <strong>Content hash:</strong><br>
+        <code style="font-size:12px;word-break:break-all;">${esc(data.contentHash)}</code>
+      </p>
+      <p style="font-weight:bold;">Keep this email.</p>
+      <p>It is an independent, dated record of your seal held outside Pitchey's own
+      systems. If you ever need to prove authorship, this email plus your downloadable
+      Certificate of Provenance together establish priority of your idea.</p>
+      <p>Anyone can verify the seal at:<br>
+        <a href="${esc(data.verifyUrl)}">${esc(data.verifyUrl)}</a></p>
+      <p style="color:#6b7280;font-size:12px;">This is evidence of priority, not a
+      registration of copyright.</p>
+    </div>`;
+
+  const text = [
+    `Hi ${data.creatorName},`,
+    ``,
+    `Your pitch "${data.pitchTitle}" has been cryptographically sealed (SHA-256) on Pitchey.`,
+    ``,
+    `Sealed on: ${sealedDate}`,
+    `Content hash: ${data.contentHash}`,
+    ``,
+    `KEEP THIS EMAIL. It is an independent, dated record of your seal held outside`,
+    `Pitchey's systems. It helps establish priority of your idea if ever disputed.`,
+    ``,
+    `Verify the seal at: ${data.verifyUrl}`,
+    ``,
+    `This is evidence of priority, not a registration of copyright.`,
+  ].join('\n');
+
+  return await service.send({ to, subject, html, text }, { templateType: 'pitchSealed' });
+}

--- a/src/services/opentimestamps.ts
+++ b/src/services/opentimestamps.ts
@@ -1,0 +1,326 @@
+// Minimal, dependency-free OpenTimestamps client for Cloudflare Workers.
+//
+// Why hand-rolled: the `javascript-opentimestamps` npm package pulls bitcoinjs-lib
+// / tiny-secp256k1 (native/WASM) which do NOT bundle into a browser-target Worker.
+// We only need three things, and none of them require Bitcoin verification:
+//   1. SUBMIT a SHA-256 digest to public OTS calendars (establishes the anchor — the
+//      timestamp is fixed the moment the calendar accepts it and includes it in its
+//      next Bitcoin tx; everything after is just *retrieval*).
+//   2. BUILD a standard .ots detached-proof file from the calendar response(s).
+//   3. UPGRADE a pending proof to a complete (Bitcoin-attested) one once confirmed.
+// Independent verification is offloaded to standard tooling (the `ots` CLI or
+// https://opentimestamps.org) — we never reimplement Bitcoin consensus.
+//
+// Format references (python-opentimestamps): serialize.py (LEB128 varuint, varbytes),
+// timestamp.py (tree: 0xff = "another edge follows", 0x00 = attestation marker),
+// op.py (op tags), notary.py (attestation magics).
+
+// ---- constants ----------------------------------------------------------------
+
+// b'\x00OpenTimestamps\x00\x00Proof\x00\xbf\x89\xe2\xe8\x84\xe8\x92\x94' (31 bytes)
+const MAGIC = new Uint8Array([
+  0x00, 0x4f, 0x70, 0x65, 0x6e, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x73,
+  0x00, 0x00, 0x50, 0x72, 0x6f, 0x6f, 0x66, 0x00, 0xbf, 0x89, 0xe2, 0xe8, 0x84, 0xe8, 0x92, 0x94,
+]);
+
+const OP_SHA256 = 0x08;
+const OP_APPEND = 0xf0;
+const OP_PREPEND = 0xf1;
+const OP_REVERSE = 0xf2;
+const OP_HEXLIFY = 0xf3;
+
+const ATT_PENDING = new Uint8Array([0x83, 0xdf, 0xe3, 0x0d, 0x2e, 0xf9, 0x0c, 0x8e]);
+const ATT_BITCOIN = new Uint8Array([0x05, 0x88, 0x96, 0x0d, 0x73, 0xd7, 0x19, 0x01]);
+
+// Public calendars (the standard whitelist). We submit to all; we only need one to
+// survive to Bitcoin, but redundancy protects against any single calendar vanishing.
+export const DEFAULT_CALENDARS = [
+  'https://alice.btc.calendar.opentimestamps.org',
+  'https://bob.btc.calendar.opentimestamps.org',
+  'https://finney.calendar.opentimestamps.org',
+  'https://btc.calendar.catallaxy.com',
+];
+
+const ACCEPT = 'application/vnd.opentimestamps.v1';
+
+// ---- model --------------------------------------------------------------------
+
+type Attestation =
+  | { kind: 'pending'; uri: string }
+  | { kind: 'bitcoin'; height: number }
+  | { kind: 'unknown'; magic: Uint8Array; payload: Uint8Array };
+
+interface Op { tag: number; arg?: Uint8Array }
+
+interface Timestamp {
+  msg: Uint8Array;                              // message digest at this node
+  attestations: Attestation[];
+  ops: Array<{ op: Op; child: Timestamp }>;
+}
+
+// ---- byte helpers -------------------------------------------------------------
+
+class Reader {
+  pos = 0;
+  constructor(private buf: Uint8Array) {}
+  get remaining() { return this.buf.length - this.pos; }
+  byte(): number {
+    if (this.pos >= this.buf.length) throw new Error('OTS: unexpected end of stream');
+    return this.buf[this.pos++];
+  }
+  peek(): number { return this.buf[this.pos]; }
+  bytes(n: number): Uint8Array {
+    if (this.pos + n > this.buf.length) throw new Error('OTS: read past end');
+    return this.buf.slice(this.pos, (this.pos += n));
+  }
+  varuint(): number {
+    let result = 0, shift = 0, b: number;
+    do { b = this.byte(); result += (b & 0x7f) * 2 ** shift; shift += 7; } while (b & 0x80);
+    return result;
+  }
+  varbytes(): Uint8Array { return this.bytes(this.varuint()); }
+}
+
+function pushVaruint(out: number[], n: number) {
+  if (n === 0) { out.push(0); return; }
+  while (n > 0) { let b = n % 128; n = Math.floor(n / 128); if (n > 0) b |= 0x80; out.push(b); }
+}
+function pushVarbytes(out: number[], b: Uint8Array) { pushVaruint(out, b.length); out.push(...b); }
+
+function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const r = new Uint8Array(a.length + b.length); r.set(a); r.set(b, a.length); return r;
+}
+function eq(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+export function hex(b: Uint8Array): string {
+  return Array.from(b).map((x) => x.toString(16).padStart(2, '0')).join('');
+}
+function fromHex(s: string): Uint8Array {
+  const out = new Uint8Array(s.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(s.substr(i * 2, 2), 16);
+  return out;
+}
+export function toBase64(b: Uint8Array): string {
+  let s = ''; for (let i = 0; i < b.length; i++) s += String.fromCharCode(b[i]); return btoa(s);
+}
+export function fromBase64(s: string): Uint8Array {
+  const bin = atob(s); const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i); return out;
+}
+
+// ---- op execution -------------------------------------------------------------
+
+async function applyOp(op: Op, msg: Uint8Array): Promise<Uint8Array> {
+  switch (op.tag) {
+    case OP_APPEND: return concat(msg, op.arg!);
+    case OP_PREPEND: return concat(op.arg!, msg);
+    case OP_REVERSE: return msg.slice().reverse();
+    case OP_HEXLIFY: return new TextEncoder().encode(hex(msg));
+    case OP_SHA256: return new Uint8Array(await crypto.subtle.digest('SHA-256', msg));
+    // ripemd160 / sha1 aren't in WebCrypto; they don't appear on the calendar→Bitcoin
+    // path, so we abort the upgrade rather than guess (the pending proof is kept).
+    default: throw new Error(`OTS: unsupported op 0x${op.tag.toString(16)}`);
+  }
+}
+
+// ---- parse / serialize --------------------------------------------------------
+
+function readAttestation(r: Reader): Attestation {
+  const magic = r.bytes(8);
+  const payload = r.varbytes();
+  const pr = new Reader(payload);
+  if (eq(magic, ATT_PENDING)) return { kind: 'pending', uri: new TextDecoder().decode(pr.varbytes()) };
+  if (eq(magic, ATT_BITCOIN)) return { kind: 'bitcoin', height: pr.varuint() };
+  return { kind: 'unknown', magic, payload };
+}
+
+function writeAttestation(out: number[], att: Attestation) {
+  if (att.kind === 'pending') {
+    out.push(...ATT_PENDING);
+    const inner: number[] = []; pushVarbytes(inner, new TextEncoder().encode(att.uri));
+    pushVarbytes(out, new Uint8Array(inner));
+  } else if (att.kind === 'bitcoin') {
+    out.push(...ATT_BITCOIN);
+    const inner: number[] = []; pushVaruint(inner, att.height);
+    pushVarbytes(out, new Uint8Array(inner));
+  } else {
+    out.push(...att.magic); pushVarbytes(out, att.payload);
+  }
+}
+
+function readOp(r: Reader, tag: number): Op {
+  if (tag === OP_APPEND || tag === OP_PREPEND) return { tag, arg: r.varbytes() };
+  return { tag };
+}
+
+// Parse a Timestamp tree from the current reader position, given the message at this
+// node. async because computing each op's result digest may require SHA-256.
+async function parseTimestamp(r: Reader, msg: Uint8Array): Promise<Timestamp> {
+  const ts: Timestamp = { msg, attestations: [], ops: [] };
+  // Edges: every edge but the last is prefixed with 0xff. 0x00 marks an attestation
+  // edge; anything else is an op tag.
+  for (;;) {
+    let tag = r.byte();
+    const isLast = tag !== 0xff;
+    if (!isLast) tag = r.byte();      // consume the actual edge tag after 0xff
+    if (tag === 0x00) {
+      ts.attestations.push(readAttestation(r));
+    } else {
+      const op = readOp(r, tag);
+      const child = await parseTimestamp(r, await applyOp(op, msg));
+      ts.ops.push({ op, child });
+    }
+    if (isLast) break;
+  }
+  return ts;
+}
+
+function serializeTimestamp(out: number[], ts: Timestamp) {
+  const edges = ts.attestations.length + ts.ops.length;
+  if (edges === 0) throw new Error('OTS: empty timestamp');
+  let i = 0;
+  const writeEdge = (fn: () => void) => { if (i < edges - 1) out.push(0xff); fn(); i++; };
+  for (const att of ts.attestations) writeEdge(() => { out.push(0x00); writeAttestation(out, att); });
+  for (const { op, child } of ts.ops) writeEdge(() => {
+    out.push(op.tag);
+    if (op.arg) pushVarbytes(out, op.arg);
+    serializeTimestamp(out, child);
+  });
+}
+
+// Parse a full detached .ots file → digest + root timestamp.
+async function parseDetached(bytes: Uint8Array): Promise<{ digest: Uint8Array; root: Timestamp }> {
+  const r = new Reader(bytes);
+  if (!eq(r.bytes(MAGIC.length), MAGIC)) throw new Error('OTS: bad magic');
+  r.varuint();                                  // major version
+  const hashOp = r.byte();
+  if (hashOp !== OP_SHA256) throw new Error(`OTS: unexpected file hash op 0x${hashOp.toString(16)}`);
+  const digest = r.bytes(32);
+  const root = await parseTimestamp(r, digest);
+  return { digest, root };
+}
+
+function buildDetached(digest: Uint8Array, timestamp: Timestamp): Uint8Array {
+  const out: number[] = [...MAGIC, 0x01, OP_SHA256, ...digest];
+  serializeTimestamp(out, timestamp);
+  return new Uint8Array(out);
+}
+
+// Merge timestamp b into a (same msg). Union of attestations + ops; ops with the same
+// tag+arg are merged recursively. Used to combine multiple calendars' responses, and
+// to graft an upgrade response onto a pending node.
+function mergeTimestamp(a: Timestamp, b: Timestamp) {
+  for (const att of b.attestations) {
+    const dup = a.attestations.some((x) =>
+      (x.kind === 'pending' && att.kind === 'pending' && x.uri === att.uri) ||
+      (x.kind === 'bitcoin' && att.kind === 'bitcoin' && x.height === att.height));
+    if (!dup) a.attestations.push(att);
+  }
+  for (const be of b.ops) {
+    const match = a.ops.find((ae) =>
+      ae.op.tag === be.op.tag &&
+      ((!ae.op.arg && !be.op.arg) || (ae.op.arg && be.op.arg && eq(ae.op.arg, be.op.arg))));
+    if (match) mergeTimestamp(match.child, be.child);
+    else a.ops.push(be);
+  }
+}
+
+function anyBitcoin(ts: Timestamp): { found: boolean; height?: number } {
+  for (const att of ts.attestations) if (att.kind === 'bitcoin') return { found: true, height: att.height };
+  for (const { child } of ts.ops) { const r = anyBitcoin(child); if (r.found) return r; }
+  return { found: false };
+}
+
+// Collect every pending attestation with the digest committed at that node.
+function collectPending(ts: Timestamp, out: Array<{ uri: string; commitment: Uint8Array; node: Timestamp }> = []) {
+  for (const att of ts.attestations) if (att.kind === 'pending') out.push({ uri: att.uri, commitment: ts.msg, node: ts });
+  for (const { child } of ts.ops) collectPending(child, out);
+  return out;
+}
+
+// ---- network ------------------------------------------------------------------
+
+async function submitDigest(calendar: string, digest: Uint8Array): Promise<Timestamp | null> {
+  try {
+    const res = await fetch(`${calendar.replace(/\/+$/, '')}/digest`, {
+      method: 'POST',
+      headers: { 'Accept': ACCEPT, 'Content-Type': 'application/octet-stream' },
+      body: digest,
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!res.ok) return null;
+    const body = new Uint8Array(await res.arrayBuffer());
+    return await parseTimestamp(new Reader(body), digest);
+  } catch (err) {
+    console.error(`OTS submit ${calendar} failed:`, err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}
+
+// ---- public API ---------------------------------------------------------------
+
+// Submit a SHA-256 digest (hex) to the calendars and return a pending .ots file
+// (base64) plus the calendars that accepted it. Returns null if every calendar fails.
+export async function createOtsForDigest(
+  digestHex: string,
+  calendars: string[] = DEFAULT_CALENDARS,
+): Promise<{ otsBase64: string; calendars: string[] } | null> {
+  const digest = fromHex(digestHex);
+  if (digest.length !== 32) return null;
+
+  const results = await Promise.all(calendars.map((c) => submitDigest(c, digest)));
+  let root: Timestamp | null = null;
+  const accepted: string[] = [];
+  results.forEach((ts, i) => {
+    if (!ts) return;
+    accepted.push(calendars[i]);
+    if (!root) root = ts; else mergeTimestamp(root, ts);
+  });
+  if (!root) return null;
+  return { otsBase64: toBase64(buildDetached(digest, root)), calendars: accepted };
+}
+
+// Try to upgrade a pending proof to a Bitcoin-attested one. Contacts each pending
+// calendar's /timestamp/<commitment> endpoint and grafts any returned (Bitcoin) path.
+// Returns the (possibly unchanged) proof + whether it now carries a Bitcoin attestation.
+// Never throws — on any failure the original proof is returned unchanged.
+export async function upgradeOts(
+  otsBase64: string,
+): Promise<{ otsBase64: string; complete: boolean; blockHeight?: number } | null> {
+  try {
+    const { digest, root } = await parseDetached(fromBase64(otsBase64));
+    let changed = false;
+
+    for (const p of collectPending(root)) {
+      try {
+        const url = `${p.uri.replace(/\/+$/, '')}/timestamp/${hex(p.commitment)}`;
+        const res = await fetch(url, { headers: { 'Accept': ACCEPT }, signal: AbortSignal.timeout(8000) });
+        if (!res.ok) continue;                  // 404 = not anchored yet
+        const body = new Uint8Array(await res.arrayBuffer());
+        const upgraded = await parseTimestamp(new Reader(body), p.commitment);
+        mergeTimestamp(p.node, upgraded);       // graft Bitcoin path onto the node
+        changed = true;
+      } catch { /* skip this calendar, keep others */ }
+    }
+
+    const btc = anyBitcoin(root);
+    if (!changed && !btc.found) return { otsBase64, complete: false };
+    return { otsBase64: toBase64(buildDetached(digest, root)), complete: btc.found, blockHeight: btc.height };
+  } catch (err) {
+    console.error('OTS upgrade failed:', err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}
+
+// Internals exposed for unit tests only — not part of the public API.
+function serializeTimestampBytes(ts: Timestamp): Uint8Array {
+  const o: number[] = []; serializeTimestamp(o, ts); return new Uint8Array(o);
+}
+export const __testing = {
+  applyOp, buildDetached, parseDetached, parseTimestamp, serializeTimestampBytes,
+  collectPending, mergeTimestamp, anyBitcoin, Reader, eq,
+  OP_SHA256, OP_APPEND,
+};

--- a/src/services/pitch-provenance.ts
+++ b/src/services/pitch-provenance.ts
@@ -38,10 +38,22 @@ function canonical(p: Record<string, unknown>): string {
   });
 }
 
+// Result of a seal attempt. `isNew` is true only when a NEW content_hash row was
+// actually inserted (i.e. first publish, or content changed since the last seal) —
+// callers use it to fire the "your pitch was sealed" email exactly once per seal,
+// never on a no-op re-publish of identical content. Null is returned on error
+// (sealing must never throw / never break publishing).
+export interface SealResult {
+  isNew: boolean;
+  hash: string;
+  sealedAt: string | null;
+  version: number;
+}
+
 // Seal a pitch's current content. Idempotent (identical content never duplicates;
 // changed content adds a new version row). Only seals PUBLISHED pitches. NEVER
 // throws — provenance must never break publishing.
-export async function sealPitchProvenance(sql: Sql, pitchId: number | string): Promise<void> {
+export async function sealPitchProvenance(sql: Sql, pitchId: number | string): Promise<SealResult | null> {
   try {
     const rows = await sql`
       SELECT id, user_id, title, logline, short_synopsis, long_synopsis, synopsis,
@@ -49,7 +61,7 @@ export async function sealPitchProvenance(sql: Sql, pitchId: number | string): P
       FROM pitches WHERE id = ${pitchId}
     `;
     const p = rows[0];
-    if (!p || p.status !== 'published') return;
+    if (!p || p.status !== 'published') return null;
 
     const hash = await sha256Hex(canonical(p));
 
@@ -65,14 +77,28 @@ export async function sealPitchProvenance(sql: Sql, pitchId: number | string): P
     `;
     const version = (Number(verRows[0]?.n) || 0) + 1;
 
-    await sql`
+    const inserted = await sql`
       INSERT INTO pitch_provenance
         (pitch_id, creator_id, content_hash, algorithm, content_version, prev_hash, sealed_at)
       VALUES (${pitchId}, ${p.user_id}, ${hash}, 'sha256', ${version}, ${prevHash}, NOW())
       ON CONFLICT (content_hash) DO NOTHING
+      RETURNING sealed_at, content_version
     `;
+
+    // A returned row means a brand-new seal was written; empty means the identical
+    // content was already sealed (ON CONFLICT no-op) — not a new seal, no email.
+    if (inserted.length > 0) {
+      return {
+        isNew: true,
+        hash,
+        sealedAt: inserted[0].sealed_at as string,
+        version: Number(inserted[0].content_version),
+      };
+    }
+    return { isNew: false, hash, sealedAt: null, version };
   } catch (err) {
     console.error('sealPitchProvenance error:', err instanceof Error ? err.message : String(err));
+    return null;
   }
 }
 
@@ -128,4 +154,357 @@ export async function verifyProvenanceByHash(sql: Sql, hash: string): Promise<{
     console.error('verifyProvenanceByHash error:', err instanceof Error ? err.message : String(err));
     return { sealed: false };
   }
+}
+
+// ---------------------------------------------------------------------------
+// Certificate of Provenance — the downloadable evidence artifact.
+//
+// Unlike the PUBLIC verify endpoint (date+creator+title only), the certificate is
+// OWNER-ONLY and content-INCLUSIVE: it embeds the exact sealed content alongside
+// its hash, timestamp and chain, so the single document is self-contained proof of
+// "this material existed on Pitchey on this date." The caller MUST enforce that the
+// requester owns the pitch before rendering (the data includes user_id for that).
+// ---------------------------------------------------------------------------
+
+export interface CertificateData {
+  pitch: {
+    id: number; user_id: number; title: string; logline: string;
+    short_synopsis: string; long_synopsis: string; synopsis: string;
+    genre: string; format: string; themes: string; budget: string;
+  };
+  creator: { username: string; name: string; email: string };
+  firstSealedAt: string;          // earliest seal = priority-of-idea date
+  latestHash: string;
+  latestSealedAt: string;
+  versions: Array<{ version: number; hash: string; sealed_at: string; prev_hash: string | null }>;
+  currentHash: string;            // hash of the pitch's content right now
+  contentMatchesSeal: boolean;    // currentHash === latestHash (content unchanged since seal)
+  ots: {
+    status: 'none' | 'pending' | 'complete';  // OpenTimestamps / Bitcoin anchor state
+    submittedAt: string | null;
+    upgradedAt: string | null;
+    blockHeight: number | null;
+    calendars: string | null;
+  };
+}
+
+// Fetch everything needed to render a certificate. Returns null if the pitch
+// doesn't exist or was never sealed. Owner check is the CALLER's responsibility.
+export async function getCertificateData(sql: Sql, pitchId: number | string): Promise<CertificateData | null> {
+  try {
+    const rows = await sql`
+      SELECT p.id, p.user_id, p.title, p.logline, p.short_synopsis, p.long_synopsis,
+             p.synopsis, p.genre, p.format, p.themes, p.budget,
+             u.username, u.name AS creator_name, u.email AS creator_email
+      FROM pitches p JOIN users u ON u.id = p.user_id
+      WHERE p.id = ${pitchId}
+    `;
+    const p = rows[0];
+    if (!p) return null;
+
+    const seals = await sql`
+      SELECT content_hash, content_version, prev_hash, sealed_at,
+             ots_proof, ots_calendars, ots_submitted_at, ots_upgraded_at, ots_block_height
+      FROM pitch_provenance WHERE pitch_id = ${pitchId}
+      ORDER BY content_version ASC
+    `;
+    if (!seals.length) return null;
+
+    const latest = seals[seals.length - 1];
+    const otsStatus: 'none' | 'pending' | 'complete' =
+      latest.ots_upgraded_at ? 'complete' : (latest.ots_proof ? 'pending' : 'none');
+    // canonical() reads p.id/p.user_id/title/... — all present on the joined row.
+    const currentHash = await sha256Hex(canonical(p));
+
+    return {
+      pitch: {
+        id: Number(p.id), user_id: Number(p.user_id),
+        title: p.title ?? '', logline: p.logline ?? '',
+        short_synopsis: p.short_synopsis ?? '', long_synopsis: p.long_synopsis ?? '',
+        synopsis: p.synopsis ?? '', genre: p.genre ?? '', format: p.format ?? '',
+        themes: typeof p.themes === 'object' ? JSON.stringify(p.themes) : (p.themes ?? ''),
+        budget: p.budget ?? '',
+      },
+      creator: {
+        username: p.username ?? '', name: p.creator_name ?? '', email: p.creator_email ?? '',
+      },
+      firstSealedAt: seals[0].sealed_at as string,
+      latestHash: latest.content_hash as string,
+      latestSealedAt: latest.sealed_at as string,
+      versions: seals.map((s: Record<string, unknown>) => ({
+        version: Number(s.content_version),
+        hash: s.content_hash as string,
+        sealed_at: s.sealed_at as string,
+        prev_hash: (s.prev_hash as string | null) ?? null,
+      })),
+      currentHash,
+      contentMatchesSeal: currentHash === (latest.content_hash as string),
+      ots: {
+        status: otsStatus,
+        submittedAt: (latest.ots_submitted_at as string | null) ?? null,
+        upgradedAt: (latest.ots_upgraded_at as string | null) ?? null,
+        blockHeight: latest.ots_block_height != null ? Number(latest.ots_block_height) : null,
+        calendars: (latest.ots_calendars as string | null) ?? null,
+      },
+    };
+  } catch (err) {
+    console.error('getCertificateData error:', err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}
+
+// Submit a freshly-sealed content hash to the OpenTimestamps calendars and store the
+// pending .ots proof. Best-effort; never throws (must not break publishing). Only
+// fills a row that has no proof yet (idempotent on re-publish).
+export async function submitProvenanceToOts(sql: Sql, contentHash: string): Promise<void> {
+  try {
+    const { createOtsForDigest } = await import('./opentimestamps');
+    const out = await createOtsForDigest(contentHash);
+    if (!out) return;
+    await sql`
+      UPDATE pitch_provenance
+      SET ots_proof = ${out.otsBase64}, ots_calendars = ${out.calendars.join(',')}, ots_submitted_at = NOW()
+      WHERE content_hash = ${contentHash} AND ots_proof IS NULL
+    `;
+  } catch (err) {
+    console.error('submitProvenanceToOts error:', err instanceof Error ? err.message : String(err));
+  }
+}
+
+// Lazily upgrade a pending proof to a Bitcoin-attested one. Called on certificate /
+// .ots download. No-op until the proof is >1h old (Bitcoin confirmation takes hours)
+// and until a calendar actually returns the attestation. Best-effort; never throws.
+export async function maybeUpgradeProvenanceOts(sql: Sql, contentHash: string): Promise<void> {
+  try {
+    const rows = await sql`
+      SELECT ots_proof, ots_submitted_at FROM pitch_provenance
+      WHERE content_hash = ${contentHash} AND ots_proof IS NOT NULL AND ots_upgraded_at IS NULL
+      LIMIT 1
+    `;
+    const row = rows[0];
+    if (!row?.ots_proof) return;
+    if (row.ots_submitted_at) {
+      const ageMs = Date.now() - new Date(row.ots_submitted_at as string).getTime();
+      if (ageMs < 60 * 60 * 1000) return;          // < 1h: Bitcoin not confirmed yet
+    }
+    const { upgradeOts } = await import('./opentimestamps');
+    const up = await upgradeOts(row.ots_proof as string);
+    if (up?.complete) {
+      await sql`
+        UPDATE pitch_provenance
+        SET ots_proof = ${up.otsBase64}, ots_upgraded_at = NOW(), ots_block_height = ${up.blockHeight ?? null}
+        WHERE content_hash = ${contentHash}
+      `;
+    }
+  } catch (err) {
+    console.error('maybeUpgradeProvenanceOts error:', err instanceof Error ? err.message : String(err));
+  }
+}
+
+// Cron sweep (hourly): submit any seals that lack a proof, and upgrade pending proofs
+// older than 1h. Decouples the slow calendar round-trips from the publish path. Best-
+// effort and bounded (LIMIT) so a backlog can't blow the cron budget; the next run
+// picks up the rest. Creates its own Neon client from env (cron has no request db).
+export async function sweepProvenanceOts(env: any): Promise<{ submitted: number; upgraded: number }> {
+  const url = env?.DATABASE_URL;
+  if (!url) return { submitted: 0, upgraded: 0 };
+  const { neon } = await import('@neondatabase/serverless');
+  const sql = neon(url) as unknown as Sql;
+  let submitted = 0, upgraded = 0;
+  try {
+    const toSubmit = await sql`
+      SELECT content_hash FROM pitch_provenance
+      WHERE ots_proof IS NULL ORDER BY sealed_at DESC LIMIT 20
+    `;
+    for (const r of toSubmit) { await submitProvenanceToOts(sql, r.content_hash as string); submitted++; }
+
+    const toUpgrade = await sql`
+      SELECT content_hash FROM pitch_provenance
+      WHERE ots_proof IS NOT NULL AND ots_upgraded_at IS NULL
+        AND ots_submitted_at < NOW() - INTERVAL '1 hour'
+      ORDER BY ots_submitted_at ASC LIMIT 20
+    `;
+    for (const r of toUpgrade) { await maybeUpgradeProvenanceOts(sql, r.content_hash as string); upgraded++; }
+  } catch (err) {
+    console.error('sweepProvenanceOts error:', err instanceof Error ? err.message : String(err));
+  }
+  return { submitted, upgraded };
+}
+
+// Fetch the raw .ots proof for download. Returns ownerId for the caller's owner check.
+export async function getProvenanceOts(
+  sql: Sql, pitchId: number | string,
+): Promise<{ ownerId: number; otsBase64: string; hash: string } | null> {
+  try {
+    const rows = await sql`
+      SELECT pr.creator_id, pr.ots_proof, pr.content_hash
+      FROM pitch_provenance pr
+      WHERE pr.pitch_id = ${pitchId} AND pr.ots_proof IS NOT NULL
+      ORDER BY pr.content_version DESC LIMIT 1
+    `;
+    const r = rows[0];
+    if (!r?.ots_proof) return null;
+    return { ownerId: Number(r.creator_id), otsBase64: r.ots_proof as string, hash: r.content_hash as string };
+  } catch (err) {
+    console.error('getProvenanceOts error:', err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}
+
+function esc(v: unknown): string {
+  return String(v ?? '')
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+function fmtDate(v: string | null): string {
+  if (!v) return '—';
+  try {
+    return new Date(v).toLocaleString('en-US', {
+      year: 'numeric', month: 'long', day: 'numeric',
+      hour: '2-digit', minute: '2-digit', timeZoneName: 'short',
+    });
+  } catch { return String(v); }
+}
+
+// Render the certificate as a self-contained, print-optimized HTML page. Workers
+// can't produce a real PDF (see nda-pdf.service.ts) — the page carries a "Save as
+// PDF" button that triggers the browser's print-to-PDF. `verifyBaseUrl` is the
+// public frontend origin so the printed QR/text link resolves for third parties.
+export function renderCertificateHTML(data: CertificateData, opts: { verifyBaseUrl: string }): string {
+  const base = (opts.verifyBaseUrl || '').replace(/\/+$/, '');
+  const verifyUrl = `${base}/verify/p/${data.latestHash}`;
+  const creatorLabel = data.creator.name?.trim()
+    ? `${esc(data.creator.name)} (@${esc(data.creator.username)})`
+    : `@${esc(data.creator.username)}`;
+
+  const contentRow = (label: string, value: string) => value && value.trim()
+    ? `<div class="field"><div class="label">${esc(label)}</div><div class="value">${esc(value)}</div></div>`
+    : '';
+
+  const historyRows = data.versions.map((v) => `
+    <tr>
+      <td>v${v.version}</td>
+      <td>${esc(fmtDate(v.sealed_at))}</td>
+      <td class="mono">${esc(v.hash)}</td>
+    </tr>`).join('');
+
+  const integrity = data.contentMatchesSeal
+    ? `<span class="ok">✓ The pitch content is UNCHANGED since it was sealed.</span>`
+    : `<span class="warn">⚠ The pitch content has been edited since the latest seal below. The content shown here corresponds to hash <span class="mono">${esc(data.currentHash)}</span>.</span>`;
+
+  const otsBlock = (() => {
+    if (data.ots.status === 'complete') {
+      return `<div class="seal-box" style="border-color:#a7f3d0;background:#f0fdf4;">
+        <div class="field"><div class="value"><span class="ok">✓ Independently anchored to the Bitcoin blockchain.</span></div></div>
+        ${data.ots.blockHeight ? `<div class="field"><div class="label">Bitcoin block</div><div class="value">#${esc(String(data.ots.blockHeight))}</div></div>` : ''}
+        <div class="field"><div class="label">Confirmed</div><div class="value">${esc(fmtDate(data.ots.upgradedAt))}</div></div>
+        <p style="font-size:12px;color:var(--muted);margin:6px 0 0;">The content hash above is embedded in the Bitcoin blockchain, proving it existed before this block. No party — including Pitchey — can backdate or forge this timestamp.</p>
+        <p style="font-size:13px;margin:8px 0 0;"><a href="/api/pitches/${data.pitch.id}/provenance.ots">Download the machine-verifiable .ots proof file</a></p>
+      </div>`;
+    }
+    if (data.ots.status === 'pending') {
+      return `<div class="seal-box">
+        <div class="field"><div class="value">⏳ Submitted to the OpenTimestamps calendars on <strong>${esc(fmtDate(data.ots.submittedAt))}</strong> — awaiting Bitcoin confirmation (typically a few hours).</div></div>
+        <p style="font-size:12px;color:var(--muted);margin:6px 0 0;">Once confirmed, this seal is provable against the Bitcoin blockchain independently of Pitchey. The .ots proof file can also be verified now with standard OpenTimestamps tooling.</p>
+        <p style="font-size:13px;margin:8px 0 0;"><a href="/api/pitches/${data.pitch.id}/provenance.ots">Download the .ots proof file</a></p>
+      </div>`;
+    }
+    return '';
+  })();
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Certificate of Provenance — ${esc(data.pitch.title)}</title>
+<style>
+  :root { --ink:#1a1a2e; --muted:#6b7280; --line:#e5e7eb; --accent:#059669; }
+  * { box-sizing: border-box; }
+  body { font-family: Georgia, 'Times New Roman', serif; color: var(--ink);
+         max-width: 800px; margin: 0 auto; padding: 48px 40px; line-height: 1.55;
+         background: #fff; }
+  .toolbar { text-align: right; margin-bottom: 24px; }
+  .toolbar button { font-family: system-ui, sans-serif; font-size: 14px; cursor: pointer;
+    background: var(--accent); color: #fff; border: 0; border-radius: 8px;
+    padding: 10px 18px; }
+  header { text-align: center; border-bottom: 3px double var(--ink); padding-bottom: 20px; margin-bottom: 28px; }
+  header .crest { font-size: 13px; letter-spacing: 3px; text-transform: uppercase; color: var(--muted); }
+  header h1 { font-size: 28px; margin: 8px 0 4px; }
+  header .sub { color: var(--muted); font-size: 14px; }
+  .statement { font-size: 15px; background: #f9fafb; border-left: 3px solid var(--accent);
+    padding: 14px 18px; margin: 0 0 28px; }
+  h2 { font-size: 13px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--muted);
+    border-bottom: 1px solid var(--line); padding-bottom: 6px; margin: 28px 0 14px; }
+  .field { margin-bottom: 12px; }
+  .field .label { font-size: 11px; letter-spacing: 1px; text-transform: uppercase; color: var(--muted); }
+  .field .value { font-size: 16px; white-space: pre-wrap; }
+  .mono { font-family: ui-monospace, 'SFMono-Regular', Menlo, monospace; font-size: 12px; word-break: break-all; }
+  .seal-box { border: 1px solid var(--line); border-radius: 10px; padding: 18px 20px; background: #fafdfb; }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; }
+  th, td { text-align: left; padding: 8px 6px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { font-family: system-ui, sans-serif; font-size: 10px; letter-spacing: 1px; text-transform: uppercase; color: var(--muted); }
+  .ok { color: var(--accent); font-weight: bold; }
+  .warn { color: #b45309; font-weight: bold; }
+  .verify { text-align: center; margin: 28px 0; padding: 16px; border: 1px dashed var(--line); border-radius: 10px; }
+  .verify a { color: #2563eb; }
+  footer { margin-top: 36px; padding-top: 16px; border-top: 1px solid var(--line);
+    font-size: 11px; color: var(--muted); text-align: center; }
+  @media print { .toolbar { display: none; } body { padding: 0; } }
+</style>
+</head>
+<body>
+  <div class="toolbar"><button onclick="window.print()">Save as PDF / Print</button></div>
+
+  <header>
+    <div class="crest">Pitchey · Content Provenance</div>
+    <h1>Certificate of Provenance</h1>
+    <div class="sub">Tamper-evident proof of authorship and priority of idea</div>
+  </header>
+
+  <p class="statement">
+    This certifies that the creative material described below was recorded on the
+    Pitchey platform and cryptographically sealed (SHA-256) on
+    <strong>${esc(fmtDate(data.firstSealedAt))}</strong>. The seal establishes that
+    this content existed in this form on that date. ${integrity}
+  </p>
+
+  <h2>Creator</h2>
+  <div class="field"><div class="value">${creatorLabel}</div></div>
+
+  <h2>Sealed Work</h2>
+  ${contentRow('Title', data.pitch.title)}
+  ${contentRow('Logline', data.pitch.logline)}
+  ${contentRow('Genre', data.pitch.genre)}
+  ${contentRow('Format', data.pitch.format)}
+  ${contentRow('Themes', data.pitch.themes)}
+  ${contentRow('Short Synopsis', data.pitch.short_synopsis)}
+  ${contentRow('Synopsis', data.pitch.long_synopsis || data.pitch.synopsis)}
+
+  <h2>Cryptographic Seal</h2>
+  <div class="seal-box">
+    <div class="field"><div class="label">Content hash (SHA-256)</div><div class="value mono">${esc(data.latestHash)}</div></div>
+    <div class="field"><div class="label">First sealed</div><div class="value">${esc(fmtDate(data.firstSealedAt))}</div></div>
+    <div class="field"><div class="label">Latest seal</div><div class="value">${esc(fmtDate(data.latestSealedAt))}</div></div>
+  </div>
+
+  ${otsBlock ? `<h2>Independent Timestamp (OpenTimestamps · Bitcoin)</h2>${otsBlock}` : ''}
+
+  ${data.versions.length > 1 ? `<h2>Seal History (tamper-evident chain)</h2>
+  <table><thead><tr><th>Version</th><th>Sealed</th><th>Content hash</th></tr></thead>
+  <tbody>${historyRows}</tbody></table>` : ''}
+
+  <div class="verify">
+    Anyone can independently verify this seal at<br>
+    <a href="${esc(verifyUrl)}">${esc(verifyUrl)}</a>
+  </div>
+
+  <footer>
+    Generated by Pitchey for pitch #${data.pitch.id}. The hash is computed over the
+    substantive content (title, logline, synopses, genre, format, themes, budget).
+    This certificate is evidence of priority; it is not a registration of copyright.
+  </footer>
+</body>
+</html>`;
 }

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -2736,6 +2736,80 @@ class RouteRegistry {
       });
     });
 
+    // Downloadable Certificate of Provenance — OWNER-ONLY, content-inclusive HTML
+    // the creator can save/print as evidence of authorship. Distinct from the public
+    // verify endpoint above (which never exposes content). Returns text/html so the
+    // browser renders it directly with a "Save as PDF" button.
+    this.register('GET', '/api/pitches/:id/certificate', async (req) => {
+      const authResult = await this.requirePortalAuth(req, ['creator', 'production']);
+      if (!authResult.authorized) return authResult.response!;
+      const userId = (authResult.user as any).id;
+
+      const parts = new URL(req.url).pathname.split('/');
+      const pitchId = parts[parts.indexOf('pitches') + 1];
+
+      const sql = this.db.getSql() as any;
+      const { getCertificateData, renderCertificateHTML, maybeUpgradeProvenanceOts } = await import('./services/pitch-provenance');
+      let data = await getCertificateData(sql, pitchId);
+      if (!data) {
+        return new Response('No provenance certificate is available for this pitch yet.', { status: 404 });
+      }
+      // Owner-only: the certificate embeds protected content.
+      if (String(data.pitch.user_id) !== String(userId)) {
+        return new Response('Only the pitch owner can download its certificate.', { status: 403 });
+      }
+      // Best-effort: if the OTS proof is still pending, try an upgrade now so the
+      // creator sees a fresh "Bitcoin-anchored" status (no-op if <1h old).
+      if (data.ots.status === 'pending') {
+        try {
+          await maybeUpgradeProvenanceOts(sql, data.latestHash);
+          data = (await getCertificateData(sql, pitchId)) || data;
+        } catch { /* keep the pending view */ }
+      }
+
+      const verifyBaseUrl = this.env.FRONTEND_URL || 'https://pitchey-5o8.pages.dev';
+      const html = renderCertificateHTML(data, { verifyBaseUrl });
+      return new Response(html, {
+        status: 200,
+        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+      });
+    });
+
+    // Download the raw .ots proof file (owner-only) — the machine-verifiable artifact
+    // that anyone can check against the Bitcoin blockchain with standard OpenTimestamps
+    // tooling. Triggers a best-effort upgrade first so the file is as complete as possible.
+    this.register('GET', '/api/pitches/:id/provenance.ots', async (req) => {
+      const authResult = await this.requirePortalAuth(req, ['creator', 'production']);
+      if (!authResult.authorized) return authResult.response!;
+      const userId = (authResult.user as any).id;
+
+      const parts = new URL(req.url).pathname.split('/');
+      const pitchId = parts[parts.indexOf('pitches') + 1];
+
+      const sql = this.db.getSql() as any;
+      const { getProvenanceOts, maybeUpgradeProvenanceOts } = await import('./services/pitch-provenance');
+      let rec = await getProvenanceOts(sql, pitchId);
+      if (!rec) {
+        return new Response('No OpenTimestamps proof is available for this pitch yet.', { status: 404 });
+      }
+      if (String(rec.ownerId) !== String(userId)) {
+        return new Response('Only the pitch owner can download its proof.', { status: 403 });
+      }
+      try {
+        await maybeUpgradeProvenanceOts(sql, rec.hash);
+        rec = (await getProvenanceOts(sql, pitchId)) || rec;
+      } catch { /* serve whatever we have */ }
+
+      const { fromBase64 } = await import('./services/opentimestamps');
+      return new Response(fromBase64(rec.otsBase64), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          'Content-Disposition': `attachment; filename="pitch-${pitchId}.ots"`,
+        },
+      });
+    });
+
     this.register('POST', '/api/pitches/:id/publish', async (req) => {
       // Publishing is the paywall: watchers (user_type='viewer') can create
       // drafts but must upgrade to a Creator account to publish. The VIEWER
@@ -2757,11 +2831,35 @@ class RouteRegistry {
         // idea existed on Pitchey at this date (the creator's priority-of-idea
         // artifact). Fire-and-forget; sealPitchProvenance never throws.
         try {
-          const sealBody = await response.clone().json() as { data?: { pitch?: { id: number } } };
+          const sealBody = await response.clone().json() as { data?: { pitch?: { id: number; title?: string } } };
           const sealedPitchId = sealBody?.data?.pitch?.id;
           if (sealedPitchId) {
             const { sealPitchProvenance } = await import('./services/pitch-provenance');
-            await sealPitchProvenance(this.db.getSql() as any, sealedPitchId);
+            const seal = await sealPitchProvenance(this.db.getSql() as any, sealedPitchId);
+
+            // Email the creator their seal — exactly once per NEW seal. Besides
+            // notifying them, this lodges an independently-dated copy of the hash in
+            // their inbox (Phase-1 anchor: a third-party timestamp outside our DB).
+            // Best-effort; must never block or fail publishing.
+            if (seal?.isNew && this.env.RESEND_API_KEY) {
+              try {
+                const [creator] = await this.db.query(
+                  'SELECT email, name FROM users WHERE id = (SELECT user_id FROM pitches WHERE id = $1)',
+                  [sealedPitchId]
+                ) as { email?: string; name?: string }[];
+                if (creator?.email) {
+                  const frontend = this.env.FRONTEND_URL || 'https://pitchey-5o8.pages.dev';
+                  const { sendPitchSealedEmail } = await import('./services/email');
+                  await sendPitchSealedEmail(creator.email, {
+                    creatorName: creator.name || 'there',
+                    pitchTitle: sealBody?.data?.pitch?.title || 'your pitch',
+                    contentHash: seal.hash,
+                    sealedAt: seal.sealedAt || new Date().toISOString(),
+                    verifyUrl: `${frontend}/verify/p/${seal.hash}`,
+                  }, this.env.RESEND_API_KEY);
+                }
+              } catch (e) { console.error('pitch-sealed email failed (non-fatal):', e); }
+            }
           }
         } catch (e) { console.error('provenance seal on publish failed:', e); }
 
@@ -22010,7 +22108,15 @@ const websocketSafeHandler = {
           break;
 
         case "0 * * * *": // Hourly
-          await checkMoneyPathSLOs(env, ctx);
+          await Promise.all([
+            checkMoneyPathSLOs(env, ctx),
+            // Provenance OpenTimestamps anchor: submit new seals to the OTS calendars
+            // and upgrade pending proofs once Bitcoin confirms. Decoupled from publish.
+            (async () => {
+              const { sweepProvenanceOts } = await import('./services/pitch-provenance');
+              await sweepProvenanceOts(env);
+            })(),
+          ]);
           break;
 
         case "0 0 * * *": // Daily


### PR DESCRIPTION
## Why
Karl: *if a pitch is stolen, the creator needs a date+stamp and a document that supports an IP-theft claim.* The existing "Sealed [date]" seal gives the date+stamp; this turns it into evidence a creator can present, and adds a timestamp that isn't on our own clock.

## Phase 1 — Certificate + email-at-seal (anchor A)
- `sealPitchProvenance` returns `SealResult{isNew,...}` (`INSERT…RETURNING`) → email fires exactly once per genuinely new seal, never on a no-op re-publish.
- `getCertificateData` + `renderCertificateHTML`: **owner-only, content-inclusive** printable HTML certificate (Workers can't render PDF → browser print-to-PDF, same precedent as `nda-pdf.service.ts`).
- `GET /api/pitches/:id/certificate` (auth, owner-only).
- `sendPitchSealedEmail` — also lodges an independently-dated copy of the hash in the creator's inbox (a record outside our DB).
- `PitchDetail`: owner-only **Certificate** button beside `SealBadge`.

## Phase 2 — OpenTimestamps (anchor B, Bitcoin)
- `src/services/opentimestamps.ts` — **dependency-free** OTS client (the npm lib pulls bitcoinjs/secp256k1 which won't bundle into a browser-target Worker). Full `.ots` binary codec, submit-to-calendars, pending→Bitcoin upgrade. **7 unit tests** (round-trip byte-identity, commitment math, graft, network glue). Bitcoin verification offloaded to standard `ots` tooling.
- **migration 113**: OTS columns + partial index on `pitch_provenance`. Verified on a Neon branch (applies + idempotent).
- Submit **decoupled from publish**: hourly cron `sweepProvenanceOts` (submit ≤20 new, upgrade ≤20 pending >1h old) + best-effort lazy upgrade on certificate/`.ots` view.
- `GET /api/pitches/:id/provenance.ots` (owner-only) — machine-verifiable proof file.
- No new secrets (calendars are public).

## Verification
- `tsc` clean · worker bundles · catch-swallow gate clean (0 untagged)
- OTS codec: **7/7** unit tests
- Migration 113 + real `getCertificateData` query + certificate render: **smoke-tested on a Neon branch** forked from prod
- Nothing anchored until the hourly cron runs; the ~11 backfilled seals get pending proofs within an hour of deploy, Bitcoin-confirmed a few hours later (expected).

## Deploy notes
1. `npm run db:migrate` (applies 113; CI gate requires it recorded before deploy)
2. `npx wrangler deploy` (worker: cron + routes + email)
3. frontend deploy (Certificate button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)