### PR TITLE
feat(deals): structured negotiation thread (P3)

### DIFF
--- a/frontend/src/components/dashboard/CreatorDealInbox.tsx
+++ b/frontend/src/components/dashboard/CreatorDealInbox.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState, useCallback } from 'react';
-import { Handshake, Check, X, Reply, Flag, CheckCircle2 } from 'lucide-react';
+import { Handshake, Check, X, Reply, Flag, CheckCircle2, MessageSquare } from 'lucide-react';
 import apiClient from '../../lib/api-client';
 import { formatNumber } from '@shared/utils/formatters';
+import DealThread from '../deals/DealThread';
 
 // Creator Deal Inbox (moat #6) — production deals proposed to the creator, with
 // accept / counter / reject. Self-contained; renders null when there are no deals
@@ -63,6 +64,7 @@ export default function CreatorDealInbox() {
   const [outcomeAmount, setOutcomeAmount] = useState('');
   const [outcomeTerms, setOutcomeTerms] = useState('');
   const [outcomeDate, setOutcomeDate] = useState('');
+  const [threadFor, setThreadFor] = useState<number | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -305,6 +307,18 @@ export default function CreatorDealInbox() {
                   </div>
                 </div>
               )}
+
+              {/* Negotiation thread (P3) */}
+              <div className="mt-3 border-t border-gray-100 pt-2">
+                <button
+                  type="button"
+                  onClick={() => setThreadFor(threadFor === d.id ? null : d.id)}
+                  className="inline-flex items-center gap-1 text-gray-500 hover:text-purple-700 text-sm font-medium"
+                >
+                  <MessageSquare className="w-4 h-4" /> {threadFor === d.id ? 'Hide discussion' : 'Discuss'}
+                </button>
+                {threadFor === d.id && <DealThread dealId={d.id} />}
+              </div>
             </li>
           );
         })}

--- a/frontend/src/components/deals/DealThread.tsx
+++ b/frontend/src/components/deals/DealThread.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Send, Loader2 } from 'lucide-react';
+import apiClient from '../../lib/api-client';
+import { formatNumber } from '@shared/utils/formatters';
+
+// Deal negotiation thread (disintermediation defense P3). Shared by the creator
+// deal inbox and the production deals page — role-neutral, deal-scoped. Keeps the
+// back-and-forth (and any proposed terms) on Pitchey instead of in email.
+
+interface DealMessage {
+  id: number;
+  sender_id: number;
+  sender_role: 'creator' | 'production';
+  kind: 'message' | 'counter';
+  body: string | null;
+  proposed_amount: number | null;
+  proposed_terms: string | null;
+  created_at: string;
+  sender_name: string | null;
+}
+
+export default function DealThread({ dealId }: { dealId: number }) {
+  const [messages, setMessages] = useState<DealMessage[] | null>(null);
+  const [text, setText] = useState('');
+  const [amount, setAmount] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await apiClient.get<{ messages: DealMessage[] }>(`/api/deals/${dealId}/messages`);
+      setMessages(res?.success && res.data?.messages ? res.data.messages : []);
+    } catch {
+      setMessages([]);
+    }
+  }, [dealId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const send = useCallback(async () => {
+    const payload: Record<string, unknown> = {};
+    if (text.trim()) payload.body = text.trim();
+    if (amount.trim()) payload.proposedAmount = Number(amount);
+    if (!payload.body && payload.proposedAmount === undefined) return;
+    setBusy(true);
+    try {
+      await apiClient.post(`/api/deals/${dealId}/messages`, payload);
+      setText('');
+      setAmount('');
+      await load();
+    } catch {
+      /* best-effort; reload reflects truth */
+    } finally {
+      setBusy(false);
+    }
+  }, [dealId, text, amount, load]);
+
+  return (
+    <div className="mt-3 rounded-lg bg-gray-50 p-3">
+      {messages === null ? (
+        <div className="flex items-center gap-2 text-xs text-gray-400 py-2">
+          <Loader2 className="w-3.5 h-3.5 animate-spin" /> Loading thread…
+        </div>
+      ) : messages.length === 0 ? (
+        <p className="text-xs text-gray-400 py-1">No messages yet. Start the negotiation here to keep it on Pitchey.</p>
+      ) : (
+        <ul className="space-y-2 mb-3 max-h-64 overflow-y-auto">
+          {messages.map((m) => (
+            <li key={m.id} className="text-sm">
+              <div className="flex items-center gap-2">
+                <span className="font-medium text-gray-800">{m.sender_name ?? 'User'}</span>
+                <span className="text-[10px] uppercase tracking-wide text-gray-400">{m.sender_role}</span>
+                {m.kind === 'counter' && (
+                  <span className="text-[10px] font-medium rounded-full px-1.5 py-0.5 bg-blue-100 text-blue-700">counter</span>
+                )}
+                <span className="text-[10px] text-gray-400">{new Date(m.created_at).toLocaleString()}</span>
+              </div>
+              {m.body && <p className="text-gray-700">{m.body}</p>}
+              {(m.proposed_amount != null || m.proposed_terms) && (
+                <p className="text-xs text-blue-700">
+                  Proposed{m.proposed_amount != null ? ` €${formatNumber(m.proposed_amount)}` : ''}
+                  {m.proposed_terms ? ` · ${m.proposed_terms}` : ''}
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex items-center gap-2">
+        <input
+          type="text" value={text} onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') void send(); }}
+          aria-label="Message"
+          className="flex-1 border border-gray-200 rounded-lg px-2 py-1.5 text-sm"
+          placeholder="Message…"
+        />
+        <input
+          type="number" value={amount} onChange={(e) => setAmount(e.target.value)}
+          aria-label="Proposed amount"
+          className="w-28 border border-gray-200 rounded-lg px-2 py-1.5 text-sm"
+          placeholder="€ amount"
+        />
+        <button
+          type="button" disabled={busy}
+          onClick={() => void send()}
+          aria-label="Send"
+          className="inline-flex items-center gap-1 bg-purple-600 hover:bg-purple-700 disabled:opacity-50 text-white text-sm font-medium rounded-lg px-3 py-1.5"
+        >
+          <Send className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/portals/production/pages/ProductionDeals.tsx
+++ b/frontend/src/portals/production/pages/ProductionDeals.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState, useCallback } from 'react';
-import { Handshake, Flag, Check, CheckCircle2, Loader2 } from 'lucide-react';
+import { Handshake, Flag, Check, CheckCircle2, Loader2, MessageSquare } from 'lucide-react';
 import apiClient from '@/lib/api-client';
 import { ProductionService } from '../services/production.service';
 import { formatNumber } from '@shared/utils/formatters';
+import DealThread from '@/components/deals/DealThread';
 
 // Production Deals page (disintermediation defense P1 — deal system-of-record).
 // The producer's view of deals they've proposed, with the both-sided "mark outcome"
@@ -57,6 +58,7 @@ export default function ProductionDeals() {
   const [outcomeAmount, setOutcomeAmount] = useState('');
   const [outcomeTerms, setOutcomeTerms] = useState('');
   const [outcomeDate, setOutcomeDate] = useState('');
+  const [threadFor, setThreadFor] = useState<number | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -240,6 +242,18 @@ export default function ProductionDeals() {
                     </div>
                   </div>
                 )}
+
+                {/* Negotiation thread (P3) */}
+                <div className="mt-3 border-t border-gray-100 pt-2">
+                  <button
+                    type="button"
+                    onClick={() => setThreadFor(threadFor === d.id ? null : d.id)}
+                    className="inline-flex items-center gap-1 text-gray-500 hover:text-brand-portal-production text-sm font-medium"
+                  >
+                    <MessageSquare className="w-4 h-4" /> {threadFor === d.id ? 'Hide discussion' : 'Discuss'}
+                  </button>
+                  {threadFor === d.id && <DealThread dealId={d.id} />}
+                </div>
               </li>
             );
           })}

--- a/src/db/migrations/115_deal_messages.sql
+++ b/src/db/migrations/115_deal_messages.sql
@@ -1,0 +1,33 @@
+-- 115_deal_messages.sql
+--
+-- Phase 3 of the disintermediation-defense roadmap — structured negotiation thread.
+--
+-- Today the back-and-forth on a deal is a text-blob appended to
+-- `production_deals.notes` (see creator-deals.ts respond: `notes || '[Creator
+-- counter]: …'`). It has no structure (who/when/how-much), can't be threaded, and
+-- the moment a real negotiation starts the parties move to email — taking the deal
+-- (and the relationship) off-platform. That's a disintermediation leak.
+--
+-- A deal-scoped thread keeps the negotiation ON Pitchey: each entry records who
+-- sent it, when, an optional free-form message, and an optional structured
+-- terms-delta (proposed amount / terms). It is NON-binding — the deal state machine
+-- (accept/counter/reject, mark-outcome) still owns status + standing terms; the
+-- thread is the conversation around it.
+--
+-- Additive + idempotent. ON DELETE CASCADE so a deleted deal takes its thread.
+
+CREATE TABLE IF NOT EXISTS deal_messages (
+  id          SERIAL PRIMARY KEY,
+  deal_id     INTEGER NOT NULL REFERENCES production_deals(id) ON DELETE CASCADE,
+  sender_id   INTEGER NOT NULL,
+  -- denormalised from the deal at write time so the thread renders without a join
+  sender_role VARCHAR(16) NOT NULL CHECK (sender_role IN ('creator', 'production')),
+  -- 'message' = free-form; 'counter' = carries a structured proposed terms-delta
+  kind        VARCHAR(16) NOT NULL DEFAULT 'message' CHECK (kind IN ('message', 'counter')),
+  body            TEXT,
+  proposed_amount NUMERIC,
+  proposed_terms  TEXT,
+  created_at  TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_deal_messages_deal ON deal_messages (deal_id, created_at);

--- a/src/handlers/creator-deals.ts
+++ b/src/handlers/creator-deals.ts
@@ -153,6 +153,15 @@ export async function respondToCreatorDeal(request: Request, env: Env): Promise<
       )
     `, { fallback: [], context: 'creator-deals.respond.notify' });
 
+    // Mirror a counter into the structured negotiation thread (P3) — best-effort,
+    // so the deal thread is the complete record and not just the notes-blob.
+    if (action === 'counter') {
+      await safeQuery(() => sql`
+        INSERT INTO deal_messages (deal_id, sender_id, sender_role, kind, body, proposed_amount)
+        VALUES (${dealId}, ${Number(userId)}, 'creator', 'counter', ${message || null}, ${counterAmount})
+      `, { fallback: [], context: 'creator-deals.respond.thread-mirror' });
+    }
+
     return jsonResponse({ success: true, data: { deal: updated } }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));

--- a/src/handlers/deal-messages.ts
+++ b/src/handlers/deal-messages.ts
@@ -1,0 +1,147 @@
+/**
+ * Deal negotiation thread — Phase 3 of the disintermediation-defense roadmap.
+ *
+ * Keeps the back-and-forth on a deal ON Pitchey instead of in email. Today counters
+ * are a text-blob in `production_deals.notes`; this is a structured, deal-scoped
+ * thread: each entry records who sent it, when, an optional free-form message, and
+ * an optional structured terms-delta (proposed amount / terms).
+ *
+ * NON-binding by design: the deal state machine (accept/counter/reject in
+ * creator-deals.ts, mark-outcome in deal-outcome.ts) still owns status + standing
+ * terms. The thread is the conversation around it. Role-neutral — both portals hit
+ * the same routes; the caller's role is resolved from the deal row.
+ *
+ *   GET  /api/deals/:id/messages   — list the thread (party-gated)
+ *   POST /api/deals/:id/messages   — post a message / structured counter (party-gated)
+ */
+
+import { getDb } from '../db/connection';
+import type { Env } from '../db/connection';
+import { getCorsHeaders } from '../utils/response';
+import { getUserId } from '../utils/auth-extract';
+import { safeQuery } from '../db/safe-query';
+
+function jsonResponse(data: unknown, origin: string | null, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...getCorsHeaders(origin) },
+  });
+}
+function errorResponse(message: string, origin: string | null, status = 400): Response {
+  return jsonResponse({ success: false, error: message }, origin, status);
+}
+
+interface DealParties {
+  id: number;
+  creator_id: number;
+  production_company_id: number;
+  pitch_id: number | null;
+}
+
+function dealIdFromPath(url: string): number {
+  const parts = new URL(url).pathname.split('/'); // /api/deals/:id/messages
+  return Number(parts[parts.length - 2]);
+}
+
+/** Load the deal and resolve the caller's party role, or null if not a party. */
+async function loadPartyDeal(sql: ReturnType<typeof getDb>, dealId: number, userId: string | number) {
+  const [deal] = await sql`
+    SELECT id, creator_id, production_company_id, pitch_id
+    FROM production_deals WHERE id = ${dealId}
+  ` as unknown as DealParties[];
+  if (!deal) return { deal: null as DealParties | null, role: null as 'creator' | 'production' | null };
+  const role = String(deal.creator_id) === String(userId) ? 'creator'
+    : String(deal.production_company_id) === String(userId) ? 'production'
+    : null;
+  return { deal, role };
+}
+
+/** GET /api/deals/:id/messages */
+export async function getDealMessages(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+  const userId = await getUserId(request, env);
+  if (!userId) return errorResponse('Unauthorized', origin, 401);
+
+  const sql = getDb(env);
+  if (!sql) return jsonResponse({ success: true, data: { messages: [] } }, origin);
+
+  try {
+    const dealId = dealIdFromPath(request.url);
+    if (!dealId || Number.isNaN(dealId)) return errorResponse('Invalid deal id', origin);
+
+    const { deal, role } = await loadPartyDeal(sql, dealId, userId);
+    if (!deal) return errorResponse('Deal not found', origin, 404);
+    if (!role) return errorResponse('Forbidden', origin, 403);
+
+    const result = await safeQuery(() => sql`
+      SELECT m.id, m.sender_id, m.sender_role, m.kind, m.body,
+             m.proposed_amount, m.proposed_terms, m.created_at,
+             COALESCE(NULLIF(TRIM(u.first_name || ' ' || u.last_name), ''), u.company_name, u.username, 'User') AS sender_name
+      FROM deal_messages m
+      LEFT JOIN users u ON u.id = m.sender_id
+      WHERE m.deal_id = ${dealId}
+      ORDER BY m.created_at ASC
+    `, { fallback: [], context: 'deal-messages.list' });
+
+    return jsonResponse({ success: true, data: { messages: result.rows } }, origin);
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error('getDealMessages error:', e.message);
+    return jsonResponse({ success: true, data: { messages: [] } }, origin);
+  }
+}
+
+/** POST /api/deals/:id/messages */
+export async function postDealMessage(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+  const userId = await getUserId(request, env);
+  if (!userId) return errorResponse('Unauthorized', origin, 401);
+
+  const sql = getDb(env);
+  if (!sql) return errorResponse('Database unavailable', origin, 503);
+
+  try {
+    const dealId = dealIdFromPath(request.url);
+    if (!dealId || Number.isNaN(dealId)) return errorResponse('Invalid deal id', origin);
+
+    const { deal, role } = await loadPartyDeal(sql, dealId, userId);
+    if (!deal) return errorResponse('Deal not found', origin, 404);
+    if (!role) return errorResponse('Forbidden', origin, 403);
+
+    const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+    const text = typeof body.body === 'string' ? body.body.slice(0, 4000).trim() : '';
+    const proposedAmount = Number.isFinite(body.proposedAmount as number) ? Number(body.proposedAmount) : null;
+    const proposedTerms = typeof body.proposedTerms === 'string' ? body.proposedTerms.slice(0, 2000).trim() : '';
+
+    if (!text && proposedAmount === null && !proposedTerms) {
+      return errorResponse('Message body or a proposed term is required', origin);
+    }
+    const kind = (proposedAmount !== null || proposedTerms) ? 'counter' : 'message';
+
+    const [message] = await sql`
+      INSERT INTO deal_messages (deal_id, sender_id, sender_role, kind, body, proposed_amount, proposed_terms)
+      VALUES (${dealId}, ${Number(userId)}, ${role}, ${kind}, ${text || null}, ${proposedAmount}, ${proposedTerms || null})
+      RETURNING id, sender_id, sender_role, kind, body, proposed_amount, proposed_terms, created_at
+    ` as unknown as Record<string, unknown>[];
+
+    // Notify the counterparty — best-effort.
+    const counterpartyId = role === 'creator' ? deal.production_company_id : deal.creator_id;
+    await safeQuery(() => sql`
+      INSERT INTO notifications (user_id, type, title, message, related_user_id, related_pitch_id, created_at)
+      VALUES (
+        ${counterpartyId}, 'deal_message',
+        ${kind === 'counter' ? 'New counter-offer' : 'New deal message'},
+        ${kind === 'counter'
+          ? 'The other party proposed new terms on your deal'
+          : 'The other party sent a message on your deal'},
+        ${Number(userId)}, ${deal.pitch_id}, NOW()
+      )
+    `, { fallback: [], context: 'deal-messages.notify' });
+
+    return jsonResponse({ success: true, data: { message } }, origin, 201);
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error('postDealMessage error:', e.message);
+    return errorResponse('Failed to post message', origin, 500);
+  }
+}

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -3632,6 +3632,15 @@ class RouteRegistry {
       const { markDealOutcome } = await import('./handlers/deal-outcome');
       return markDealOutcome(req, this.env);
     });
+    // Deal negotiation thread (disintermediation defense P3) — role-neutral, both portals.
+    this.register('GET', '/api/deals/:id/messages', async (req) => {
+      const { getDealMessages } = await import('./handlers/deal-messages');
+      return getDealMessages(req, this.env);
+    });
+    this.register('POST', '/api/deals/:id/messages', async (req) => {
+      const { postDealMessage } = await import('./handlers/deal-messages');
+      return postDealMessage(req, this.env);
+    });
     this.register('GET', '/api/creator/pitches/analytics', async (req) => {
       const { creatorPitchesAnalyticsHandler } = await import('./handlers/creator-sidebar');
       return creatorPitchesAnalyticsHandler(req, this.env);


### PR DESCRIPTION
## What & why

Phase 3 of the disintermediation-defense roadmap. Today a deal's back-and-forth is a text-blob appended to `production_deals.notes` — no structure, not threaded, and the moment a real negotiation starts the parties move to email, taking the deal (and relationship) off Pitchey. This adds a **deal-scoped, structured negotiation thread** that keeps it on-platform.

## Changes
- **Migration 115** (additive, idempotent): `deal_messages` — `deal_id` FK `ON DELETE CASCADE`, `sender_id` + denormalised `sender_role`, `kind` (`message`/`counter`), `body`, `proposed_amount`, `proposed_terms`.
- **`src/handlers/deal-messages.ts`**: `GET`/`POST /api/deals/:id/messages` — role-neutral (caller's party role resolved from the deal row), party-gated, counterparty notify. **Non-binding**: the deal state machine (accept/counter/reject, mark-outcome) still owns status + standing terms.
- **`creator-deals.ts`**: the creator counter action now also mirrors a structured `counter` into the thread (best-effort) so the thread is the complete record, not the notes-blob.
- **`DealThread`** shared component wired into `CreatorDealInbox` + the production `ProductionDeals` page (both portals, same endpoints).

## Verification gates
- **G1 — Schema** (verified on a throwaway Neon branch): table idempotent; `message` + structured `counter` insert under the CHECK constraints; list query resolves sender names and orders the thread; FK `ON DELETE CASCADE`. ✅
- **G2 — Access**: party-gated (only the deal's creator or production company); role-neutral handler. ✅
- **G3 — Typecheck/bundle**: worker `tsc` 0, `build:worker` bundles; frontend `tsc` 0. ✅
- **G4 — catch-swallow**: `--include-worker --threshold 0` → 0 untagged. ✅
- **G5 — Unit**: `CreatorDealInbox` 6/6. ✅
- **G6 — pre-merge**: apply migration 115 to prod (auto-deploy path has no migration gate — migrate **before** merge). ⏳

## Notes
- Non-binding by design — keeps the existing state machine authoritative; the thread is the conversation around it.
- Nothing applied to prod yet; migration 115 verified on a throwaway Neon branch only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)