### PR TITLE
ci(worker): ratcheted type-check gate (stop new worker type errors landing invisibly)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -135,6 +135,15 @@ jobs:
         # and docs/catch-swallow-audit-2026-04-17.md.
         run: node scripts/catch-swallow-gate.mjs --include-worker --threshold 0 --list
 
+      - name: 🔒 Worker type-check gate (ratchet)
+        # The Worker (src/, wrangler `main`) ships via esbuild, which does NOT
+        # type-check, and CI's `type-check` step only covers frontend/. So worker
+        # type errors accumulated invisibly (38+ live ones, found 2026-06-25). This
+        # runs `tsc` over the root tsconfig and FAILS if the error count rises above
+        # the committed baseline — no new type errors can land unseen. Lower the
+        # baseline in the script as errors are fixed (it only ratchets down).
+        run: node scripts/worker-typecheck-gate.mjs --list
+
   # =================================================================
   # DATABASE TESTS
   # =================================================================

--- a/STACK.md
+++ b/STACK.md
@@ -23,7 +23,7 @@
 | Frontend build | `cd frontend && npm run build` | Vite |
 | Worker bundle | `npm run build:worker` | esbuild → `dist/worker.js`; doubles as a worker syntax/bundle check |
 | Frontend type-check | `cd frontend && npm run type-check` | `tsc --noEmit -p tsconfig.app.json` — **the gate for any FE type fix** |
-| Worker type-check | `./frontend/node_modules/.bin/tsc --noEmit -p tsconfig.json` | root tsconfig (strict). ⚠️ **No tsc at root** — worker is esbuild-bundled (no type-check), CI never runs this; use the frontend binary. Surfaces silent worker type drift (38 errors as of 2026-06-25). |
+| Worker type-check | `npx tsc --noEmit -p tsconfig.json` | root tsconfig (strict). `typescript` is now a root devDep. esbuild (the deploy build) still doesn't type-check, so **CI gates this** via the ratchet `node scripts/worker-typecheck-gate.mjs` in the `⚡ Worker Tests` job — fails on any error count above the baseline. Lower the baseline in that script as errors are fixed. |
 | Lint | `cd frontend && npm run lint` (`eslint .`) | **frontend only — no backend ESLint exists** |
 | Test (backend) | `npm test` → `vitest --config vitest.backend.config.ts` | pure-logic ring around utils/lib |
 | Test (integration) | `npm run test:integration` → `vitest.integration.config.ts` | real `worker.fetch()` vs throwaway Neon branch (`TEST_DATABASE_URL`) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@vitest/coverage-v8": "^4.1.9",
         "esbuild": "^0.27.2",
         "form-data": "^4.0.5",
+        "typescript": "~5.8.3",
         "vitest": "^4.1.9",
         "wrangler": "^4.95.0"
       }
@@ -3368,6 +3369,20 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/uncrypto": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@vitest/coverage-v8": "^4.1.9",
     "esbuild": "^0.27.2",
     "form-data": "^4.0.5",
+    "typescript": "~5.8.3",
     "vitest": "^4.1.9",
     "wrangler": "^4.95.0"
   },

--- a/scripts/worker-typecheck-gate.mjs
+++ b/scripts/worker-typecheck-gate.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Worker type-check ratchet gate.
+//
+// WHY: the Cloudflare Worker (src/, wrangler `main`) is bundled by esbuild, which does
+// NOT type-check. CI's `type-check` step only covers frontend/. So worker type errors
+// accumulated invisibly (38+ live ones found 2026-06-25). This gate runs `tsc` over the
+// root tsconfig and FAILS if the worker error count rises above the baseline — stopping
+// the bleeding without requiring every pre-existing error fixed first.
+//
+// RATCHET: it is a one-way ratchet downward.
+//   count >  BASELINE -> FAIL (a PR introduced new worker type errors)
+//   count <  BASELINE -> PASS, but loudly asks you to LOWER the baseline to lock the win
+//   count == BASELINE -> PASS
+//
+// HOW TO LOWER: when you fix worker errors, set BASELINE below to the new (lower) count
+// and commit it in the same PR. The number can only ever go down.
+//
+// Usage: node scripts/worker-typecheck-gate.mjs [--list]
+
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+// ── The baseline. Lower it (never raise it) as worker type errors are fixed. ──
+const BASELINE = 40;
+// 2026-06-25: 40 on main at gate creation. 9 of these are the notification latent-bug
+// (issue #361, intentionally unfixed). The 5 fix PRs (#356–#360) drop it to 9 once
+// merged — lower BASELINE to 9 in a follow-up after they land.
+
+const LIST = process.argv.includes('--list');
+
+// Prefer a root-installed tsc (CI: `npm ci` installs the root `typescript` devDep);
+// fall back to the frontend binary for local runs that haven't installed root deps.
+const tscCandidates = ['./node_modules/.bin/tsc', './frontend/node_modules/.bin/tsc'];
+const tsc = tscCandidates.find((p) => existsSync(p));
+if (!tsc) {
+  console.error('❌ No tsc binary found. Run `npm ci` (root) first.');
+  process.exit(2);
+}
+
+let out = '';
+try {
+  out = execSync(`${tsc} --noEmit -p tsconfig.json`, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+} catch (e) {
+  // tsc exits non-zero when there are errors — that's expected; capture its output.
+  out = `${e.stdout || ''}${e.stderr || ''}`;
+}
+
+const errorLines = out.split('\n').filter((l) => /error TS\d+:/.test(l));
+const count = errorLines.length;
+
+console.log(`Worker type-check: ${count} error(s) (baseline ${BASELINE}) via ${tsc}`);
+if (LIST && count) {
+  console.log('---');
+  for (const l of errorLines) console.log('  ' + l.trim());
+  console.log('---');
+}
+
+if (count > BASELINE) {
+  console.error(`\n❌ ${count - BASELINE} NEW worker type error(s) introduced (baseline ${BASELINE}).`);
+  console.error('   The worker is not type-checked at deploy (esbuild only), so this gate is the');
+  console.error('   net. Fix the new error(s) below, or do not merge.\n');
+  if (!LIST) for (const l of errorLines) console.error('  ' + l.trim());
+  process.exit(1);
+}
+
+if (count < BASELINE) {
+  console.log(`\n✅ ${BASELINE - count} worker type error(s) fixed since the baseline. Nice.`);
+  console.log(`   👉 Lower BASELINE in scripts/worker-typecheck-gate.mjs to ${count} and commit`);
+  console.log('      it in this PR to lock the win (the ratchet only tightens).');
+  process.exit(0);
+}
+
+console.log('✅ No new worker type errors.');
+process.exit(0);


### PR DESCRIPTION
The highest-leverage outcome of the backend-health investigation: **the worker is never type-checked at deploy** (esbuild doesn't type-check; CI's `type-check` covers only `frontend/`). That's the root cause behind the 40 type errors the nightly harness found — they accumulated with no gate. This adds the gate.

## What
- **`typescript` → root devDeps.** The worker gets its own type-check toolchain; `npx tsc -p tsconfig.json` now works at root (retires the "use the frontend binary" workaround — all worker type deps were already at root).
- **`scripts/worker-typecheck-gate.mjs`** — runs `tsc` over the root tsconfig and **fails if the error count rises above a committed baseline**. One-way ratchet:
  - `count > baseline` → **FAIL** (a PR introduced new worker type errors; prints them)
  - `count < baseline` → PASS, but nudges you to lower the baseline (lock the win)
  - `count == baseline` → PASS
- Hooked into the existing **required** `⚡ Worker Tests` job (beside the catch-swallow gate), so it gates immediately — no branch-protection change needed.
- `STACK.md` updated.

## Why ratchet, not "zero errors"
There are still 40 (9 of which are the notification latent bug — issue #361, intentionally unfixed). A hard-zero gate would block everything; the ratchet **stops new errors today** while the existing ones are burned down via the 5 fix PRs (#356–#360).

## Tested
Local: passes at 40, fails when baseline forced to 35 (detects +5), nudges when forced to 45. This PR's own CI is the first real run of the gate in-environment (verify-not-self-verify).

## Follow-up
Once #356–#360 merge (count → 9), lower `BASELINE` to 9 in the script to lock it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)