### PR TITLE
fix(worker): clear 3 trivial handler type errors (harness trio)

### DIFF
--- a/src/handlers/collaborator.ts
+++ b/src/handlers/collaborator.ts
@@ -208,7 +208,7 @@ export async function listCollaborators(request: Request, env: Env): Promise<Res
       ORDER BY pc.invited_at DESC
     `;
 
-    const mapped = collaborators.map(c => ({
+    const mapped = collaborators.map((c: any) => ({
       id: c.id,
       user_id: c.user_id,
       invited_email: c.invited_email,
@@ -483,7 +483,7 @@ export async function getAllTeamCollaborators(request: Request, env: Env): Promi
       ORDER BY pc.invited_at DESC
     `;
 
-    const mapped = collaborators.map(c => ({
+    const mapped = collaborators.map((c: any) => ({
       id: c.id,
       project_id: c.project_id,
       project_title: c.project_title,
@@ -501,9 +501,9 @@ export async function getAllTeamCollaborators(request: Request, env: Env): Promi
       } : null,
     }));
 
-    const active = mapped.filter(c => c.status === 'active').length;
-    const pending = mapped.filter(c => c.status === 'pending').length;
-    const projects = new Set(mapped.map(c => c.project_id)).size;
+    const active = mapped.filter((c: any) => c.status === 'active').length;
+    const pending = mapped.filter((c: any) => c.status === 'pending').length;
+    const projects = new Set(mapped.map((c: any) => c.project_id)).size;
 
     return jsonResponse({
       success: true,
@@ -548,7 +548,7 @@ export async function getMyCollaborations(request: Request, env: Env): Promise<R
       ORDER BY pc.accepted_at DESC
     `;
 
-    const mapped = collaborations.map(c => ({
+    const mapped = collaborations.map((c: any) => ({
       project_id: c.project_id,
       project_title: c.project_title,
       project_stage: c.project_stage,
@@ -874,7 +874,7 @@ export async function getCollaborationActivity(request: Request, env: Env): Prom
       LIMIT ${limit} OFFSET ${offset}
     `;
 
-    const mapped = activity.map(a => ({
+    const mapped = activity.map((a: any) => ({
       id: a.id,
       action: a.action,
       entity_id: a.entity_id,

--- a/src/handlers/creator-value.ts
+++ b/src/handlers/creator-value.ts
@@ -78,7 +78,7 @@ export async function creatorValueHandler(request: Request, env: Env): Promise<R
     guard(() => sql`
       SELECT verification_tier, created_at, username
       FROM users WHERE id::text = ${userId}
-    `, { verification_tier: 'grey', created_at: null, username: null }, 'user'),
+    `, { verification_tier: 'grey', created_at: null as string | null, username: null as string | null }, 'user'),
 
     guard(() => sql`
       SELECT

--- a/src/services/worker-email.ts
+++ b/src/services/worker-email.ts
@@ -43,7 +43,7 @@ export class WorkerEmailService {
   /**
    * Send a single email and log to database
    */
-  async send(message: EmailMessage, meta?: { userId?: number; templateType?: string }): Promise<{ success: boolean; id?: string; error?: string }> {
+  async send(message: EmailMessage, meta?: { userId?: string | number; templateType?: string }): Promise<{ success: boolean; id?: string; error?: string }> {
     const recipient = Array.isArray(message.to) ? message.to.join(', ') : message.to;
     try {
       const response = await fetch(this.resendApiUrl, {
@@ -86,7 +86,7 @@ export class WorkerEmailService {
   /** Fire-and-forget log to email_logs table */
   private logEmail(
     recipient: string, subject: string, templateType: string | undefined,
-    providerId: string | null, status: string, error: string | null, userId?: number
+    providerId: string | null, status: string, error: string | null, userId?: string | number
   ) {
     if (!this.db) return;
     this.db.query(


### PR DESCRIPTION
Fourth harness batch — the **trivial trio**, executed + gated live. 9 errors, 3 signals, one reviewable PR.

| Signal | File | Fix |
|---|---|---|
| `sig-002` (7× TS7006) | `collaborator.ts` | annotate 7 SQL-row callbacks `(c: any)`/`(a: any)` — matches the repo's 25+ `.map((row: any) => …)` idiom |
| `sig-003` (TS2352) | `creator-value.ts` | the `guard()` fallback literal typed `username`/`created_at` as literal `null`; typed them `null as string \| null` to match the real nullable columns — fixes the root, not the bad cast |
| `sig-004` (TS2322) | `worker-email.ts` | `email.send().meta.userId` (+ `logEmail`) were `number`, but `getUserId()` returns a string id used only as a SQL param / log field; widened to `string \| number`. Fixes the `promo-codes.ts:335` caller at the shared signature |

## Gate
- Worker `tsc`: **40 → 31** — all target errors gone
- **Zero** new errors (diff-checked)
- `build:worker` bundles

Two of the three again landed the fix at a **different layer than the call site** the signal named (the `guard` fallback for #003; the `email.send` signature for #004) — the human-in-the-loop pattern holding at 6/6.

Closes `sig-2026-06-25-002`, `-003`, `-004` + prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)