### PR TITLE
fix(handlers): 2 always-false userId comparisons (own-media hidden, self-DM guard dead)

### DIFF
--- a/src/handlers/media-access.ts
+++ b/src/handlers/media-access.ts
@@ -169,8 +169,11 @@ export class MediaAccessHandler {
   // Get user's media files
   async getUserMedia(userId: number, targetUserId: number) {
     try {
-      // Check if requesting own media or has permission
-      const isOwnMedia = userId === targetUserId;
+      // Check if requesting own media or has permission.
+      // Compare as strings: userId arrives as a string (getUserId) while
+      // targetUserId is parseInt'd to a number at the route, so a raw `===`
+      // is always false (own private media would be hidden from its owner).
+      const isOwnMedia = String(userId) === String(targetUserId);
       
       let query;
       let params;

--- a/src/handlers/messaging-simple.ts
+++ b/src/handlers/messaging-simple.ts
@@ -354,7 +354,10 @@ export class SimpleMessagingHandler {
   // Find or create a direct conversation (without requiring a message)
   async findOrCreateConversation(userId: number, recipientId: number, pitchId?: number) {
     try {
-      if (!recipientId || recipientId === userId) {
+      // Block self-conversations. Compare as strings: userId arrives as a string
+      // (getUserId) while recipientId is coerced to a number at the route, so a raw
+      // `===` is always false and the self-DM guard never fires.
+      if (!recipientId || String(recipientId) === String(userId)) {
         return { success: false, error: 'Invalid recipient' };
       }
 


### PR DESCRIPTION
Two **real runtime bugs** the audit surfaced — masked by the userId string/number schism (#363), invisible to the compiler because the values launder through mis-typed `number` params.

Found as `TS2367` ("types have no overlap") while prototyping the #363 codemod; verified against the live call sites.

## The bugs
1. **`media-access.ts:173`** — `isOwnMedia = userId === targetUserId`. `targetUserId = parseInt(path)` (**number**); `userId` is the **string** auth id → always false → **a user viewing their own media gets the "other user" query and only sees their *public* media; their own private media is hidden from them.**
2. **`messaging-simple.ts:357`** — self-conversation guard `recipientId === userId`. `recipientId` is coerced to a **number** at the route; `userId` is the **string** auth id → guard always false → **a user can start a conversation with themselves.**

## Fix
Canonical-agnostic string comparison (`String(a) === String(b)`) — correct regardless of how #363 resolves the canonical type. Both call sites verified (`getUserMedia(authCheck.user.id, parseInt(...))`, `findOrCreateConversation(authCheck.user.id, <coerced number>, ...)`).

## Note
The third site the prototype flagged (`promo-codes.ts:135`, TS2677) is **not** a runtime bug — it compiles on main; only the codemod breaks it. Correctly left for the #363 sweep.

## Gate
Worker `tsc` unchanged (40 — these were never type errors, by design); `build:worker` bundles.

Related: #363 (the schism), #361 (same "executing reveals a masked bug" pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)