### PR TITLE
fix(launch): pre-launch hardening batch

### DIFF
--- a/frontend/src/lib/__tests__/apiServices.test.ts
+++ b/frontend/src/lib/__tests__/apiServices.test.ts
@@ -57,7 +57,6 @@ vi.mock('../../config', () => ({
 
 // ─── Dynamic import (after all vi.mock calls) ─────────────────────────
 let ndaAPI: any
-let companyAPI: any
 let analyticsAPI: any
 let messageAPI: any
 let pitchServicesAPI: any
@@ -68,7 +67,6 @@ let getUserId: any
 beforeAll(async () => {
   const mod = await import('../apiServices')
   ndaAPI = mod.ndaAPI
-  companyAPI = mod.companyAPI
   analyticsAPI = mod.analyticsAPI
   messageAPI = mod.messageAPI
   pitchServicesAPI = mod.pitchServicesAPI
@@ -168,36 +166,7 @@ describe('apiServices.ts', () => {
     })
   })
 
-  // ─── companyAPI ───────────────────────────────────────────────────
-  describe('companyAPI.getVerificationStatus', () => {
-    it('returns success with spread data', async () => {
-      mockApiGet.mockResolvedValueOnce(success({ status: 'pending', verified: false }))
-      const result = await companyAPI.getVerificationStatus()
-      expect(result.success).toBe(true)
-      expect(result.status).toBe('pending')
-    })
-
-    it('returns success:false on error', async () => {
-      mockApiGet.mockResolvedValueOnce(failure('Not found'))
-      const result = await companyAPI.getVerificationStatus()
-      expect(result.success).toBe(false)
-    })
-  })
-
-  describe('companyAPI.submitVerification', () => {
-    it('posts verification data and returns spread response', async () => {
-      mockApiPost.mockResolvedValueOnce(success({ submitted: true }))
-      const result = await companyAPI.submitVerification({
-        companyName: 'Acme',
-        companyNumber: '12345',
-      })
-      expect(result.success).toBe(true)
-      expect(mockApiPost).toHaveBeenCalledWith('/api/company/verify', {
-        companyName: 'Acme',
-        companyNumber: '12345',
-      })
-    })
-  })
+  // companyAPI removed 2026-06-21 — wrapped the dead /api/company/verify endpoint.
 
   // ─── analyticsAPI ─────────────────────────────────────────────────
   describe('analyticsAPI.getDashboardAnalytics', () => {

--- a/frontend/src/lib/apiServices.ts
+++ b/frontend/src/lib/apiServices.ts
@@ -146,31 +146,10 @@ export const ndaAPI = {
   },
 };
 
-// Company Verification Services (Updated to use robust API client)
-export const companyAPI = {
-  // Get verification status
-  async getVerificationStatus() {
-    const response = await apiClient.get<any>('/api/company/verify');
-    if (response.success) {
-      return { success: true, ...(response.data as object || {}) };
-    }
-    return { success: false, error: response.error?.message };
-  },
-
-  // Submit verification request
-  async submitVerification(data: {
-    companyName: string;
-    companyNumber: string;
-    companyWebsite?: string;
-    companyAddress?: string;
-  }) {
-    const response = await apiClient.post<any>('/api/company/verify', data);
-    if (response.success) {
-      return { success: true, ...(response.data as object || {}) };
-    }
-    return { success: false, error: response.error?.message };
-  },
-};
+// Company verification wrappers removed 2026-06-21: they called the dead
+// /api/company/verify endpoint (now unregistered — it 500s on a phantom column).
+// The live company-verification path is /api/production/verify (ProductionVerification
+// page). Nothing called these wrappers (dead import only).
 
 // Analytics Services (Updated to use robust API client)
 export const analyticsAPI = {

--- a/frontend/src/pages/ProductionDashboard.tsx
+++ b/frontend/src/pages/ProductionDashboard.tsx
@@ -19,7 +19,7 @@ import { useBetterAuthStore } from '../store/betterAuthStore';
 import { usePitchStore } from '@features/pitches/store/pitchStore';
 import { pitchAPI } from '../lib/api';
 import type { Pitch } from '../lib/api';
-import { ndaAPI, analyticsAPI, companyAPI, paymentsAPI, pitchServicesAPI } from '../lib/apiServices';
+import { ndaAPI, analyticsAPI, paymentsAPI, pitchServicesAPI } from '../lib/apiServices';
 import { API_URL } from '../config';
 import apiClient, { savedPitchesAPI } from '../lib/api-client';
 import { NotificationWidget } from '../components/Dashboard/NotificationWidget';

--- a/frontend/src/pages/VerifyEmail.tsx
+++ b/frontend/src/pages/VerifyEmail.tsx
@@ -94,7 +94,7 @@ export default function VerifyEmail() {
                 Email verified successfully!
               </h3>
               <p className="text-sm text-gray-600 mb-6">
-                Next: log in and finish your profile — that's the last step before your dashboard.
+                Next: log in and complete your profile (name and a short bio) — it's required before you can reach your dashboard.
               </p>
               <p className="text-xs text-gray-500 mb-6">
                 Redirecting to login page...

--- a/frontend/src/pages/__tests__/VerifyEmail.test.tsx
+++ b/frontend/src/pages/__tests__/VerifyEmail.test.tsx
@@ -68,7 +68,7 @@ describe('VerifyEmail', () => {
       await waitFor(() => {
         expect(screen.getByText('Email verified successfully!')).toBeInTheDocument()
       })
-      expect(screen.getByText(/finish your profile/)).toBeInTheDocument()
+      expect(screen.getByText(/complete your profile/)).toBeInTheDocument()
       expect(screen.getByText('Redirecting to login page...')).toBeInTheDocument()
     })
 

--- a/src/services/stripe.service.ts
+++ b/src/services/stripe.service.ts
@@ -267,9 +267,10 @@ export class StripeService {
 
     if (!timestamp || !signature) return false;
 
-    // Reject timestamps older than 5 minutes to prevent replay attacks
+    // Reject timestamps more than 5 minutes from now (either direction) to prevent
+    // replay attacks. Math.abs guards against future-dated forgeries, not just stale ones.
     const age = Math.floor(Date.now() / 1000) - parseInt(timestamp);
-    if (age > 300) return false;
+    if (Math.abs(age) > 300) return false;
 
     const signedPayload = `${timestamp}.${payload}`;
     const key = await crypto.subtle.importKey(

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -1832,18 +1832,19 @@ class RouteRegistry {
       }
     }
 
+    // Clear BOTH the live `pitchey-session` cookie AND the legacy `better-auth-session`
+    // name. The old code cleared only the legacy name, so the real cookie lingered in
+    // the browser after logout (the session row is deleted above, so it was a dead
+    // cookie — but clearing it is correct hygiene). Two Set-Cookie headers require a
+    // Headers object (a plain object literal can only hold one).
+    const logoutHeaders = new Headers({ 'Content-Type': 'application/json', ...corsHeaders });
+    for (const cookie of (await import('./config/session.config')).createClearSessionCookie()) {
+      logoutHeaders.append('Set-Cookie', cookie);
+    }
     return new Response(JSON.stringify({
       success: true,
       data: { message: 'Logged out successfully' }
-    }), {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json',
-        // Clear the Better Auth session cookie
-        'Set-Cookie': 'better-auth-session=; Path=/; HttpOnly; Secure; SameSite=None; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
-        ...corsHeaders
-      }
-    });
+    }), { status: 200, headers: logoutHeaders });
   }
 
   /**
@@ -3085,8 +3086,10 @@ class RouteRegistry {
     this.register('POST', '/api/meetings/schedule', this.handleMeetingSchedule.bind(this));
     this.register('POST', '/api/export', this.handleExport.bind(this));
     this.register('POST', '/api/verification/start', this.handleVerificationStart.bind(this));
-    this.register('GET', '/api/company/verify', this.handleCompanyVerify.bind(this));
-    this.register('POST', '/api/company/verify', this.handleCompanyVerifySubmit.bind(this));
+    // NOTE: /api/company/verify was unregistered (2026-06-21) — it 500s on a phantom
+    // `users.verification_status` column and nothing live calls it. The live company
+    // verification path is /api/production/verify (ProductionVerification page). The
+    // dead handlers (handleCompanyVerify*) remain as orphans; do not re-wire.
     this.register('GET', '/api/info-requests', this.handleGetInfoRequests.bind(this));
     this.register('POST', '/api/info-requests', this.handleCreateInfoRequest.bind(this));
     this.register('POST', '/api/info-requests/:id/respond', this.handleRespondInfoRequest.bind(this));
@@ -9137,7 +9140,13 @@ pitchey_analytics_datapoints_per_minute 1250
 
       // Check if database is available
       if (!this.db) {
-        // Return demo/mock response if database is not available
+        // DB unreachable (e.g. Neon cold-start blip): we return a safe default so the
+        // UI doesn't break, but this hides real NDA state from a producer — surface it
+        // to ops so a transient outage isn't invisible. (Hardening to a 503 is deferred;
+        // needs a frontend retry-handling check first.)
+        if (typeof Sentry?.captureException === 'function') {
+          Sentry.captureException(new Error('getNDAStatus: DB unavailable, returning safe default'), { extra: { pitchId } });
+        }
         return builder.success({
           hasNDA: false,
           nda: null,
@@ -9165,7 +9174,11 @@ pitchey_analytics_datapoints_per_minute 1250
       });
     } catch (error) {
       console.error('NDA status error:', error);
-      // Return safe default response on error
+      // Report so a DB failure during NDA checks isn't invisible to ops; still return a
+      // safe default so the UI degrades rather than breaks.
+      if (typeof Sentry?.captureException === 'function') {
+        Sentry.captureException(error instanceof Error ? error : new Error(String(error)), { extra: { handler: 'getNDAStatus', pitchId } });
+      }
       return builder.success({
         hasNDA: false,
         nda: null,
@@ -9207,7 +9220,11 @@ pitchey_analytics_datapoints_per_minute 1250
 
       // Check if database is available
       if (!this.db) {
-        // Return demo/mock response if database is not available
+        // DB unreachable: safe default keeps the UI working, but report it so a
+        // transient outage isn't invisible to ops.
+        if (typeof Sentry?.captureException === 'function') {
+          Sentry.captureException(new Error('canRequestNDA: DB unavailable, returning safe default'), { extra: { pitchId } });
+        }
         return builder.success({
           canRequest: true,
           reason: null,
@@ -9254,7 +9271,10 @@ pitchey_analytics_datapoints_per_minute 1250
       });
     } catch (error) {
       console.error('Can request NDA error:', error);
-      // Return safe default response on error
+      // Report so a DB failure isn't invisible; still return a safe default.
+      if (typeof Sentry?.captureException === 'function') {
+        Sentry.captureException(error instanceof Error ? error : new Error(String(error)), { extra: { handler: 'canRequestNDA', pitchId } });
+      }
       return builder.success({
         canRequest: true,
         reason: null,
@@ -11756,7 +11776,11 @@ pitchey_analytics_datapoints_per_minute 1250
           // is the revocation path once Stripe gives up retrying. No new status
           // enum value introduced — surface failure via metadata.last_payment_failed_at.
           const invoice = event.data.object;
-          const subId = invoice.subscription;
+          // Stripe API v2025 drift: invoice.subscription moved to
+          // invoice.parent.subscription_details.subscription (same fallback as
+          // invoice.paid above). Without it, newer accounts skip dunning logging.
+          const subId = invoice.subscription
+            || invoice.parent?.subscription_details?.subscription;
           if (!subId) break;
 
           const [row] = await sql`


### PR DESCRIPTION
From the launch-readiness audit (26-agent fan-out → adversarial verify → synthesis). The 3 scariest "blockers" were DB-state guesses the sandboxed agents couldn't check; **verified against prod and all already satisfied**: 11 published pitches live (not empty), migrations 114/115 applied, all 10 demo accounts incl. `jamie.watcher` present. So this PR is the batch of **real, small** fixes.

## Fixes
| # | Fix | File |
|---|---|---|
| B4 | Logout clears **both** `pitchey-session` (live) + legacy `better-auth-session` (was only clearing legacy; session already invalidated server-side, so hygiene) | `worker-integrated.ts` |
| H4 | `invoice.payment_failed` reads the Stripe v2025 `invoice.parent.subscription_details.subscription` fallback (was silently skipping dunning on newer accounts) | `worker-integrated.ts` |
| M3 | Webhook timestamp check → `Math.abs(age) > 300` (rejects future-dated forgeries) | `stripe.service.ts` |
| M1 | Unregister dead `/api/company/verify` (500s on phantom `users.verification_status`; live path is `/api/production/verify`) | `worker-integrated.ts` |
| H3 | NDA status / can-request handlers report DB-unavailable + catch failures to **Sentry** (were invisible to ops); response contract unchanged | `worker-integrated.ts` |
| H7 | VerifyEmail copy: profile completion is **required** (ProfileGuard hard-redirects), not "optional last step" | `VerifyEmail.tsx` |

## Deliberately excluded
- **H6 (Axiom `.catch(()=>{})`)** — intentional fire-and-forget per `src/CLAUDE.md`; routing to Sentry would spam during an Axiom outage. Right fix is a separate Axiom-health probe. Not changed.
- **H3 "return 503" hardening** — deferred; needs a frontend retry-handling check before changing the producer-facing NDA contract.
- **H2 (CI deploy-gate)** — ships as its own PR (touches deploy workflows).

## Gates
- No migration. ✅
- worker `tsc` 0 · `build:worker` bundles · catch-swallow `--include-worker --threshold 0` → 0 untagged ✅
- frontend `tsc` 0 · `CreatorDealInbox` 6/6 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)