### PR TITLE
feat(reputation): credit mutually-confirmed deals toward creator gold (P2)

### DIFF
--- a/src/services/creator-reputation.ts
+++ b/src/services/creator-reputation.ts
@@ -1,10 +1,21 @@
 // Platform-earned GOLD tier for creators — the moat-native trust signal.
 //
 // A creator can't do company verification (no company). Their top trust tier is
-// EARNED from on-platform history that only exists because of Pitchey:
-//   - a real sealed catalogue (>= 2 sealed pitches — provenance), and
-//   - sustained, un-withdrawn buyer interest (>= 3 honored NDAs from OTHER users:
-//     status='signed' AND not revoked).
+// EARNED from on-platform history that only exists because of Pitchey. Two
+// independent paths qualify (whichever lands first):
+//   A. Catalogue + sustained interest — a real sealed catalogue (>= 2 sealed
+//      pitches, provenance) AND sustained, un-withdrawn buyer interest (>= 3
+//      honored NDAs from OTHER users: status='signed' AND not revoked).
+//   B. A closed deal — at least one MUTUALLY-CONFIRMED closed deal
+//      (production_deals.outcome closed on/off platform, with BOTH sides'
+//      confirmation flags set). This is disintermediation-defense Phase 2: the
+//      "earned, forfeitable, platform-bound" credential the research shows is the
+//      only kind that retains (Airbnb Plus ~6% vs free Superhost ~0%). It is also
+//      the bilateral incentive to REPORT a deal back even when money moved
+//      off-platform — the creator's reward for confirming the outcome. A single
+//      such deal stands on its own: it is far harder to fake than NDAs (it needs a
+//      real counterparty producer to also confirm), so it is its own gold path and
+//      does NOT additionally require the sealed catalogue.
 // This reputation is non-transferable and hard to fake — exactly the asset that
 // makes Pitchey the venue rather than a listing site.
 //
@@ -13,14 +24,16 @@
 // investor (who earn gold via company-verification) or admin-granted gold. So it
 // cannot conflict with the company-verification / admin / identity tier writers.
 //
-// NOTE: gold does NOT require identity (silver) in v1 — the catalogue + honored-NDA
-// signals stand on their own and are hard to fake. To tighten once Stripe Identity
-// is enabled, add `AND u.identity_verified_at IS NOT NULL` to the WHERE.
+// NOTE: gold does NOT require identity (silver) in v1 — the signals stand on their
+// own and are hard to fake. To tighten once Stripe Identity is enabled, add
+// `AND u.identity_verified_at IS NOT NULL` to the WHERE.
 
 import { neon } from '@neondatabase/serverless';
 
 const MIN_SEALED_PITCHES = 2;
 const MIN_HONORED_NDAS = 3;
+// One mutually-confirmed closed deal is enough — both parties had to confirm it.
+const MIN_HONORED_DEALS = 1;
 
 export async function recomputeCreatorReputationTiers(env: any, _ctx?: any): Promise<{ promoted: number }> {
   const url = env?.DATABASE_URL;
@@ -32,17 +45,31 @@ export async function recomputeCreatorReputationTiers(env: any, _ctx?: any): Pro
       WHERE u.user_type = 'creator'
         AND COALESCE(u.verification_tier, 'grey') <> 'gold'
         AND (
-          SELECT COUNT(*) FROM pitch_provenance pr WHERE pr.creator_id = u.id
-        ) >= ${MIN_SEALED_PITCHES}
-        AND (
-          SELECT COUNT(*) FROM ndas n
-          JOIN pitches p ON p.id = n.pitch_id
-          WHERE p.user_id = u.id
-            AND n.status = 'signed'
-            AND n.signer_id <> u.id
-            AND n.revoked_at IS NULL
-            AND n.access_revoked_at IS NULL
-        ) >= ${MIN_HONORED_NDAS}
+          -- Path A: sealed catalogue + sustained honored-NDA interest
+          (
+            (
+              SELECT COUNT(*) FROM pitch_provenance pr WHERE pr.creator_id = u.id
+            ) >= ${MIN_SEALED_PITCHES}
+            AND (
+              SELECT COUNT(*) FROM ndas n
+              JOIN pitches p ON p.id = n.pitch_id
+              WHERE p.user_id = u.id
+                AND n.status = 'signed'
+                AND n.signer_id <> u.id
+                AND n.revoked_at IS NULL
+                AND n.access_revoked_at IS NULL
+            ) >= ${MIN_HONORED_NDAS}
+          )
+          -- Path B: a mutually-confirmed closed deal (Phase 2 — strongest earned
+          -- credential; 'dead' deals do NOT count, only real closes)
+          OR (
+            SELECT COUNT(*) FROM production_deals d
+            WHERE d.creator_id = u.id
+              AND d.outcome IN ('closed_on_platform', 'closed_off_platform')
+              AND d.outcome_confirmed_by_creator = true
+              AND d.outcome_confirmed_by_production = true
+          ) >= ${MIN_HONORED_DEALS}
+        )
       RETURNING u.id
     `;
     const promoted = rows.length;


### PR DESCRIPTION
## What & why

Phase 2 of the disintermediation-defense roadmap. Phase 1 made Pitchey the deal **system-of-record** (both sides can mark+confirm a deal outcome). This phase converts that into a **retention mechanic**: a mutually-confirmed closed deal now earns the creator the platform-native **gold** tier.

That's the research's "earned, forfeitable, platform-bound" credential — the only kind shown to retain (Airbnb Plus ~6% vs free Superhost ~0%) — and it's the creator's reward for confirming a deal back even when the money moved off-platform.

## Change (one file, `creator-reputation.ts`)
Adds a second standalone gold path to the existing promote-only daily cron:

| Path | Criteria |
|---|---|
| A (existing) | ≥2 sealed pitches **AND** ≥3 honored NDAs |
| **B (new)** | **≥1 mutually-confirmed closed deal** (`outcome ∈ {closed_on_platform, closed_off_platform}` **AND** `outcome_confirmed_by_creator` **AND** `outcome_confirmed_by_production`) |

A confirmed closed deal needs a real counterparty to co-sign, so it's harder to fake than NDAs and stands on its own (no sealed-catalogue floor). `dead` deals do **not** count.

## Verification gates
- **G1 — Promotion correctness** (verified on a throwaway Neon branch): creator with a mutual closed deal → promoted to gold; `dead` deal → NOT promoted; one-sided-confirmed deal → NOT promoted; already-gold creator → untouched. ✅
- **G2 — Invariants preserved**: promote-only (`verification_tier='gold'` only), `<> 'gold'` guard, `user_type='creator'` only — never downgrades, never touches company-verification / admin / identity tier writers. ✅
- **G3 — Typecheck + bundle**: worker `tsc` 0 errors; `build:worker` bundles. ✅
- **G4 — No migration / no frontend**: pure backend logic on columns shipped in #341 (migration 114, already live on prod). ✅

## Notes
- The function runs via the existing daily cron (`0 0 * * *`) — no wiring change. New gold promotions land on the next daily run.
- **Deferred** (explicit product decision): the producer/investor-side reputation signal. They already earn gold via company verification; a buyer-side surface is its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)