### PR TITLE
fix(worker): declare 4 missing secrets on Env type

### DIFF
--- a/src/types/worker-types.ts
+++ b/src/types/worker-types.ts
@@ -39,6 +39,12 @@ export interface Env {
   NDA_STORAGE?: R2Bucket;
   PROCESSED_STORAGE?: R2Bucket;
   TEMP_STORAGE?: R2Bucket;
+
+  // Secrets (set via `wrangler secret put`; already declared on the worker-integrated Env)
+  UPSTASH_REDIS_REST_URL?: string;
+  UPSTASH_REDIS_REST_TOKEN?: string;
+  STRIPE_SECRET_KEY?: string;
+  RESEND_API_KEY?: string;
 }
 
 export interface DatabaseService {


### PR DESCRIPTION
First fix produced by the audit harness — executed and gated live, not by the (still-parked) write layer.

## What
`src/types/worker-types.ts` `Env` omitted four secrets that `worker-modules/admin-endpoints.ts` reads, causing **7 `TS2339` errors** — invisible because the worker is never type-checked in CI (esbuild bundles without checking). Added them as optional `?: string`:
`UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `STRIPE_SECRET_KEY`, `RESEND_API_KEY`.

All four are **real runtime secrets** (`wrangler secret put`; used as `env.X` across 44+ live sites; already declared on the `worker-integrated.ts` and `src/types/env.ts` Env interfaces). Type-only change — **no runtime behavior change**.

## Gate (the prompt's Done-When)
- Worker `tsc`: **40 → 33** errors — all **7** admin-endpoints `TS2339` gone
- **Zero** new errors introduced (diff-checked)
- `build:worker` still bundles

## Provenance
- Signal `sig-2026-06-25-009` → prompt `prompts/2026-06-25-sig-2026-06-25-009-admin-env-props.md`
- Executing it surfaced a **4th** missing member (`RESEND_API_KEY`) the static signal didn't list — exactly the kind of thing a human-in-the-loop catches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)