### PR TITLE
feat(deals): deal outcome capture — Phase 1 disintermediation defense

### DIFF
--- a/frontend/src/components/dashboard/CreatorDealInbox.tsx
+++ b/frontend/src/components/dashboard/CreatorDealInbox.tsx
@@ -1,11 +1,18 @@
 import { useEffect, useState, useCallback } from 'react';
-import { Handshake, Check, X, Reply } from 'lucide-react';
+import { Handshake, Check, X, Reply, Flag, CheckCircle2 } from 'lucide-react';
 import apiClient from '../../lib/api-client';
 import { formatNumber } from '@shared/utils/formatters';
 
 // Creator Deal Inbox (moat #6) — production deals proposed to the creator, with
 // accept / counter / reject. Self-contained; renders null when there are no deals
 // so it never clutters the dashboard.
+//
+// Phase 1 disintermediation defense (deal system-of-record): each deal can also
+// have its OUTCOME marked (closed on/off platform, or dead) by either party, with
+// the counterparty confirming — capturing the result even when money moves off
+// Pitchey. Bilateral confirmation feeds the Phase 2 reputation loop.
+
+type Outcome = 'closed_on_platform' | 'closed_off_platform' | 'dead';
 
 interface Deal {
   id: number;
@@ -18,6 +25,12 @@ interface Deal {
   producer_name: string | null;
   actionable: boolean;
   created_at: string;
+  outcome: Outcome | null;
+  outcome_amount: number | null;
+  outcome_terms: string | null;
+  closed_at: string | null;
+  outcome_confirmed_by_creator: boolean;
+  outcome_confirmed_by_production: boolean;
 }
 
 const STATUS_LABEL: Record<string, { label: string; cls: string }> = {
@@ -27,11 +40,29 @@ const STATUS_LABEL: Record<string, { label: string; cls: string }> = {
   completed: { label: 'Completed', cls: 'bg-green-100 text-green-700' },
 };
 
+const OUTCOME_LABEL: Record<Outcome, string> = {
+  closed_on_platform: 'Closed on Pitchey',
+  closed_off_platform: 'Closed off-platform',
+  dead: 'Deal died',
+};
+
+const OUTCOME_OPTIONS: Array<{ value: Outcome; label: string }> = [
+  { value: 'closed_on_platform', label: 'Closed on Pitchey' },
+  { value: 'closed_off_platform', label: 'Closed off-platform' },
+  { value: 'dead', label: 'Deal died / no deal' },
+];
+
 export default function CreatorDealInbox() {
   const [deals, setDeals] = useState<Deal[] | null>(null);
   const [busyId, setBusyId] = useState<number | null>(null);
   const [counterFor, setCounterFor] = useState<number | null>(null);
   const [counterAmount, setCounterAmount] = useState('');
+  // Outcome form state (one deal open at a time).
+  const [outcomeFor, setOutcomeFor] = useState<number | null>(null);
+  const [outcomeValue, setOutcomeValue] = useState<Outcome>('closed_off_platform');
+  const [outcomeAmount, setOutcomeAmount] = useState('');
+  const [outcomeTerms, setOutcomeTerms] = useState('');
+  const [outcomeDate, setOutcomeDate] = useState('');
 
   const load = useCallback(async () => {
     try {
@@ -59,6 +90,27 @@ export default function CreatorDealInbox() {
     }
   }, [load]);
 
+  const resetOutcomeForm = useCallback(() => {
+    setOutcomeFor(null);
+    setOutcomeValue('closed_off_platform');
+    setOutcomeAmount('');
+    setOutcomeTerms('');
+    setOutcomeDate('');
+  }, []);
+
+  const submitOutcome = useCallback(async (id: number, payload: Record<string, unknown>) => {
+    setBusyId(id);
+    try {
+      await apiClient.post(`/api/creator/deals/${id}/outcome`, payload);
+      resetOutcomeForm();
+      await load();
+    } catch {
+      /* best-effort; list reload reflects truth */
+    } finally {
+      setBusyId(null);
+    }
+  }, [load, resetOutcomeForm]);
+
   if (deals === null || deals.length === 0) return null;
 
   return (
@@ -73,6 +125,10 @@ export default function CreatorDealInbox() {
         {deals.map((d) => {
           const status = STATUS_LABEL[d.status] ?? { label: d.status, cls: 'bg-gray-100 text-gray-600' };
           const isCountering = counterFor === d.id;
+          const isMarkingOutcome = outcomeFor === d.id;
+          const hasOutcome = d.outcome !== null;
+          const mutuallyConfirmed = d.outcome_confirmed_by_creator && d.outcome_confirmed_by_production;
+          const needsCreatorConfirm = hasOutcome && !d.outcome_confirmed_by_creator;
           return (
             <li key={d.id} className="rounded-xl border border-gray-100 p-4">
               <div className="flex items-start justify-between gap-3">
@@ -80,17 +136,54 @@ export default function CreatorDealInbox() {
                   <div className="flex items-center gap-2 flex-wrap">
                     <span className="font-semibold text-gray-900 truncate">{d.pitch_title ?? 'Your pitch'}</span>
                     <span className={`text-[11px] font-medium rounded-full px-2 py-0.5 ${status.cls}`}>{status.label}</span>
+                    {hasOutcome && (
+                      <span className="text-[11px] font-medium rounded-full px-2 py-0.5 bg-amber-100 text-amber-700">
+                        {OUTCOME_LABEL[d.outcome as Outcome]}
+                      </span>
+                    )}
                   </div>
                   <div className="text-sm text-gray-500 mt-0.5">
                     {d.producer_name ?? 'A production company'} · <span className="capitalize">{d.deal_type}</span>
                     {d.amount ? ` · €${formatNumber(d.amount)}` : ''}
                     {d.backend_percentage ? ` · ${d.backend_percentage}% backend` : ''}
                   </div>
+                  {hasOutcome && (
+                    <div className="text-xs text-gray-500 mt-1">
+                      {d.outcome_amount ? `Reported €${formatNumber(d.outcome_amount)}` : 'No amount reported'}
+                      {d.outcome_terms ? ` · ${d.outcome_terms}` : ''}
+                      {d.closed_at ? ` · closed ${new Date(d.closed_at).toLocaleDateString()}` : ''}
+                    </div>
+                  )}
                 </div>
               </div>
 
-              {d.actionable && !isCountering && (
-                <div className="flex items-center gap-2 mt-3">
+              {/* Outcome confirmation state */}
+              {hasOutcome && (
+                <div className="mt-3">
+                  {mutuallyConfirmed ? (
+                    <span className="inline-flex items-center gap-1 text-xs font-medium text-green-700">
+                      <CheckCircle2 className="w-4 h-4" /> Outcome mutually confirmed
+                    </span>
+                  ) : needsCreatorConfirm ? (
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-xs text-gray-500">The producer recorded this outcome — confirm if it&apos;s accurate.</span>
+                      <button
+                        type="button" disabled={busyId === d.id}
+                        onClick={() => submitOutcome(d.id, { outcome: d.outcome })}
+                        className="inline-flex items-center gap-1 bg-green-600 hover:bg-green-700 disabled:opacity-50 text-white text-xs font-medium rounded-lg px-3 py-1.5"
+                      >
+                        <Check className="w-3.5 h-3.5" /> Confirm outcome
+                      </button>
+                    </div>
+                  ) : (
+                    <span className="text-xs text-gray-400">Awaiting the producer&apos;s confirmation</span>
+                  )}
+                </div>
+              )}
+
+              {/* Accept / counter / reject (early-pipeline only) */}
+              {d.actionable && !isCountering && !isMarkingOutcome && (
+                <div className="flex items-center gap-2 mt-3 flex-wrap">
                   <button
                     type="button" disabled={busyId === d.id}
                     onClick={() => respond(d.id, 'accept')}
@@ -115,6 +208,20 @@ export default function CreatorDealInbox() {
                 </div>
               )}
 
+              {/* Mark outcome trigger — available until an outcome is recorded */}
+              {!hasOutcome && !isCountering && !isMarkingOutcome && (
+                <div className="mt-3">
+                  <button
+                    type="button" disabled={busyId === d.id}
+                    onClick={() => { setOutcomeFor(d.id); }}
+                    className="inline-flex items-center gap-1 text-gray-500 hover:text-purple-700 disabled:opacity-50 text-sm font-medium"
+                  >
+                    <Flag className="w-4 h-4" /> Mark outcome
+                  </button>
+                </div>
+              )}
+
+              {/* Counter form */}
               {d.actionable && isCountering && (
                 <div className="flex items-center gap-2 mt-3">
                   <span className="text-sm text-gray-500">€</span>
@@ -138,6 +245,64 @@ export default function CreatorDealInbox() {
                   >
                     Cancel
                   </button>
+                </div>
+              )}
+
+              {/* Mark-outcome form */}
+              {isMarkingOutcome && (
+                <div className="mt-3 space-y-2 rounded-lg bg-gray-50 p-3">
+                  <select
+                    value={outcomeValue} onChange={(e) => setOutcomeValue(e.target.value as Outcome)}
+                    aria-label="Deal outcome"
+                    className="w-full border border-gray-200 rounded-lg px-2 py-1.5 text-sm bg-white"
+                  >
+                    {OUTCOME_OPTIONS.map((o) => (
+                      <option key={o.value} value={o.value}>{o.label}</option>
+                    ))}
+                  </select>
+                  {outcomeValue !== 'dead' && (
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-sm text-gray-500">€</span>
+                      <input
+                        type="number" value={outcomeAmount} onChange={(e) => setOutcomeAmount(e.target.value)}
+                        aria-label="Final amount"
+                        className="w-32 border border-gray-200 rounded-lg px-2 py-1.5 text-sm"
+                        placeholder="Final amount"
+                      />
+                      <input
+                        type="date" value={outcomeDate} onChange={(e) => setOutcomeDate(e.target.value)}
+                        aria-label="Close date"
+                        className="border border-gray-200 rounded-lg px-2 py-1.5 text-sm"
+                      />
+                    </div>
+                  )}
+                  <input
+                    type="text" value={outcomeTerms} onChange={(e) => setOutcomeTerms(e.target.value)}
+                    aria-label="Reported terms"
+                    className="w-full border border-gray-200 rounded-lg px-2 py-1.5 text-sm"
+                    placeholder="Reported terms (optional)"
+                  />
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button" disabled={busyId === d.id}
+                      onClick={() => submitOutcome(d.id, {
+                        outcome: outcomeValue,
+                        amount: outcomeValue !== 'dead' && outcomeAmount ? Number(outcomeAmount) : undefined,
+                        terms: outcomeTerms || undefined,
+                        closeDate: outcomeValue !== 'dead' && outcomeDate ? outcomeDate : undefined,
+                      })}
+                      className="bg-purple-600 hover:bg-purple-700 disabled:opacity-50 text-white text-sm font-medium rounded-lg px-3 py-1.5"
+                    >
+                      Save outcome
+                    </button>
+                    <button
+                      type="button"
+                      onClick={resetOutcomeForm}
+                      className="text-gray-400 hover:text-gray-600 text-sm px-2 py-1.5"
+                    >
+                      Cancel
+                    </button>
+                  </div>
                 </div>
               )}
             </li>

--- a/frontend/src/components/routing/AllEnhancedRoutes.tsx
+++ b/frontend/src/components/routing/AllEnhancedRoutes.tsx
@@ -63,6 +63,7 @@ const InvestorDiscover = lazy(() => import('@portals/investor/pages/InvestorDisc
 const ProductionActivity = lazy(() => import('@portals/production/pages/ProductionActivity'));
 const ProductionAnalytics = lazy(() => import('@portals/production/pages/ProductionAnalytics'));
 const ProductionStats = lazy(() => import('@portals/production/pages/ProductionStats'));
+const ProductionDeals = lazy(() => import('@portals/production/pages/ProductionDeals'));
 const ProductionSubmissions = lazy(() => import('@portals/production/pages/ProductionSubmissions'));
 const ProductionSubmissionsNew = lazy(() => import('@portals/production/pages/ProductionSubmissionsNew'));
 const ProductionSubmissionsReview = lazy(() => import('@portals/production/pages/ProductionSubmissionsReview'));
@@ -299,7 +300,12 @@ export function AllProductionRoutes({ isAuthenticated, userType }: RoutesProps) 
       <Route path={getRelativePath(PRODUCTION_ROUTES.stats, '/production')} element={
         isProduction ? <ProductionStats /> : <Navigate to="/login/production" />
       } />
-      
+
+      {/* Deals — outcome capture (disintermediation defense P1) */}
+      <Route path={getRelativePath(PRODUCTION_ROUTES.deals, '/production')} element={
+        isProduction ? <ProductionDeals /> : <Navigate to="/login/production" />
+      } />
+
       {/* Submissions */}
       <Route path={getRelativePath(PRODUCTION_ROUTES.submissions, '/production')} element={
         isProduction ? <ProductionSubmissions /> : <Navigate to="/login/production" />

--- a/frontend/src/config/navigation.routes.ts
+++ b/frontend/src/config/navigation.routes.ts
@@ -134,6 +134,9 @@ export const PRODUCTION_ROUTES = {
   submissionsRejected: '/production/submissions/rejected',
   submissionsArchive: '/production/submissions/archive',
   
+  // Deals
+  deals: '/production/deals',
+
   // Operations
   saved: '/production/saved',
   collaborations: '/production/collaborations',

--- a/frontend/src/portals/production/pages/ProductionDeals.tsx
+++ b/frontend/src/portals/production/pages/ProductionDeals.tsx
@@ -1,0 +1,250 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Handshake, Flag, Check, CheckCircle2, Loader2 } from 'lucide-react';
+import apiClient from '@/lib/api-client';
+import { ProductionService } from '../services/production.service';
+import { formatNumber } from '@shared/utils/formatters';
+
+// Production Deals page (disintermediation defense P1 — deal system-of-record).
+// The producer's view of deals they've proposed, with the both-sided "mark outcome"
+// action: record how a deal actually ended (closed on/off platform, or dead) even
+// when money moved off Pitchey. The creator confirms; bilateral confirmation feeds
+// the Phase 2 reputation loop. Mirror of the creator-side CreatorDealInbox.
+
+type Outcome = 'closed_on_platform' | 'closed_off_platform' | 'dead';
+
+interface Deal {
+  id: number;
+  deal_type: string;
+  status: string; // investment_deal_state
+  amount: number;
+  backend_percentage: number | null;
+  notes: string | null;
+  pitch_title: string | null;
+  creator_name: string | null;
+  created_at: string;
+  outcome: Outcome | null;
+  outcome_amount: number | null;
+  outcome_terms: string | null;
+  closed_at: string | null;
+  outcome_confirmed_by_creator: boolean;
+  outcome_confirmed_by_production: boolean;
+}
+
+const STATUS_LABEL: Record<string, { label: string; cls: string }> = {
+  inquiry: { label: 'Proposed', cls: 'bg-purple-100 text-purple-700' },
+  negotiation: { label: 'In negotiation', cls: 'bg-blue-100 text-blue-700' },
+  cancelled: { label: 'Closed', cls: 'bg-gray-100 text-gray-500' },
+  completed: { label: 'Completed', cls: 'bg-green-100 text-green-700' },
+};
+
+const OUTCOME_LABEL: Record<Outcome, string> = {
+  closed_on_platform: 'Closed on Pitchey',
+  closed_off_platform: 'Closed off-platform',
+  dead: 'Deal died',
+};
+
+const OUTCOME_OPTIONS: Array<{ value: Outcome; label: string }> = [
+  { value: 'closed_on_platform', label: 'Closed on Pitchey' },
+  { value: 'closed_off_platform', label: 'Closed off-platform' },
+  { value: 'dead', label: 'Deal died / no deal' },
+];
+
+export default function ProductionDeals() {
+  const [deals, setDeals] = useState<Deal[] | null>(null);
+  const [busyId, setBusyId] = useState<number | null>(null);
+  const [outcomeFor, setOutcomeFor] = useState<number | null>(null);
+  const [outcomeValue, setOutcomeValue] = useState<Outcome>('closed_off_platform');
+  const [outcomeAmount, setOutcomeAmount] = useState('');
+  const [outcomeTerms, setOutcomeTerms] = useState('');
+  const [outcomeDate, setOutcomeDate] = useState('');
+
+  const load = useCallback(async () => {
+    try {
+      const res = await apiClient.get<{ deals: Deal[] }>('/api/production/deals');
+      if (res?.success && res.data?.deals) setDeals(res.data.deals);
+      else setDeals([]);
+    } catch {
+      setDeals([]);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const resetOutcomeForm = useCallback(() => {
+    setOutcomeFor(null);
+    setOutcomeValue('closed_off_platform');
+    setOutcomeAmount('');
+    setOutcomeTerms('');
+    setOutcomeDate('');
+  }, []);
+
+  const submitOutcome = useCallback(async (id: number, payload: {
+    outcome: Outcome; amount?: number; terms?: string; closeDate?: string;
+  }) => {
+    setBusyId(id);
+    try {
+      await ProductionService.markDealOutcome(id, payload);
+      resetOutcomeForm();
+      await load();
+    } catch {
+      /* best-effort; list reload reflects truth */
+    } finally {
+      setBusyId(null);
+    }
+  }, [load, resetOutcomeForm]);
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <div className="flex items-center gap-2 mb-6">
+        <Handshake className="w-6 h-6 text-brand-portal-production" />
+        <h1 className="text-2xl font-bold text-gray-900">Deals</h1>
+      </div>
+
+      {deals === null ? (
+        <div className="flex items-center gap-2 text-gray-400 py-12 justify-center">
+          <Loader2 className="w-5 h-5 animate-spin" /> Loading deals…
+        </div>
+      ) : deals.length === 0 ? (
+        <div className="text-center py-16 bg-white rounded-2xl ring-1 ring-gray-100">
+          <Handshake className="w-10 h-10 text-gray-300 mx-auto mb-3" />
+          <p className="text-gray-500">No deals yet.</p>
+          <p className="text-sm text-gray-400 mt-1">Propose a deal from a creator&apos;s pitch to get started.</p>
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {deals.map((d) => {
+            const status = STATUS_LABEL[d.status] ?? { label: d.status, cls: 'bg-gray-100 text-gray-600' };
+            const isMarkingOutcome = outcomeFor === d.id;
+            const hasOutcome = d.outcome !== null;
+            const mutuallyConfirmed = d.outcome_confirmed_by_creator && d.outcome_confirmed_by_production;
+            const needsProductionConfirm = hasOutcome && !d.outcome_confirmed_by_production;
+            return (
+              <li key={d.id} className="rounded-xl border border-gray-100 bg-white p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="font-semibold text-gray-900 truncate">{d.pitch_title ?? 'Pitch'}</span>
+                      <span className={`text-[11px] font-medium rounded-full px-2 py-0.5 ${status.cls}`}>{status.label}</span>
+                      {hasOutcome && (
+                        <span className="text-[11px] font-medium rounded-full px-2 py-0.5 bg-amber-100 text-amber-700">
+                          {OUTCOME_LABEL[d.outcome as Outcome]}
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-sm text-gray-500 mt-0.5">
+                      {d.creator_name ?? 'Creator'} · <span className="capitalize">{d.deal_type}</span>
+                      {d.amount ? ` · €${formatNumber(d.amount)}` : ''}
+                      {d.backend_percentage ? ` · ${d.backend_percentage}% backend` : ''}
+                    </div>
+                    {hasOutcome && (
+                      <div className="text-xs text-gray-500 mt-1">
+                        {d.outcome_amount ? `Reported €${formatNumber(d.outcome_amount)}` : 'No amount reported'}
+                        {d.outcome_terms ? ` · ${d.outcome_terms}` : ''}
+                        {d.closed_at ? ` · closed ${new Date(d.closed_at).toLocaleDateString()}` : ''}
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* Outcome confirmation state */}
+                {hasOutcome && (
+                  <div className="mt-3">
+                    {mutuallyConfirmed ? (
+                      <span className="inline-flex items-center gap-1 text-xs font-medium text-green-700">
+                        <CheckCircle2 className="w-4 h-4" /> Outcome mutually confirmed
+                      </span>
+                    ) : needsProductionConfirm ? (
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-xs text-gray-500">The creator recorded this outcome — confirm if it&apos;s accurate.</span>
+                        <button
+                          type="button" disabled={busyId === d.id}
+                          onClick={() => submitOutcome(d.id, { outcome: d.outcome as Outcome })}
+                          className="inline-flex items-center gap-1 bg-green-600 hover:bg-green-700 disabled:opacity-50 text-white text-xs font-medium rounded-lg px-3 py-1.5"
+                        >
+                          <Check className="w-3.5 h-3.5" /> Confirm outcome
+                        </button>
+                      </div>
+                    ) : (
+                      <span className="text-xs text-gray-400">Awaiting the creator&apos;s confirmation</span>
+                    )}
+                  </div>
+                )}
+
+                {/* Mark outcome trigger — available until an outcome is recorded */}
+                {!hasOutcome && !isMarkingOutcome && (
+                  <div className="mt-3">
+                    <button
+                      type="button" disabled={busyId === d.id}
+                      onClick={() => setOutcomeFor(d.id)}
+                      className="inline-flex items-center gap-1 text-gray-500 hover:text-brand-portal-production disabled:opacity-50 text-sm font-medium"
+                    >
+                      <Flag className="w-4 h-4" /> Mark outcome
+                    </button>
+                  </div>
+                )}
+
+                {/* Mark-outcome form */}
+                {isMarkingOutcome && (
+                  <div className="mt-3 space-y-2 rounded-lg bg-gray-50 p-3">
+                    <select
+                      value={outcomeValue} onChange={(e) => setOutcomeValue(e.target.value as Outcome)}
+                      aria-label="Deal outcome"
+                      className="w-full border border-gray-200 rounded-lg px-2 py-1.5 text-sm bg-white"
+                    >
+                      {OUTCOME_OPTIONS.map((o) => (
+                        <option key={o.value} value={o.value}>{o.label}</option>
+                      ))}
+                    </select>
+                    {outcomeValue !== 'dead' && (
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-sm text-gray-500">€</span>
+                        <input
+                          type="number" value={outcomeAmount} onChange={(e) => setOutcomeAmount(e.target.value)}
+                          aria-label="Final amount"
+                          className="w-32 border border-gray-200 rounded-lg px-2 py-1.5 text-sm"
+                          placeholder="Final amount"
+                        />
+                        <input
+                          type="date" value={outcomeDate} onChange={(e) => setOutcomeDate(e.target.value)}
+                          aria-label="Close date"
+                          className="border border-gray-200 rounded-lg px-2 py-1.5 text-sm"
+                        />
+                      </div>
+                    )}
+                    <input
+                      type="text" value={outcomeTerms} onChange={(e) => setOutcomeTerms(e.target.value)}
+                      aria-label="Reported terms"
+                      className="w-full border border-gray-200 rounded-lg px-2 py-1.5 text-sm"
+                      placeholder="Reported terms (optional)"
+                    />
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button" disabled={busyId === d.id}
+                        onClick={() => submitOutcome(d.id, {
+                          outcome: outcomeValue,
+                          amount: outcomeValue !== 'dead' && outcomeAmount ? Number(outcomeAmount) : undefined,
+                          terms: outcomeTerms || undefined,
+                          closeDate: outcomeValue !== 'dead' && outcomeDate ? outcomeDate : undefined,
+                        })}
+                        className="bg-brand-portal-production hover:opacity-90 disabled:opacity-50 text-white text-sm font-medium rounded-lg px-3 py-1.5"
+                      >
+                        Save outcome
+                      </button>
+                      <button
+                        type="button"
+                        onClick={resetOutcomeForm}
+                        className="text-gray-400 hover:text-gray-600 text-sm px-2 py-1.5"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/portals/production/services/production.service.ts
+++ b/frontend/src/portals/production/services/production.service.ts
@@ -371,6 +371,27 @@ export class ProductionService {
     return response.data.deal;
   }
 
+  // Mark or confirm a deal outcome (disintermediation defense P1 — deal
+  // system-of-record). Both-sided: the production side records how a deal ended
+  // even when money moved off-platform; the creator confirms (or vice versa).
+  static async markDealOutcome(dealId: number, data: {
+    outcome: 'closed_on_platform' | 'closed_off_platform' | 'dead';
+    amount?: number;
+    terms?: string;
+    closeDate?: string;
+  }): Promise<{ deal: ProductionDeal; mutuallyConfirmed: boolean }> {
+    const response = await apiClient.post<{ deal: ProductionDeal; mutuallyConfirmed: boolean }>(
+      `/api/production/deals/${dealId.toString()}/outcome`,
+      data
+    );
+
+    if (response.success !== true || response.data?.deal === undefined) {
+      throw new Error(getErrorMessage(response.error, 'Failed to mark deal outcome'));
+    }
+
+    return response.data;
+  }
+
   // Search for talent
   static async searchTalent(filters?: {
     role?: string;

--- a/frontend/src/shared/components/layout/EnhancedProductionNav.tsx
+++ b/frontend/src/shared/components/layout/EnhancedProductionNav.tsx
@@ -45,6 +45,12 @@ export const productionNavigationSections: NavigationSection[] = [
   // items here. ("Projects"/"Pipeline" and the "Submissions" review pipeline were parked
   // earlier the same way.) "Collaborations" (external business partners) stays.
   {
+    title: 'Deals',
+    items: [
+      { label: 'Deals', path: PRODUCTION_ROUTES.deals, icon: Handshake },
+    ],
+  },
+  {
     title: 'People',
     items: [
       { label: 'Invite Creators', path: PRODUCTION_ROUTES.invites, icon: UserPlus },

--- a/src/db/migrations/114_production_deals_outcome_capture.sql
+++ b/src/db/migrations/114_production_deals_outcome_capture.sql
@@ -1,0 +1,47 @@
+-- 114_production_deals_outcome_capture.sql
+--
+-- Phase 1 of the disintermediation-defense roadmap (deal system-of-record).
+-- Make Pitchey the record of the deal *even when money moves off-platform*.
+--
+-- The `production_deals` state machine is LIVE (#6, migration 111) but the
+-- `investment_deal_state` enum's terminal states (`completed`/`cancelled`) only
+-- say a deal ended — not HOW. A film deal that closes off-platform looks identical
+-- to one that closed on-platform, and a dead deal looks like a cancelled one. That
+-- blind spot is exactly the disintermediation leak: we capture the high-value intro
+-- and keep no record of the outcome.
+--
+-- This migration adds OUTCOME-CAPTURE columns (NOT new states — the enum already has
+-- completed/cancelled; marking an outcome moves the deal to one of those existing
+-- terminal states). Both sides can mark an outcome; bilateral confirmation flags
+-- feed the Phase 2 reputation loop (mutually-confirmed outcomes only).
+--
+-- All additive + idempotent (CREATE TYPE guarded, ADD COLUMN IF NOT EXISTS).
+
+-- Outcome classification: how the deal actually ended.
+DO $$ BEGIN
+  CREATE TYPE deal_outcome AS ENUM ('closed_on_platform', 'closed_off_platform', 'dead');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+ALTER TABLE production_deals
+  -- How the deal ended (NULL = no outcome recorded yet).
+  ADD COLUMN IF NOT EXISTS outcome deal_outcome,
+  -- Reported final figures (free-form text terms + numeric amount), distinct from
+  -- the proposed option_amount/purchase_price — this is what the parties say the
+  -- deal actually closed at, even if transacted off-platform.
+  ADD COLUMN IF NOT EXISTS outcome_amount numeric,
+  ADD COLUMN IF NOT EXISTS outcome_terms text,
+  -- The real close date (when the deal closed), distinct from state_changed_at
+  -- (when it was recorded in Pitchey).
+  ADD COLUMN IF NOT EXISTS closed_at timestamp without time zone,
+  -- Provenance of the outcome record.
+  ADD COLUMN IF NOT EXISTS outcome_reported_by integer,
+  ADD COLUMN IF NOT EXISTS outcome_reported_at timestamp without time zone,
+  -- Bilateral confirmation. Phase 2 credits reputation ONLY when both are true.
+  ADD COLUMN IF NOT EXISTS outcome_confirmed_by_creator boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS outcome_confirmed_by_production boolean NOT NULL DEFAULT false;
+
+-- Index the outcome so the reputation cron / analytics can scan confirmed closes
+-- without a full table sweep. Partial: only rows that have an outcome.
+CREATE INDEX IF NOT EXISTS idx_production_deals_outcome
+  ON production_deals (outcome)
+  WHERE outcome IS NOT NULL;

--- a/src/handlers/creator-deals.ts
+++ b/src/handlers/creator-deals.ts
@@ -63,6 +63,8 @@ export async function getCreatorDeals(request: Request, env: Env): Promise<Respo
              d.deal_state AS status,
              COALESCE(d.option_amount, d.purchase_price, d.development_fee, 0) AS amount,
              d.backend_percentage, d.notes, d.created_at, d.state_changed_at,
+             d.outcome::text AS outcome, d.outcome_amount, d.outcome_terms, d.closed_at,
+             d.outcome_confirmed_by_creator, d.outcome_confirmed_by_production,
              p.title AS pitch_title, p.genre AS pitch_genre,
              COALESCE(NULLIF(TRIM(pc.first_name || ' ' || pc.last_name), ''), pc.company_name, pc.username, 'Production company') AS producer_name
       FROM production_deals d

--- a/src/handlers/deal-outcome.ts
+++ b/src/handlers/deal-outcome.ts
@@ -1,0 +1,179 @@
+/**
+ * Deal outcome capture — Phase 1 of the disintermediation-defense roadmap
+ * (deal system-of-record).
+ *
+ * Pitchey captures the high-value intro (NDA-gated connection + a `production_deals`
+ * offer→accept/counter state machine) but, until now, kept NO record of how a deal
+ * actually ended — a film deal that closed off-platform was indistinguishable from
+ * one that closed on-platform or one that died. That blind spot IS the leak: better
+ * intros with no outcome record accelerate disintermediation.
+ *
+ * This is a BOTH-SIDED action. Either party to a deal (the creator or the production
+ * company) can mark the outcome; the counterparty confirms. Bilateral confirmation
+ * flags (`outcome_confirmed_by_creator` / `outcome_confirmed_by_production`) feed the
+ * Phase 2 reputation loop, which credits reputation ONLY on mutually-confirmed
+ * outcomes — turning leakage into a reason to report the deal back.
+ *
+ * Marking an outcome does NOT add a new deal_state — it moves the deal to one of the
+ * existing terminal `investment_deal_state` values and records the richer outcome:
+ *   closed_on_platform | closed_off_platform  → deal_state = 'completed'
+ *   dead                                       → deal_state = 'cancelled'
+ *
+ * Wired under both:
+ *   POST /api/creator/deals/:id/outcome
+ *   POST /api/production/deals/:id/outcome
+ * The caller's role is resolved from the deal row, not the route, so the same logic
+ * serves both sides.
+ */
+
+import { getDb } from '../db/connection';
+import type { Env } from '../db/connection';
+import { getCorsHeaders } from '../utils/response';
+import { getUserId } from '../utils/auth-extract';
+import { safeQuery } from '../db/safe-query';
+
+function jsonResponse(data: unknown, origin: string | null, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...getCorsHeaders(origin) },
+  });
+}
+function errorResponse(message: string, origin: string | null, status = 400): Response {
+  return jsonResponse({ success: false, error: message }, origin, status);
+}
+
+// Outcome → existing terminal deal_state. We do NOT introduce new states.
+const OUTCOME_TO_STATE: Record<string, 'completed' | 'cancelled'> = {
+  closed_on_platform: 'completed',
+  closed_off_platform: 'completed',
+  dead: 'cancelled',
+};
+
+interface DealRow {
+  id: number;
+  creator_id: number;
+  production_company_id: number;
+  pitch_id: number | null;
+  outcome: string | null;
+  outcome_confirmed_by_creator: boolean;
+  outcome_confirmed_by_production: boolean;
+}
+
+/** POST /api/{creator,production}/deals/:id/outcome — mark or confirm a deal outcome. */
+export async function markDealOutcome(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+  const userId = await getUserId(request, env);
+  if (!userId) return errorResponse('Unauthorized', origin, 401);
+
+  const sql = getDb(env);
+  if (!sql) return errorResponse('Database unavailable', origin, 503);
+
+  try {
+    const parts = new URL(request.url).pathname.split('/');
+    const dealId = Number(parts[parts.length - 2]); // /.../deals/:id/outcome
+    if (!dealId || Number.isNaN(dealId)) return errorResponse('Invalid deal id', origin);
+
+    const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+    const outcome = typeof body.outcome === 'string' ? body.outcome : '';
+    if (!OUTCOME_TO_STATE[outcome]) {
+      return errorResponse(`Invalid outcome. Must be one of: ${Object.keys(OUTCOME_TO_STATE).join(', ')}`, origin);
+    }
+    const terminalState = OUTCOME_TO_STATE[outcome];
+
+    const amount = Number.isFinite(body.amount as number) ? Number(body.amount) : null;
+    const terms = typeof body.terms === 'string' ? body.terms.slice(0, 4000) : null;
+    // close date — accept an ISO date/datetime string; reject anything unparseable.
+    let closeDate: string | null = null;
+    if (typeof body.closeDate === 'string' && body.closeDate.trim()) {
+      const parsed = new Date(body.closeDate);
+      if (Number.isNaN(parsed.getTime())) return errorResponse('Invalid closeDate', origin);
+      closeDate = parsed.toISOString();
+    }
+
+    // Load + party-gate the deal.
+    const [deal] = await sql`
+      SELECT id, creator_id, production_company_id, pitch_id, outcome::text AS outcome,
+             outcome_confirmed_by_creator, outcome_confirmed_by_production
+      FROM production_deals WHERE id = ${dealId}
+    ` as unknown as DealRow[];
+    if (!deal) return errorResponse('Deal not found', origin, 404);
+
+    const isCreator = String(deal.creator_id) === String(userId);
+    const isProduction = String(deal.production_company_id) === String(userId);
+    if (!isCreator && !isProduction) return errorResponse('Forbidden', origin, 403);
+
+    // A fresh assertion if there is no prior outcome OR the submitted outcome differs
+    // from what's on record (a party correcting/changing it resets confirmations).
+    const isReassert = deal.outcome === null || deal.outcome !== outcome;
+
+    // Compute the two confirmation flags in JS so we can set both columns in one UPDATE.
+    let creatorConfirmed: boolean;
+    let productionConfirmed: boolean;
+    if (isReassert) {
+      creatorConfirmed = isCreator;       // the reporter has implicitly confirmed
+      productionConfirmed = isProduction; // the other side must confirm separately
+    } else {
+      // Same outcome on record → this caller is confirming; keep the other side's flag.
+      creatorConfirmed = isCreator ? true : deal.outcome_confirmed_by_creator;
+      productionConfirmed = isProduction ? true : deal.outcome_confirmed_by_production;
+    }
+
+    let updated: Record<string, unknown> | undefined;
+    if (isReassert) {
+      [updated] = await sql`
+        UPDATE production_deals
+        SET outcome = ${outcome}::deal_outcome,
+            deal_state = ${terminalState}::investment_deal_state,
+            outcome_amount = ${amount},
+            outcome_terms = ${terms},
+            closed_at = ${closeDate}::timestamp,
+            outcome_reported_by = ${Number(userId)},
+            outcome_reported_at = NOW(),
+            outcome_confirmed_by_creator = ${creatorConfirmed},
+            outcome_confirmed_by_production = ${productionConfirmed},
+            state_changed_at = NOW(), state_changed_by = ${Number(userId)}, updated_at = NOW()
+        WHERE id = ${dealId}
+        RETURNING id, deal_state AS status, outcome::text AS outcome,
+                  outcome_amount, outcome_terms, closed_at,
+                  outcome_confirmed_by_creator, outcome_confirmed_by_production
+      ` as unknown as Record<string, unknown>[];
+    } else {
+      // Confirmation: flip this side's flag, optionally refine the reported figures.
+      [updated] = await sql`
+        UPDATE production_deals
+        SET outcome_amount = COALESCE(${amount}, outcome_amount),
+            outcome_terms = COALESCE(${terms}, outcome_terms),
+            closed_at = COALESCE(${closeDate}::timestamp, closed_at),
+            outcome_confirmed_by_creator = ${creatorConfirmed},
+            outcome_confirmed_by_production = ${productionConfirmed},
+            updated_at = NOW()
+        WHERE id = ${dealId}
+        RETURNING id, deal_state AS status, outcome::text AS outcome,
+                  outcome_amount, outcome_terms, closed_at,
+                  outcome_confirmed_by_creator, outcome_confirmed_by_production
+      ` as unknown as Record<string, unknown>[];
+    }
+
+    const mutuallyConfirmed = creatorConfirmed && productionConfirmed;
+
+    // Notify the counterparty — best-effort.
+    const counterpartyId = isCreator ? deal.production_company_id : deal.creator_id;
+    const verb = isReassert ? 'reported' : 'confirmed';
+    await safeQuery(() => sql`
+      INSERT INTO notifications (user_id, type, title, message, related_user_id, related_pitch_id, created_at)
+      VALUES (
+        ${counterpartyId}, 'deal_outcome',
+        ${'Deal outcome ' + verb},
+        ${'The other party ' + verb + ' this deal as ' + outcome.replace(/_/g, ' ') +
+          (mutuallyConfirmed ? ' (now mutually confirmed).' : '. Confirm to finalise the record.')},
+        ${Number(userId)}, ${deal.pitch_id}, NOW()
+      )
+    `, { fallback: [], context: 'deal-outcome.notify' });
+
+    return jsonResponse({ success: true, data: { deal: updated, mutuallyConfirmed } }, origin);
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error('markDealOutcome error:', e.message);
+    return errorResponse('Failed to mark deal outcome', origin, 500);
+  }
+}

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -3246,6 +3246,11 @@ class RouteRegistry {
     this.register('GET', '/api/production/deals/:dealId/contract', (req: Request) =>
       getProductionContract(req, this.env)
     );
+    // Deal outcome capture (disintermediation defense P1) — both-sided; production side.
+    this.register('POST', '/api/production/deals/:dealId/outcome', async (req) => {
+      const { markDealOutcome } = await import('./handlers/deal-outcome');
+      return markDealOutcome(req, this.env);
+    });
 
     // Distribution & Export
     this.register('GET', '/api/production/projects/:id/distribution', (req: Request) =>
@@ -3621,6 +3626,11 @@ class RouteRegistry {
     this.register('POST', '/api/creator/deals/:id/respond', async (req) => {
       const { respondToCreatorDeal } = await import('./handlers/creator-deals');
       return respondToCreatorDeal(req, this.env);
+    });
+    // Deal outcome capture (disintermediation defense P1) — both-sided; creator side.
+    this.register('POST', '/api/creator/deals/:id/outcome', async (req) => {
+      const { markDealOutcome } = await import('./handlers/deal-outcome');
+      return markDealOutcome(req, this.env);
     });
     this.register('GET', '/api/creator/pitches/analytics', async (req) => {
       const { creatorPitchesAnalyticsHandler } = await import('./handlers/creator-sidebar');


### PR DESCRIPTION
## What & why

Phase 1 of the disintermediation-defense roadmap — make Pitchey the **deal system-of-record** even when money moves off-platform.

`production_deals` already records the offer→accept/counter state machine, but its terminal states (`completed`/`cancelled`) only said a deal *ended*, not *how*. A film deal closed off-platform looked identical to one closed on-platform or one that died. That blind spot is the disintermediation leak: a great intro with no outcome record accelerates leakage.

This adds a **both-sided "mark outcome" action**. Either party marks the outcome; the counterparty confirms. Bilateral confirmation flags feed the upcoming Phase 2 reputation loop (credits reputation only on *mutually-confirmed* outcomes — turning leakage into a reason to report the deal back).

**No new enum states** — marking an outcome moves the deal to an *existing* terminal state (`closed_on/off_platform` → `completed`, `dead` → `cancelled`); the richer detail lives in new columns.

## Changes
- **Migration 114** (additive, idempotent): `deal_outcome` enum + `outcome`/`outcome_amount`/`outcome_terms`/`closed_at`/`outcome_reported_by`/`outcome_reported_at`/`outcome_confirmed_by_creator`/`outcome_confirmed_by_production` on `production_deals` + partial index.
- **`src/handlers/deal-outcome.ts`** — `markDealOutcome`, both-sided (role resolved from the deal row, not the route). Reassert-vs-confirm logic; counterparty notify.
- **Routes**: `POST /api/creator/deals/:id/outcome` + `POST /api/production/deals/:dealId/outcome`.
- **`creator-deals.ts`**: `getCreatorDeals` SELECT returns outcome columns.
- **`CreatorDealInbox`**: outcome badge + mark/confirm UI.
- **`ProductionService.markDealOutcome`** (production-side callable).

## Deferred (flagged for reviewer decision)
- **Production deals-list *page*** — the `GET /api/production/deals` endpoint + service method exist, but no page renders deals, so the production-side mark-outcome UI has nowhere to live yet. Creator-side is fully wired. Build here or follow-up?
- **`investments`↔`production_deals` spine unification** (plan's 2nd P1 bullet) — touches the investor offer path; deferred.

## Verification gates
- **G1 — Migration idempotency**: ran 114 twice on a throwaway Neon branch; second run no-op; all 8 columns + enum + index present. ✅
- **G2 — Routes live, not orphaned**: both routes registered in `worker-integrated.ts`; handler uses the live `(request, env)` signature + `getUserId`. ✅
- **G3 — Typecheck**: `tsc --noEmit` 0 errors (worker `tsconfig.json` + frontend `tsconfig.app.json`); `build:worker` bundles clean. ✅
- **G4 — catch-swallow gate**: `--include-worker --threshold 0` → 0 untagged. ✅
- **G5 — Unit tests**: `CreatorDealInbox` 6/6 green. ✅
- **G6 — Outcome state machine** (verified on branch): fresh report → confirm → mutual; change/dispute resets counterparty confirmation; figures preserved via COALESCE on confirm. ✅
- **G7 — pre-merge**: `npm run db:migrate` applies 114 to prod (CI deploy gate requires it recorded) **before** worker deploy. ⏳

## Not done in this PR
Nothing applied to prod; nothing deployed. Migration 114 verified on a throwaway Neon branch only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)