### PR TITLE
fix(db): type the retry-Proxy apply trap as Promise (closes 2 harness signals)

### DIFF
--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -51,7 +51,10 @@ async function withDbRetry<T>(op: () => Promise<T>, max = 3, delayMs = 1000): Pr
 function wrapWithRetry(raw: any) {
   return new Proxy(raw, {
     apply(target, thisArg, args) {
-      return withDbRetry(() => Reflect.apply(target, thisArg, args));
+      // Promise.resolve normalizes the apply result (typed unknown through the
+      // Proxy trap) to the Promise<unknown> withDbRetry expects — no-op for the
+      // neon query thenable, behavior unchanged.
+      return withDbRetry(() => Promise.resolve(Reflect.apply(target, thisArg, args)));
     },
     get(target, prop, receiver) {
       if (prop === 'query') {

--- a/src/services/worker-database.ts
+++ b/src/services/worker-database.ts
@@ -134,7 +134,10 @@ export class WorkerDatabase implements DatabaseService {
     this._wrappedSql = new Proxy(raw, {
       apply(target, thisArg, args) {
         // sql`...` tagged-template invocation — retry transient infra failures.
-        return withRetry(() => Reflect.apply(target, thisArg, args));
+        // Promise.resolve normalizes the apply result (typed unknown through the
+        // Proxy trap) to the Promise<unknown> withRetry expects — no-op for the
+        // neon query thenable, behavior unchanged.
+        return withRetry(() => Promise.resolve(Reflect.apply(target, thisArg, args)));
       },
       get(target, prop, receiver) {
         if (prop === 'query') {


### PR DESCRIPTION
Second harness fix, executed + gated live. Closes **two** signals at once (the code cross-references the twin).

## What
Both DB retry wrappers use a `Proxy` whose `apply` trap forwards the `sql\`...\`` call via `Reflect.apply(...)` — which loses its `Promise` type through the trap (typed `unknown`). Passing that to `withRetry`/`withDbRetry` (`op: () => Promise<T>`) produced `TS2322: Type 'unknown' is not assignable to type 'Promise<unknown>'`:
- `src/services/worker-database.ts:137` — `getSql()` Proxy (core DB service, every route)
- `src/db/connection.ts:54` — `wrapWithRetry`, the `getDb()` equivalent

Fix: wrap the apply result in `Promise.resolve(...)`.

## Why this is a real fix, not silencing
`Promise.resolve(p)` **adopts** the neon query promise's state, and `withRetryRaw` still `await`s it — so transient-**retry-on-rejection behavior is identical**. It also makes the type honest (`Promise<unknown>`). No `any` / `as` / `@ts-ignore`.

## Gate
- Worker `tsc`: **40 → 38** — both target errors gone
- **Zero** new errors (diff-checked vs baseline)
- `build:worker` bundles

## Provenance
Closes `sig-2026-06-25-007` (worker-database) **and** `sig-2026-06-25-001` (connection — the identical twin) + their prompts. The harness flagged them as two separate signals; executing showed they're one root cause across cross-referenced files, so they're fixed together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)