### PR TITLE
fix(slates): authGuard userId is string|null, not number|null

### DIFF
--- a/src/handlers/slates.ts
+++ b/src/handlers/slates.ts
@@ -35,7 +35,10 @@ function jsonResponse(
   });
 }
 
-function authGuard(sql: any, userId: number | null, origin: string | null) {
+// userId is a string|null (getUserId returns the id as a string); authGuard only
+// truthiness-checks it and the handlers pass it as a SQL template param, so the
+// param type must match the real string id — not number.
+function authGuard(sql: any, userId: string | null, origin: string | null) {
   if (!sql || !userId) {
     return jsonResponse({ success: false, error: 'Authentication required' }, origin, 401);
   }


### PR DESCRIPTION
Third harness fix, executed + gated live.

## What
All **8** `TS2345` errors in `handlers/slates.ts` were the same repeated call — `authGuard(sql, userId, origin)`. `getUserId()` returns `Promise<string | null>` (user ids are strings), but the local `authGuard` declared `userId: number | null`.

`authGuard` only truthiness-checks `userId`, and every handler passes it as a SQL template param (`user_id = ${userId}`, Postgres-coerced). The value is a string everywhere — the param **type** was just wrong. Fixed `authGuard` to `string | null`. One line resolves all 8.

## Why not the prompt's suggestion
The generated prompt guessed "parse the id args to numbers." Executing showed that would be **wrong** (coercing string user ids to number). The real fix is the helper's type — a human-in-the-loop catch.

## Gate
- Worker `tsc`: **40 → 32** — all 8 slates errors gone
- **Zero** new errors (diff-checked)
- `build:worker` bundles

Closes `sig-2026-06-25-005` + its prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)