### PR TITLE
fix(worker): clear 5 type errors in the worker entry (generic-T media + Sentry)

### DIFF
--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -324,10 +324,15 @@ function toRelativeMediaUrl<T>(url: T): T {
 // backfilled to relative (migration 108). Safe no-op for relative/null values.
 function normalizePitchMedia<T extends Record<string, any>>(pitch: T): T {
   if (!pitch || typeof pitch !== 'object') return pitch;
-  if (typeof pitch.title_image === 'string') pitch.title_image = toRelativeMediaUrl(pitch.title_image);
-  if (typeof pitch.thumbnail_url === 'string') pitch.thumbnail_url = toRelativeMediaUrl(pitch.thumbnail_url);
-  if (typeof pitch.titleImage === 'string') pitch.titleImage = toRelativeMediaUrl(pitch.titleImage);
-  if (typeof pitch.thumbnailUrl === 'string') pitch.thumbnailUrl = toRelativeMediaUrl(pitch.thumbnailUrl);
+  // Mutate through a non-generic view: a bare generic T can't be indexed for
+  // writing (TS2862) and dot-access on it misses the index signature (TS2339).
+  // T extends Record<string, any>, so this is a safe, cast-free widening of the
+  // same object reference.
+  const p: Record<string, any> = pitch;
+  if (typeof p.title_image === 'string') p.title_image = toRelativeMediaUrl(p.title_image);
+  if (typeof p.thumbnail_url === 'string') p.thumbnail_url = toRelativeMediaUrl(p.thumbnail_url);
+  if (typeof p.titleImage === 'string') p.titleImage = toRelativeMediaUrl(p.titleImage);
+  if (typeof p.thumbnailUrl === 'string') p.thumbnailUrl = toRelativeMediaUrl(p.thumbnailUrl);
   return pitch;
 }
 
@@ -22233,12 +22238,17 @@ const websocketSafeHandler = {
 // which is exactly where you'd want to be paged. `fetch` is left untouched (it's
 // already wrapped + WebSocket-bypassed + Axiom-logged internally).
 const sentryScheduled = Sentry.withSentry(
-  (env: Env) => ({
-    dsn: env.SENTRY_DSN,
-    release: env.CF_VERSION_METADATA?.id,
-    environment: env.SENTRY_ENVIRONMENT || env.ENVIRONMENT || 'production',
-    tracesSampleRate: parseFloat(env.SENTRY_TRACES_SAMPLE_RATE || '0.1'),
-  }),
+  // withSentry types the injected env as `unknown` here (the handler below is
+  // `as any`, so E can't be inferred); narrow it once — it is the worker Env.
+  (env: unknown) => {
+    const e = env as Env;
+    return {
+      dsn: e.SENTRY_DSN,
+      release: e.CF_VERSION_METADATA?.id,
+      environment: e.SENTRY_ENVIRONMENT || e.ENVIRONMENT || 'production',
+      tracesSampleRate: parseFloat(e.SENTRY_TRACES_SAMPLE_RATE || '0.1'),
+    };
+  },
   { scheduled: websocketSafeHandler.scheduled } as any,
 );
 


### PR DESCRIPTION
Fifth harness fix, executed + gated live — the worker entry (`worker-integrated.ts`) itself.

## Two issues
**A — `normalizePitchMedia<T extends Record<string, any>>` (4× TS2339).** Dot-access on a bare generic `T` misses the constraint's index signature; bracket-*write* on a generic `T` is also disallowed (TS2862). Fix: mutate through a non-generic view — `const p: Record<string, any> = pitch` — a **safe, cast-free widening** of the same object reference. Still returns the original `pitch` typed `T`.

**B — `sentryScheduled` options factory (1× TS2345).** `withSentry((env: Env) => …)` failed because `withSentry` types the injected env as `unknown` (the handler is `as any`, so `E` can't be inferred). Fix: take `(env: unknown)` and narrow once (`const e = env as Env`) — keeps the four field reads typed, mirrors the working `fetch` `withSentry` above.

## Gate
- Worker `tsc`: **40 → 35** — all 5 gone
- **Zero** new errors (diff-checked)
- `build:worker` bundles

## Note
Executing iterated once: the first attempt (bracket notation) fixed the reads but the **gate caught** that bracket-*write* on a generic is its own error (TS2862) — corrected to the view-variable approach. Exactly what the re-run-the-checker gate is for.

Closes `sig-2026-06-25-008` + its prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)