### PR TITLE
feat(moat): structured investment-thesis schema (#7 — monetization foundation)

### DIFF
--- a/frontend/src/portals/investor/pages/InvestorSettingsProfile.tsx
+++ b/frontend/src/portals/investor/pages/InvestorSettingsProfile.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   User, Camera, Mail, Phone, MapPin, Globe, Building2,
-  TrendingUp, FileSignature, Save, X, Loader2,
+  TrendingUp, FileSignature, Save, X, Loader2, Target, Plus,
 } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@shared/components/ui/card';
 import { toast } from 'react-hot-toast';
@@ -10,8 +10,15 @@ import { useBetterAuthStore } from '@/store/betterAuthStore';
 import { sessionManager } from '@/lib/session-manager';
 import { sessionCache } from '@/store/sessionCache';
 import { UserService } from '@/services/user.service';
+import { InvestorThesisService, EMPTY_THESIS, type InvestorThesis } from '@/services/investor-thesis.service';
+import { getGenres, getFormats, getStages, getGenresSync, getFormatsSync, getStagesSync } from '@config/pitchConstants';
 import { API_URL } from '@/config';
 import { prepareImageForUpload, PRE_COMPRESSION_MAX_BYTES } from '@/utils/imageUpload';
+
+// Deal types are a fixed small platform set (not part of the pitch taxonomy).
+// Stored lower-cased; displayed title-cased.
+const DEAL_TYPES = ['option', 'acquisition', 'licensing', 'development', 'production'] as const;
+const titleCase = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
 
 // Investor-facing profile settings. Deliberately NOT a clone of the production
 // company page — an investor cares about their fund identity, the thesis
@@ -24,7 +31,6 @@ interface InvestorProfileForm {
   lastName: string;
   email: string;
   companyName: string;   // Fund / firm name
-  bio: string;           // Investment thesis
   website: string;       // Firm website
   phone: string;
   location: string;
@@ -34,8 +40,81 @@ interface InvestorProfileForm {
 
 const EMPTY: InvestorProfileForm = {
   username: '', firstName: '', lastName: '', email: '', companyName: '',
-  bio: '', website: '', phone: '', location: '', companyAddress: '', profileImage: '',
+  website: '', phone: '', location: '', companyAddress: '', profileImage: '',
 };
+
+// Chip-style multi-select — matches the marketplace genre-chip pattern.
+function ChipMultiSelect({
+  options, selected, onToggle,
+}: { options: string[]; selected: string[]; onToggle: (value: string) => void }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {options.map(opt => {
+        const active = selected.includes(opt);
+        return (
+          <button
+            key={opt}
+            type="button"
+            onClick={() => onToggle(opt)}
+            className={`px-3 py-1.5 rounded-full text-sm border transition ${
+              active
+                ? 'bg-[#5B4FC7] text-white border-[#5B4FC7]'
+                : 'bg-white text-gray-700 border-gray-300 hover:border-[#5B4FC7]'
+            }`}
+            aria-pressed={active}
+          >
+            {opt}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// Free-text tag input (Enter / comma adds; click x removes) for territories & themes.
+function TagInput({
+  tags, onChange, placeholder,
+}: { tags: string[]; onChange: (next: string[]) => void; placeholder: string }) {
+  const [draft, setDraft] = useState('');
+  const commit = () => {
+    const v = draft.trim();
+    if (v && !tags.includes(v)) onChange([...tags, v]);
+    setDraft('');
+  };
+  return (
+    <div>
+      <div className="flex flex-wrap gap-2 mb-2">
+        {tags.map(t => (
+          <span key={t} className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-indigo-50 text-[#5B4FC7] text-sm border border-indigo-200">
+            {t}
+            <button type="button" onClick={() => onChange(tags.filter(x => x !== t))} aria-label={`Remove ${t}`}>
+              <X className="w-3 h-3" />
+            </button>
+          </span>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ',') { e.preventDefault(); commit(); }
+          }}
+          placeholder={placeholder}
+          className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#5B4FC7] focus:border-transparent"
+        />
+        <button
+          type="button"
+          onClick={commit}
+          className="px-3 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 flex items-center gap-1"
+        >
+          <Plus className="w-4 h-4" /> Add
+        </button>
+      </div>
+    </div>
+  );
+}
 
 export default function InvestorSettingsProfile() {
   const navigate = useNavigate();
@@ -43,8 +122,33 @@ export default function InvestorSettingsProfile() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [savingThesis, setSavingThesis] = useState(false);
   const [uploadingImage, setUploadingImage] = useState(false);
   const [form, setForm] = useState<InvestorProfileForm>(EMPTY);
+
+  // Structured investment mandate — separate resource from the profile above.
+  const [thesis, setThesis] = useState<InvestorThesis>(EMPTY_THESIS);
+
+  // Taxonomy lists — SAME source the pitch CREATE form uses (configService via
+  // @config/pitchConstants). Seed synchronously from the cached/fallback config,
+  // then refresh from the API.
+  const [genreOptions, setGenreOptions] = useState<string[]>([...getGenresSync()]);
+  const [formatOptions, setFormatOptions] = useState<string[]>([...getFormatsSync()]);
+  const [stageOptions, setStageOptions] = useState<string[]>([...getStagesSync()]);
+
+  useEffect(() => {
+    const loadTaxonomy = async () => {
+      try {
+        const [g, f, s] = await Promise.all([getGenres(), getFormats(), getStages()]);
+        setGenreOptions(g);
+        setFormatOptions(f);
+        setStageOptions(s);
+      } catch {
+        // Already seeded with sync fallback values.
+      }
+    };
+    void loadTaxonomy();
+  }, []);
 
   useEffect(() => {
     const fetchProfile = async () => {
@@ -62,7 +166,6 @@ export default function InvestorSettingsProfile() {
             lastName: (d.lastName as string) ?? '',
             email: (d.email as string) ?? '',
             companyName: (d.companyName as string) ?? '',
-            bio: (d.bio as string) ?? '',
             website: (d.website as string) ?? '',
             phone: (d.phone as string) ?? '',
             location: (d.location as string) ?? '',
@@ -76,7 +179,6 @@ export default function InvestorSettingsProfile() {
             username: user.username ?? '',
             email: user.email ?? '',
             companyName: user.companyName ?? '',
-            bio: user.bio ?? '',
           }));
         }
       } catch (err) {
@@ -89,8 +191,57 @@ export default function InvestorSettingsProfile() {
     void fetchProfile();
   }, [user]);
 
+  // Load the structured thesis independently of the profile.
+  useEffect(() => {
+    const fetchThesis = async () => {
+      try {
+        const t = await InvestorThesisService.getThesis();
+        setThesis(t);
+      } catch (err) {
+        const e = err instanceof Error ? err : new Error(String(err));
+        console.error('Failed to load investment thesis:', e.message);
+      }
+    };
+    void fetchThesis();
+  }, []);
+
   const set = (field: keyof InvestorProfileForm, value: string) =>
     setForm(prev => ({ ...prev, [field]: value }));
+
+  // Toggle a value in one of the thesis multi-select arrays.
+  const toggleThesisArray = (
+    field: 'genres' | 'formats' | 'stages' | 'dealTypes',
+    value: string,
+  ) =>
+    setThesis(prev => ({
+      ...prev,
+      [field]: prev[field].includes(value)
+        ? prev[field].filter(v => v !== value)
+        : [...prev[field], value],
+    }));
+
+  // Parse a numeric input into number|null (empty → null), clamped non-negative.
+  const setThesisNum = (
+    field: 'budgetMinUsd' | 'budgetMaxUsd' | 'checkSizeMinUsd' | 'checkSizeMaxUsd',
+    raw: string,
+  ) => {
+    const digits = raw.replace(/[^0-9]/g, '');
+    setThesis(prev => ({ ...prev, [field]: digits ? Number(digits) : null }));
+  };
+
+  const handleSaveThesis = async () => {
+    setSavingThesis(true);
+    try {
+      const saved = await InvestorThesisService.updateThesis(thesis);
+      setThesis(saved);
+      toast.success('Investment thesis saved');
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      toast.error(e.message || 'Failed to save investment thesis');
+    } finally {
+      setSavingThesis(false);
+    }
+  };
 
   const refreshSession = async () => {
     // Same sequence Settings.tsx uses (the #280 fix): clear the dedup cache,
@@ -118,7 +269,6 @@ export default function InvestorSettingsProfile() {
         lastName: form.lastName.trim() || undefined,
         email: email && email !== originalEmail ? email : undefined,
         companyName: form.companyName,
-        bio: form.bio,
         website: form.website,
         phone: form.phone,
         location: form.location,
@@ -304,16 +454,173 @@ export default function InvestorSettingsProfile() {
                   />
                 </div>
               </div>
-              <div className="mt-6">
-                <label className="block text-sm font-medium text-gray-700 mb-2">Investment Thesis</label>
-                <textarea
-                  value={form.bio}
-                  onChange={(e) => set('bio', e.target.value)}
-                  rows={4}
-                  placeholder="What you invest in — genres, stage, typical cheque size, what makes a project a fit. Creators and producers read this before they pitch you."
-                  className={inputCls}
-                />
-                <p className="text-xs text-gray-500 mt-1">Shown on your public investor profile.</p>
+            </CardContent>
+          </Card>
+
+          {/* Investment Thesis (structured mandate) */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Target className="h-5 w-5" />
+                Investment Thesis
+              </CardTitle>
+              <CardDescription>
+                Your structured mandate — what you back, at what stage, and for how much.
+                Creators and producers read this before they pitch you.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-6">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">Genres</label>
+                  <ChipMultiSelect
+                    options={genreOptions}
+                    selected={thesis.genres}
+                    onToggle={(v) => toggleThesisArray('genres', v)}
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">Formats</label>
+                  <ChipMultiSelect
+                    options={formatOptions}
+                    selected={thesis.formats}
+                    onToggle={(v) => toggleThesisArray('formats', v)}
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">Development Stages</label>
+                  <ChipMultiSelect
+                    options={stageOptions}
+                    selected={thesis.stages}
+                    onToggle={(v) => toggleThesisArray('stages', v)}
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">Deal Types</label>
+                  <ChipMultiSelect
+                    options={DEAL_TYPES.map(titleCase)}
+                    selected={thesis.dealTypes.map(titleCase)}
+                    onToggle={(label) => toggleThesisArray('dealTypes', label.toLowerCase())}
+                  />
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">Territories</label>
+                    <TagInput
+                      tags={thesis.territories}
+                      onChange={(next) => setThesis(prev => ({ ...prev, territories: next }))}
+                      placeholder="e.g. North America, EU, UK…"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">Themes</label>
+                    <TagInput
+                      tags={thesis.themes}
+                      onChange={(next) => setThesis(prev => ({ ...prev, themes: next }))}
+                      placeholder="e.g. climate, female-led, sci-fi…"
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Budget Range <span className="text-gray-400 font-normal">(project budget, USD)</span>
+                  </label>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div className="relative">
+                      <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">$</span>
+                      <input
+                        type="text"
+                        inputMode="numeric"
+                        value={thesis.budgetMinUsd != null ? thesis.budgetMinUsd.toLocaleString('en-US') : ''}
+                        onChange={(e) => setThesisNum('budgetMinUsd', e.target.value)}
+                        placeholder="Min"
+                        className="w-full pl-7 pr-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#5B4FC7] focus:border-transparent"
+                      />
+                    </div>
+                    <div className="relative">
+                      <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">$</span>
+                      <input
+                        type="text"
+                        inputMode="numeric"
+                        value={thesis.budgetMaxUsd != null ? thesis.budgetMaxUsd.toLocaleString('en-US') : ''}
+                        onChange={(e) => setThesisNum('budgetMaxUsd', e.target.value)}
+                        placeholder="Max"
+                        className="w-full pl-7 pr-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#5B4FC7] focus:border-transparent"
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Cheque Size <span className="text-gray-400 font-normal">(your typical investment, USD)</span>
+                  </label>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div className="relative">
+                      <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">$</span>
+                      <input
+                        type="text"
+                        inputMode="numeric"
+                        value={thesis.checkSizeMinUsd != null ? thesis.checkSizeMinUsd.toLocaleString('en-US') : ''}
+                        onChange={(e) => setThesisNum('checkSizeMinUsd', e.target.value)}
+                        placeholder="Min"
+                        className="w-full pl-7 pr-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#5B4FC7] focus:border-transparent"
+                      />
+                    </div>
+                    <div className="relative">
+                      <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">$</span>
+                      <input
+                        type="text"
+                        inputMode="numeric"
+                        value={thesis.checkSizeMaxUsd != null ? thesis.checkSizeMaxUsd.toLocaleString('en-US') : ''}
+                        onChange={(e) => setThesisNum('checkSizeMaxUsd', e.target.value)}
+                        placeholder="Max"
+                        className="w-full pl-7 pr-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#5B4FC7] focus:border-transparent"
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">Positioning statement</label>
+                  <textarea
+                    value={thesis.positioning}
+                    onChange={(e) => setThesis(prev => ({ ...prev, positioning: e.target.value }))}
+                    rows={4}
+                    placeholder="What makes a project a fit beyond the filters above — your angle, the kind of stories you back, what makes a project a fit. Creators and producers read this before they pitch you."
+                    className={inputCls}
+                  />
+                  <p className="text-xs text-gray-500 mt-1">Shown on your public investor profile.</p>
+                </div>
+
+                <label className="flex items-start gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={thesis.isPublic}
+                    onChange={(e) => setThesis(prev => ({ ...prev, isPublic: e.target.checked }))}
+                    className="mt-1 w-4 h-4 text-[#5B4FC7] border-gray-300 rounded focus:ring-[#5B4FC7]"
+                  />
+                  <span>
+                    <span className="text-sm font-medium text-gray-900 block">Show my thesis on my public profile</span>
+                    <span className="text-xs text-gray-500">When off, your mandate stays private and is used only for matching.</span>
+                  </span>
+                </label>
+
+                <div className="pt-2">
+                  <button
+                    onClick={() => { void handleSaveThesis(); }}
+                    disabled={savingThesis}
+                    className="px-6 py-3 bg-[#5B4FC7] text-white rounded-lg hover:bg-[#4d42b0] transition disabled:opacity-50 flex items-center gap-2"
+                  >
+                    {savingThesis ? <Loader2 className="w-5 h-5 animate-spin" /> : <Save className="w-5 h-5" />}
+                    Save Thesis
+                  </button>
+                </div>
               </div>
             </CardContent>
           </Card>

--- a/frontend/src/services/investor-thesis.service.ts
+++ b/frontend/src/services/investor-thesis.service.ts
@@ -1,0 +1,93 @@
+// Investor Thesis Service
+//
+// A structured investment mandate is the monetization foundation: it's the
+// machine-readable version of the prose thesis that used to live in the
+// investor profile's `bio` textarea. It powers targeted creator/producer
+// outreach and (later) matching. This is a DEDICATED resource, separate from
+// the generic /api/user/profile, so the thesis can be revised and surfaced
+// independently of identity/fund/NDA-address fields.
+//
+// Contract (camelCase, mirrors the backend):
+//   GET /api/investor/thesis  -> { success, thesis: ThesisObject }
+//   PUT /api/investor/thesis  (body = ThesisObject) -> { success, thesis }
+import { apiClient } from '../lib/api-client';
+
+export interface InvestorThesis {
+  genres: string[];
+  formats: string[];
+  stages: string[];
+  dealTypes: string[];
+  territories: string[];
+  themes: string[];
+  budgetMinUsd: number | null;
+  budgetMaxUsd: number | null;
+  checkSizeMinUsd: number | null;
+  checkSizeMaxUsd: number | null;
+  positioning: string;
+  isPublic: boolean;
+}
+
+// A clean empty mandate — used as the initial form state and as a safe default
+// when the backend returns an as-yet-unfilled thesis.
+export const EMPTY_THESIS: InvestorThesis = {
+  genres: [],
+  formats: [],
+  stages: [],
+  dealTypes: [],
+  territories: [],
+  themes: [],
+  budgetMinUsd: null,
+  budgetMaxUsd: null,
+  checkSizeMinUsd: null,
+  checkSizeMaxUsd: null,
+  positioning: '',
+  isPublic: false,
+};
+
+// Coerce a partial/loose payload into a well-formed thesis so the form never
+// chokes on a missing field from an older record.
+function normalize(raw: Partial<InvestorThesis> | null | undefined): InvestorThesis {
+  const r = raw ?? {};
+  const arr = (v: unknown): string[] => (Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : []);
+  const num = (v: unknown): number | null => (typeof v === 'number' && Number.isFinite(v) ? v : null);
+  return {
+    genres: arr(r.genres),
+    formats: arr(r.formats),
+    stages: arr(r.stages),
+    dealTypes: arr(r.dealTypes),
+    territories: arr(r.territories),
+    themes: arr(r.themes),
+    budgetMinUsd: num(r.budgetMinUsd),
+    budgetMaxUsd: num(r.budgetMaxUsd),
+    checkSizeMinUsd: num(r.checkSizeMinUsd),
+    checkSizeMaxUsd: num(r.checkSizeMaxUsd),
+    positioning: typeof r.positioning === 'string' ? r.positioning : '',
+    isPublic: r.isPublic === true,
+  };
+}
+
+export class InvestorThesisService {
+  static async getThesis(): Promise<InvestorThesis> {
+    const response = await apiClient.get<{ success: boolean; thesis: Partial<InvestorThesis> }>(
+      '/api/investor/thesis'
+    );
+    if (!response.success) {
+      throw new Error(response.error?.message || 'Failed to load investment thesis');
+    }
+    return normalize(response.data?.thesis);
+  }
+
+  static async updateThesis(thesis: InvestorThesis): Promise<InvestorThesis> {
+    const response = await apiClient.put<{ success: boolean; thesis: Partial<InvestorThesis> }, InvestorThesis>(
+      '/api/investor/thesis',
+      thesis
+    );
+    if (!response.success) {
+      throw new Error(response.error?.message || 'Failed to save investment thesis');
+    }
+    // Backend echoes the saved thesis; fall back to the submitted value if it doesn't.
+    return normalize(response.data?.thesis ?? thesis);
+  }
+}
+
+export const investorThesisService = InvestorThesisService;

--- a/src/db/migrations/116_investor_thesis.sql
+++ b/src/db/migrations/116_investor_thesis.sql
@@ -1,0 +1,48 @@
+-- 116_investor_thesis.sql
+--
+-- Structured investment thesis for investors — one row per investor (1:1 with users).
+--
+-- Replaces the prior free-text `users.bio`-as-thesis hack with a proper structured
+-- record so investor intent is queryable/matchable (genre/format/stage/deal-type/
+-- territory/theme preferences + budget & check-size ranges + a prose positioning).
+--
+-- Vocabulary discipline: genres/formats/stages/deal_types/territories/themes are stored
+-- as native TEXT[] arrays — NOT comma-separated strings and NOT opaque JSONB (both are
+-- existing drift patterns we are deliberately avoiding). The canonical genre/format/
+-- stage/deal-type vocabularies are validated app-side (the same lists used across the
+-- pitch + open-call surfaces); the DB stores plain text tokens.
+--
+-- `investor_id` is the PRIMARY KEY, which both enforces the 1:1 uniqueness and enables
+-- an `ON CONFLICT (investor_id)` upsert in the handler.
+--
+-- A GIN index on `genres` supports future investor↔pitch matching (array containment).
+--
+-- The backfill seeds `positioning` from the existing `users.bio` for current investors
+-- so no prose is lost in the cutover from bio-as-thesis.
+
+CREATE TABLE IF NOT EXISTS investor_thesis (
+  investor_id        INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  genres             TEXT[]  NOT NULL DEFAULT '{}',
+  formats            TEXT[]  NOT NULL DEFAULT '{}',
+  stages             TEXT[]  NOT NULL DEFAULT '{}',
+  deal_types         TEXT[]  NOT NULL DEFAULT '{}',
+  territories        TEXT[]  NOT NULL DEFAULT '{}',
+  themes             TEXT[]  NOT NULL DEFAULT '{}',
+  budget_min_usd     BIGINT,
+  budget_max_usd     BIGINT,
+  check_size_min_usd BIGINT,
+  check_size_max_usd BIGINT,
+  positioning        TEXT    NOT NULL DEFAULT '',
+  is_public          BOOLEAN NOT NULL DEFAULT true,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_investor_thesis_genres
+  ON investor_thesis USING GIN (genres);
+
+-- Backfill: preserve existing free-text bios as the thesis positioning prose.
+INSERT INTO investor_thesis (investor_id, positioning)
+SELECT id, bio FROM users
+WHERE user_type = 'investor' AND bio IS NOT NULL AND btrim(bio) <> ''
+ON CONFLICT (investor_id) DO NOTHING;

--- a/src/handlers/investor-thesis.ts
+++ b/src/handlers/investor-thesis.ts
@@ -1,0 +1,237 @@
+/**
+ * Investor Thesis Handlers
+ *
+ * Structured investment thesis, 1:1 with users (PK = investor_id), backed by
+ * the `investor_thesis` table (migration 116). Replaces the old free-text
+ * `users.bio`-as-thesis.
+ *
+ * Wire format is camelCase; DB is snake_case — mapped in both directions here.
+ * Table absence (migration not yet applied) is handled gracefully: GET returns
+ * empty defaults, PUT returns a clear 503.
+ */
+
+import { getDb } from '../db/connection';
+import type { Env } from '../db/connection';
+import { getCorsHeaders } from '../utils/response';
+import { requireRole } from '../utils/auth-extract';
+
+// ---------------------------------------------------------------------------
+// Types & helpers
+// ---------------------------------------------------------------------------
+
+interface ThesisObject {
+  genres: string[];
+  formats: string[];
+  stages: string[];
+  dealTypes: string[];
+  territories: string[];
+  themes: string[];
+  budgetMinUsd: number | null;
+  budgetMaxUsd: number | null;
+  checkSizeMinUsd: number | null;
+  checkSizeMaxUsd: number | null;
+  positioning: string;
+  isPublic: boolean;
+}
+
+function emptyThesis(): ThesisObject {
+  return {
+    genres: [],
+    formats: [],
+    stages: [],
+    dealTypes: [],
+    territories: [],
+    themes: [],
+    budgetMinUsd: null,
+    budgetMaxUsd: null,
+    checkSizeMinUsd: null,
+    checkSizeMaxUsd: null,
+    positioning: '',
+    isPublic: true,
+  };
+}
+
+/** Map a DB row (snake_case) into the camelCase wire shape. */
+function rowToThesis(row: Record<string, unknown>): ThesisObject {
+  const arr = (v: unknown): string[] => (Array.isArray(v) ? (v as unknown[]).map(String) : []);
+  const num = (v: unknown): number | null => {
+    if (v === null || v === undefined || v === '') return null;
+    const n = Number(v);
+    return Number.isFinite(n) ? Math.trunc(n) : null;
+  };
+  return {
+    genres: arr(row.genres),
+    formats: arr(row.formats),
+    stages: arr(row.stages),
+    dealTypes: arr(row.deal_types),
+    territories: arr(row.territories),
+    themes: arr(row.themes),
+    budgetMinUsd: num(row.budget_min_usd),
+    budgetMaxUsd: num(row.budget_max_usd),
+    checkSizeMinUsd: num(row.check_size_min_usd),
+    checkSizeMaxUsd: num(row.check_size_max_usd),
+    positioning: typeof row.positioning === 'string' ? row.positioning : '',
+    isPublic: row.is_public === undefined || row.is_public === null ? true : Boolean(row.is_public),
+  };
+}
+
+function jsonResponse(data: unknown, origin: string | null, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...getCorsHeaders(origin) },
+  });
+}
+
+const MAX_NUMERIC = 1_000_000_000_000; // 1e12
+
+/** Sanitize a string array: coerce, trim, drop empties, dedupe, cap at 50. */
+function sanitizeArray(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const item of v) {
+    if (out.length >= 50) break;
+    const s = String(item ?? '').trim();
+    if (!s || seen.has(s)) continue;
+    seen.add(s);
+    out.push(s);
+  }
+  return out;
+}
+
+/** Coerce to a non-negative integer clamped to 0..1e12, else null. */
+function sanitizeNumeric(v: unknown): number | null {
+  if (v === null || v === undefined || v === '') return null;
+  const n = Number(v);
+  if (!Number.isFinite(n)) return null;
+  const i = Math.trunc(n);
+  if (i < 0) return null;
+  return Math.min(i, MAX_NUMERIC);
+}
+
+/** "Table doesn't exist yet" detector — covers missing relation across drift. */
+function isMissingTable(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  // Postgres: 42P01 undefined_table → "relation \"investor_thesis\" does not exist"
+  return /relation .*investor_thesis.* does not exist/i.test(msg)
+    || /does not exist/i.test(msg) && /investor_thesis/i.test(msg);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/investor/thesis
+// ---------------------------------------------------------------------------
+export async function getInvestorThesisHandler(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+
+  const roleCheck = await requireRole(request, env, ['investor']);
+  if ('error' in roleCheck) return roleCheck.error;
+  const userId = roleCheck.user.id;
+
+  const sql = getDb(env);
+  if (!sql) {
+    return jsonResponse({ success: true, thesis: emptyThesis() }, origin);
+  }
+
+  try {
+    const rows = await sql`
+      SELECT genres, formats, stages, deal_types, territories, themes,
+             budget_min_usd, budget_max_usd, check_size_min_usd, check_size_max_usd,
+             positioning, is_public
+      FROM investor_thesis
+      WHERE investor_id = ${userId}
+      LIMIT 1
+    `;
+    const row = rows[0];
+    return jsonResponse(
+      { success: true, thesis: row ? rowToThesis(row) : emptyThesis() },
+      origin,
+    );
+  } catch (error) {
+    // Missing table (migration 116 not applied) or any read error → empty defaults.
+    // Never 500 on a missing store.
+    if (!isMissingTable(error)) {
+      const e = error instanceof Error ? error : new Error(String(error));
+      console.error('[getInvestorThesisHandler] Query error:', e.message);
+    }
+    return jsonResponse({ success: true, thesis: emptyThesis() }, origin);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PUT /api/investor/thesis
+// ---------------------------------------------------------------------------
+export async function updateInvestorThesisHandler(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+
+  const roleCheck = await requireRole(request, env, ['investor']);
+  if ('error' in roleCheck) return roleCheck.error;
+  const userId = roleCheck.user.id;
+
+  const sql = getDb(env);
+  if (!sql) {
+    return jsonResponse({ success: false, error: 'thesis store unavailable' }, origin, 503);
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    body = {};
+  }
+
+  // Sanitize (do NOT hard-reject — the frontend constrains choices).
+  const genres = sanitizeArray(body.genres);
+  const formats = sanitizeArray(body.formats);
+  const stages = sanitizeArray(body.stages);
+  const dealTypes = sanitizeArray(body.dealTypes);
+  const territories = sanitizeArray(body.territories);
+  const themes = sanitizeArray(body.themes);
+  const budgetMinUsd = sanitizeNumeric(body.budgetMinUsd);
+  const budgetMaxUsd = sanitizeNumeric(body.budgetMaxUsd);
+  const checkSizeMinUsd = sanitizeNumeric(body.checkSizeMinUsd);
+  const checkSizeMaxUsd = sanitizeNumeric(body.checkSizeMaxUsd);
+  const positioning = (typeof body.positioning === 'string' ? body.positioning : '').slice(0, 4000);
+  const isPublic = body.isPublic === undefined ? true : Boolean(body.isPublic);
+
+  try {
+    const rows = await sql`
+      INSERT INTO investor_thesis (
+        investor_id, genres, formats, stages, deal_types, territories, themes,
+        budget_min_usd, budget_max_usd, check_size_min_usd, check_size_max_usd,
+        positioning, is_public, created_at, updated_at
+      ) VALUES (
+        ${userId},
+        ${genres}::text[], ${formats}::text[], ${stages}::text[],
+        ${dealTypes}::text[], ${territories}::text[], ${themes}::text[],
+        ${budgetMinUsd}, ${budgetMaxUsd}, ${checkSizeMinUsd}, ${checkSizeMaxUsd},
+        ${positioning}, ${isPublic}, now(), now()
+      )
+      ON CONFLICT (investor_id) DO UPDATE SET
+        genres = EXCLUDED.genres,
+        formats = EXCLUDED.formats,
+        stages = EXCLUDED.stages,
+        deal_types = EXCLUDED.deal_types,
+        territories = EXCLUDED.territories,
+        themes = EXCLUDED.themes,
+        budget_min_usd = EXCLUDED.budget_min_usd,
+        budget_max_usd = EXCLUDED.budget_max_usd,
+        check_size_min_usd = EXCLUDED.check_size_min_usd,
+        check_size_max_usd = EXCLUDED.check_size_max_usd,
+        positioning = EXCLUDED.positioning,
+        is_public = EXCLUDED.is_public,
+        updated_at = now()
+      RETURNING genres, formats, stages, deal_types, territories, themes,
+                budget_min_usd, budget_max_usd, check_size_min_usd, check_size_max_usd,
+                positioning, is_public
+    `;
+    const row = rows[0];
+    return jsonResponse({ success: true, thesis: row ? rowToThesis(row) : emptyThesis() }, origin);
+  } catch (error) {
+    if (isMissingTable(error)) {
+      return jsonResponse({ success: false, error: 'thesis store unavailable' }, origin, 503);
+    }
+    const e = error instanceof Error ? error : new Error(String(error));
+    console.error('[updateInvestorThesisHandler] Query error:', e.message);
+    return jsonResponse({ success: false, error: 'Failed to save thesis' }, origin, 500);
+  }
+}

--- a/src/handlers/user-lookup.ts
+++ b/src/handlers/user-lookup.ts
@@ -165,7 +165,50 @@ export async function userByIdHandler(request: Request, env: Env): Promise<Respo
       return jsonResponse({ success: false, error: { code: 'NOT_FOUND', message: 'User not found' } }, 404, origin);
     }
 
-    return jsonResponse({ success: true, data: user }, 200, origin);
+    // For investors, expose their structured investment thesis on the public
+    // profile only when they've opted in (investor_thesis.is_public = true).
+    // Non-investors get thesis: null. Missing table (migration 116 not applied)
+    // or any read error → thesis: null, never breaks the profile lookup.
+    let thesis: Record<string, unknown> | null = null;
+    if (user.user_type === 'investor') {
+      try {
+        const [t] = await sql`
+          SELECT genres, formats, stages, deal_types, territories, themes,
+                 budget_min_usd, budget_max_usd, check_size_min_usd, check_size_max_usd,
+                 positioning, is_public
+          FROM investor_thesis
+          WHERE investor_id = ${userId}
+          LIMIT 1
+        `;
+        if (t && t.is_public) {
+          const arr = (v: unknown): string[] => (Array.isArray(v) ? (v as unknown[]).map(String) : []);
+          const num = (v: unknown): number | null => {
+            if (v === null || v === undefined || v === '') return null;
+            const n = Number(v);
+            return Number.isFinite(n) ? Math.trunc(n) : null;
+          };
+          thesis = {
+            genres: arr(t.genres),
+            formats: arr(t.formats),
+            stages: arr(t.stages),
+            dealTypes: arr(t.deal_types),
+            territories: arr(t.territories),
+            themes: arr(t.themes),
+            budgetMinUsd: num(t.budget_min_usd),
+            budgetMaxUsd: num(t.budget_max_usd),
+            checkSizeMinUsd: num(t.check_size_min_usd),
+            checkSizeMaxUsd: num(t.check_size_max_usd),
+            positioning: typeof t.positioning === 'string' ? t.positioning : '',
+            isPublic: true,
+          };
+        }
+      } catch {
+        // investor_thesis table may not exist yet; leave thesis null.
+        thesis = null;
+      }
+    }
+
+    return jsonResponse({ success: true, data: { ...user, thesis } }, 200, origin);
   } catch (error) {
     console.error('User by ID error:', error);
     return jsonResponse({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to fetch user' } }, 500, origin);

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -3587,6 +3587,14 @@ class RouteRegistry {
       const { investorSettingsSaveHandler } = await import('./handlers/investor-sidebar');
       return investorSettingsSaveHandler(req, this.env);
     });
+    this.register('GET', '/api/investor/thesis', async (req) => {
+      const { getInvestorThesisHandler } = await import('./handlers/investor-thesis');
+      return getInvestorThesisHandler(req, this.env);
+    });
+    this.register('PUT', '/api/investor/thesis', async (req) => {
+      const { updateInvestorThesisHandler } = await import('./handlers/investor-thesis');
+      return updateInvestorThesisHandler(req, this.env);
+    });
     this.register('GET', '/api/investor/pitch/:pitchId/investment-detail', async (req) => {
       const { investorPitchInvestmentDetailHandler } = await import('./handlers/investor-sidebar');
       return investorPitchInvestmentDetailHandler(req, this.env);


### PR DESCRIPTION
The named moat #7 "build FIRST" — turns the investor "thesis" from a relabelled free-text `users.bio` into a real **structured** record, so investor intent is queryable/matchable. This is the foundation the buyer-facing/monetizable layer depends on.

## What's in it
- **Migration 116** `investor_thesis` (1:1, PK=`investor_id`): `TEXT[]` arrays for genres/formats/stages/deal_types/territories/themes (**not** comma-strings, **not** opaque JSONB — the two existing drift patterns we avoided), budget + cheque-size ranges, `positioning` prose, `is_public`, GIN index on genres for future matching. **Backfills `positioning` from existing `users.bio`** so no prose is lost.
- **Backend:** `GET`/`PUT /api/investor/thesis` (investor-gated, upsert `ON CONFLICT`, inputs sanitized + clamped, graceful if the table isn't migrated yet); `GET /api/users/:id` returns the thesis for investors when `is_public`.
- **Frontend:** structured thesis form in `InvestorSettingsProfile` — chip multi-selects (genres/formats/stages/deal-types) **reusing the same pitch taxonomy** (`config/pitchConstants` → `/api/config/*`), tag inputs (territories/themes), budget + cheque ranges, positioning prose, public toggle. Saved via a dedicated service, separate from the identity/fund/address save.

## Reuse / anti-drift
Reuses the canonical genre/format/stage lists + `production_deal_type` values — no parallel enum. Backend & frontend share one contract (`{genres[],formats[],stages[],dealTypes[],territories[],themes[],budgetMinUsd,budgetMaxUsd,checkSizeMinUsd,checkSizeMaxUsd,positioning,isPublic}`).

## ⚠️ Not yet applied / deployed
- **Migration 116 must run before deploy** — prod Neon was at its compute quota at build time, so it wasn't applied. The deploy gate requires it recorded.
- Backend bundles clean (`build:worker`); frontend + backend `tsc` clean. **Not yet live-tested** (Neon down).

## Verification gates
- [ ] G1 — apply migration 116 (Neon branch → prod via `scripts/migrate.mjs`); confirm `investor_thesis` exists + bio backfill landed
- [ ] G2 — as an investor, save a structured thesis via the form → `PUT /api/investor/thesis` persists; reload shows it
- [ ] G3 — `GET /api/users/:investorId` returns `thesis` when public, `null` when private/non-investor
- [ ] G4 — chip options match the pitch create form's taxonomy (no drift)

## Phase 2 (follow-up, not in this PR)
Public investor-profile **rendering** of the thesis (so creators can target) + thesis↔pitch **matching/notify**. Production-company mandates (analogous) are partly served by Open Calls — separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)