### PR TITLE
chore: gitignore 3 local-only .claude/skills dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,12 @@ files(1)/
 # Claude Code runtime artifacts — lock files from the scheduled-tasks skill; keep config (settings.json etc) tracked
 .claude/scheduled_tasks.lock
 
+# Local-only skills (work on disk for this dev; not shared in the repo). The 5 official
+# project skills under .claude/skills/ stay tracked; these three are personal tooling.
+.claude/skills/catch-swallow-auditor/
+.claude/skills/pr-gate-generator/
+.claude/skills/system-cartographer/
+
 # Local backup of the gitignored MCP config (contains the Neon API key — never commit)
 .mcp.json.bak
 coverage-integration/


### PR DESCRIPTION
Follow-up to #346: adds the 3 local-only skill dirs to `.gitignore` so a future `git add -A` can't re-commit them. The 5 official project skills stay tracked. No app/deploy impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)