### PR TITLE
refactor(auth): canonicalize the user id to number (fix the string/number schism, #363)

### DIFF
--- a/src/auth/auth-adapter.ts
+++ b/src/auth/auth-adapter.ts
@@ -21,7 +21,7 @@ export interface AuthAdapterConfig {
 }
 
 interface JWTPayload {
-  userId: string;
+  userId: number;
   email: string;
   userType: PortalType;
   name: string;
@@ -63,7 +63,7 @@ export class AuthAdapter {
             return {
               valid: true,
               user: {
-                id: cached.userId,
+                id: Number(cached.userId),
                 email: cached.userEmail,
                 name: cached.userName || cached.userEmail,
                 userType: cached.userType,
@@ -79,7 +79,7 @@ export class AuthAdapter {
                  u.first_name, u.last_name, u.company_name, u.bio,
                  COALESCE(u.name, u.username, u.email) as name
           FROM sessions s
-          JOIN users u ON s.user_id::text = u.id::text
+          JOIN users u ON s.user_id = u.id
           WHERE s.id = ${sessionId}
           AND s.expires_at > NOW()
           LIMIT 1`;
@@ -104,7 +104,7 @@ export class AuthAdapter {
           return {
             valid: true,
             user: {
-              id: row.user_id,
+              id: Number(row.user_id),
               email: row.email,
               name: row.name,
               username: row.username,
@@ -128,8 +128,11 @@ export class AuthAdapter {
         const token = authHeader.substring(7);
         const payload = await this.validateJWTToken(token);
         if (payload) {
-          const user = await this.getUserFromDatabase(payload.userId);
-          if (user) return { valid: true, user };
+          const userId = Number(payload.userId);
+          if (!Number.isNaN(userId)) {
+            const user = await this.getUserFromDatabase(userId);
+            if (user) return { valid: true, user };
+          }
         }
       }
     }
@@ -178,7 +181,7 @@ export class AuthAdapter {
     }
   }
 
-  private async getUserFromDatabase(userId: string, requiredType?: PortalType): Promise<any> {
+  private async getUserFromDatabase(userId: number, requiredType?: PortalType): Promise<any> {
     const demoUsers: Record<string, any> = {
       'alex.creator@demo.com': {
         id: '1', email: 'alex.creator@demo.com', username: 'alexcreator',
@@ -204,7 +207,7 @@ export class AuthAdapter {
       },
     };
 
-    const demoUser = Object.values(demoUsers).find(u => u.id === userId || u.email === userId);
+    const demoUser = Object.values(demoUsers).find(u => Number(u.id) === userId);
     if (demoUser) {
       if (requiredType && demoUser.userType !== requiredType) return null;
       return demoUser;
@@ -218,14 +221,14 @@ export class AuthAdapter {
                  first_name, last_name, company_name, bio,
                  COALESCE(name, username, email) as name
           FROM users
-          WHERE id::text = ${userId} OR email = ${userId}
+          WHERE id = ${userId}
           LIMIT 1`;
 
         if (result && result.length > 0) {
           const row = result[0];
           if (requiredType && row.user_type !== requiredType) return null;
           return {
-            id: row.id,
+            id: Number(row.id),
             email: row.email,
             username: row.username,
             name: row.name,

--- a/src/auth/session-store.ts
+++ b/src/auth/session-store.ts
@@ -31,8 +31,8 @@ function toArray<T>(result: any): T[] {
 
 export interface SessionStore {
   findUser(email: string): Promise<Record<string, unknown> | undefined>;
-  findUserById(id: string): Promise<Record<string, unknown> | undefined>;
-  createSession(userId: string, expiresAt: Date): Promise<string>;
+  findUserById(id: number): Promise<Record<string, unknown> | undefined>;
+  createSession(userId: number, expiresAt: Date): Promise<string>;
   findSession(sessionId: string): Promise<Record<string, unknown> | undefined>;
   deleteSession(sessionId: string): Promise<void>;
   deleteExpiredSessions(): Promise<number>;
@@ -64,7 +64,7 @@ export function createSessionStore(env: SessionStoreEnv): SessionStore {
       return rows[0];
     },
 
-    async findUserById(id: string) {
+    async findUserById(id: number) {
       const result = await sql`
         SELECT id, email, username, user_type,
                first_name, last_name, company_name, profile_image, subscription_tier,
@@ -78,7 +78,7 @@ export function createSessionStore(env: SessionStoreEnv): SessionStore {
       return rows[0];
     },
 
-    async createSession(userId: string, expiresAt: Date) {
+    async createSession(userId: number, expiresAt: Date) {
       const sessionId = crypto.randomUUID();
       const sessionToken = crypto.randomUUID();
       await sql`

--- a/src/db/queries/analytics.ts
+++ b/src/db/queries/analytics.ts
@@ -145,7 +145,7 @@ export async function getUserViewsTimeSeries(
         )::date AS date
       ),
       user_pitches AS (
-        SELECT id FROM pitches WHERE creator_id::text = ${userId} OR user_id::text = ${userId}
+        SELECT id FROM pitches WHERE creator_id = ${userId} OR user_id = ${userId}
       )
       SELECT
         ds.date::text,
@@ -183,7 +183,7 @@ export async function getEngagementTimeSeries(
         )::date AS date
       ),
       user_pitches AS (
-        SELECT id FROM pitches WHERE creator_id::text = ${userId} OR user_id::text = ${userId}
+        SELECT id FROM pitches WHERE creator_id = ${userId} OR user_id = ${userId}
       ),
       daily_views AS (
         SELECT DATE(viewed_at) as date, COUNT(*) as views
@@ -245,7 +245,7 @@ export async function getFundingTimeSeries(
         )::date AS date
       ),
       user_pitches AS (
-        SELECT id FROM pitches WHERE creator_id::text = ${userId}
+        SELECT id FROM pitches WHERE creator_id = ${userId}
       ),
       daily_funding AS (
         SELECT
@@ -283,7 +283,7 @@ export async function getAudienceDemographics(
     // Get viewer user types
     const userTypeResult = await sql`
       WITH user_pitches AS (
-        SELECT id FROM pitches WHERE creator_id::text = ${userId}
+        SELECT id FROM pitches WHERE creator_id = ${userId}
       ),
       viewer_types AS (
         SELECT
@@ -311,7 +311,7 @@ export async function getAudienceDemographics(
     // Get views by pitch category/genre
     const categoryResult = await sql`
       WITH user_pitches AS (
-        SELECT id, genre FROM pitches WHERE creator_id::text = ${userId} OR user_id::text = ${userId}
+        SELECT id, genre FROM pitches WHERE creator_id = ${userId} OR user_id = ${userId}
       ),
       category_views AS (
         SELECT
@@ -373,7 +373,7 @@ export async function getTopPerformingPitchesForUser(
           0
         )::numeric as funding
       FROM pitches p
-      WHERE p.creator_id::text = ${userId}
+      WHERE p.creator_id = ${userId}
         AND p.status = 'published'
       ORDER BY views DESC, engagement_rate DESC
       LIMIT ${limit}
@@ -408,11 +408,11 @@ export async function getMonthlyPerformance(
           DATE_TRUNC('month', created_at)::date as month,
           COUNT(*) as pitches
         FROM pitches
-        WHERE creator_id::text = ${userId} OR user_id::text = ${userId}
+        WHERE creator_id = ${userId} OR user_id = ${userId}
         GROUP BY DATE_TRUNC('month', created_at)
       ),
       user_pitch_ids AS (
-        SELECT id FROM pitches WHERE creator_id::text = ${userId} OR user_id::text = ${userId}
+        SELECT id FROM pitches WHERE creator_id = ${userId} OR user_id = ${userId}
       ),
       monthly_views AS (
         SELECT
@@ -465,7 +465,7 @@ export async function getUserAverageRating(
       SELECT COALESCE(AVG(rating), 0)::numeric as avg_rating
       FROM pitch_ratings pr
       JOIN pitches p ON pr.pitch_id = p.id
-      WHERE p.creator_id::text = ${userId}
+      WHERE p.creator_id = ${userId}
     `;
 
     const data = extractFirst<{ avg_rating: number }>(result);
@@ -488,15 +488,15 @@ export async function getUserResponseRate(
       WITH received AS (
         SELECT COUNT(*) as total
         FROM messages
-        WHERE recipient_id::text = ${userId}
+        WHERE recipient_id = ${userId}
       ),
       responded AS (
         SELECT COUNT(DISTINCT m1.sender_id) as total
         FROM messages m1
-        WHERE m1.recipient_id::text = ${userId}
+        WHERE m1.recipient_id = ${userId}
           AND EXISTS (
             SELECT 1 FROM messages m2
-            WHERE m2.sender_id::text = ${userId}
+            WHERE m2.sender_id = ${userId}
               AND m2.recipient_id = m1.sender_id
               AND m2.sent_at > m1.sent_at
           )

--- a/src/db/queries/documents.ts
+++ b/src/db/queries/documents.ts
@@ -412,7 +412,7 @@ export async function getNDARequest(
 
 export async function getUserNDARequests(
   sql: SqlQuery,
-  userId: string,
+  userId: number,
   type: 'sent' | 'received' | 'all' = 'all'
 ): Promise<NDARequest[]> {
   const wb = new WhereBuilder();

--- a/src/db/queries/investments.ts
+++ b/src/db/queries/investments.ts
@@ -203,7 +203,7 @@ export async function updateInvestmentStatus(
 // Investor portfolio queries
 export async function getInvestorPortfolio(
   sql: SqlQuery,
-  investorId: string,
+  investorId: number,
   filters?: InvestmentFilters
 ): Promise<Investment[]> {
   const wb = new WhereBuilder();

--- a/src/db/queries/notifications.ts
+++ b/src/db/queries/notifications.ts
@@ -141,7 +141,7 @@ export async function createBatchNotifications(
 
 export async function getUserNotifications(
   sql: SqlQuery,
-  userId: string,
+  userId: number,
   options?: {
     includeRead?: boolean;
     type?: string;

--- a/src/handlers/ai-pitch-extract.ts
+++ b/src/handlers/ai-pitch-extract.ts
@@ -85,7 +85,7 @@ export async function aiPitchExtract(request: Request, env: Env): Promise<Respon
   try {
     // Credit check — gate-feeding. Fail closed on credit-table outage AND surface to Sentry.
     const creditRows = await safeQuery<{ balance: number | string }>(() => sql`
-      SELECT balance FROM user_credits WHERE user_id = ${Number(userId)}
+      SELECT balance FROM user_credits WHERE user_id = ${userId}
     `, { fallback: [], context: 'ai-pitch-extract.credit-check' });
 
     if (!creditRows.ok) {
@@ -210,7 +210,7 @@ export async function aiPitchExtract(request: Request, env: Env): Promise<Respon
     await observedSwallow(
       () => sql`
         UPDATE user_credits SET balance = balance - ${AI_EXTRACT_CREDIT_COST}, total_used = total_used + ${AI_EXTRACT_CREDIT_COST}, last_updated = NOW()
-        WHERE user_id = ${Number(userId)}
+        WHERE user_id = ${userId}
       `,
       'ai-pitch-extract.credit-deduction',
     );
@@ -218,7 +218,7 @@ export async function aiPitchExtract(request: Request, env: Env): Promise<Respon
     await observedSwallow(
       () => sql`
         INSERT INTO credit_transactions (user_id, type, amount, description, balance_before, balance_after, usage_type, created_at)
-        VALUES (${Number(userId)}, 'usage', ${-AI_EXTRACT_CREDIT_COST}, 'AI pitch extraction', ${balance}, ${balance - AI_EXTRACT_CREDIT_COST}, 'ai_extract', NOW())
+        VALUES (${userId}, 'usage', ${-AI_EXTRACT_CREDIT_COST}, 'AI pitch extraction', ${balance}, ${balance - AI_EXTRACT_CREDIT_COST}, 'ai_extract', NOW())
       `,
       'ai-pitch-extract.transaction-log',
     );

--- a/src/handlers/ai-production-autofill.ts
+++ b/src/handlers/ai-production-autofill.ts
@@ -89,7 +89,7 @@ export async function aiProductionAutofill(request: Request, env: Env): Promise<
     // Credit check — gate-feeding. Fail closed on credit-table outage (don't grant
     // access on a query exception) AND surface the failure to Sentry so we know.
     const creditRows = await safeQuery<{ balance: number | string }>(() => sql`
-      SELECT balance FROM user_credits WHERE user_id = ${Number(userId)}
+      SELECT balance FROM user_credits WHERE user_id = ${userId}
     `, { fallback: [], context: 'ai-production-autofill.credit-check' });
 
     if (!creditRows.ok) {
@@ -215,7 +215,7 @@ export async function aiProductionAutofill(request: Request, env: Env): Promise<
     await observedSwallow(
       () => sql`
         UPDATE user_credits SET balance = balance - ${AUTOFILL_CREDIT_COST}, total_used = total_used + ${AUTOFILL_CREDIT_COST}, last_updated = NOW()
-        WHERE user_id = ${Number(userId)}
+        WHERE user_id = ${userId}
       `,
       'ai-production-autofill.credit-deduction',
     );
@@ -223,7 +223,7 @@ export async function aiProductionAutofill(request: Request, env: Env): Promise<
     await observedSwallow(
       () => sql`
         INSERT INTO credit_transactions (user_id, type, amount, description, balance_before, balance_after, usage_type, created_at)
-        VALUES (${Number(userId)}, 'usage', ${-AUTOFILL_CREDIT_COST}, 'AI production auto-fill', ${balance}, ${balance - AUTOFILL_CREDIT_COST}, 'ai_autofill', NOW())
+        VALUES (${userId}, 'usage', ${-AUTOFILL_CREDIT_COST}, 'AI production auto-fill', ${balance}, ${balance - AUTOFILL_CREDIT_COST}, 'ai_autofill', NOW())
       `,
       'ai-production-autofill.transaction-log',
     );

--- a/src/handlers/collaborator.ts
+++ b/src/handlers/collaborator.ts
@@ -103,7 +103,7 @@ export async function inviteCollaborator(request: Request, env: Env): Promise<Re
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
   try {
-    const isOwner = await verifyProjectOwnership(sql, projectId, Number(userId));
+    const isOwner = await verifyProjectOwnership(sql, projectId, userId);
     if (!isOwner) return errorResponse('Forbidden: not project owner', origin, 403);
 
     const body = await request.json() as Record<string, unknown>;
@@ -150,15 +150,15 @@ export async function inviteCollaborator(request: Request, env: Env): Promise<Re
 
     const result = await sql`
       INSERT INTO project_collaborators (project_id, user_id, invited_email, role, custom_role_name, invited_by, invite_token)
-      VALUES (${projectId}, ${inviteeUserId}, ${email}, ${role}, ${customRoleName}, ${Number(userId)}, ${token})
+      VALUES (${projectId}, ${inviteeUserId}, ${email}, ${role}, ${customRoleName}, ${userId}, ${token})
       RETURNING id, project_id, user_id, invited_email, role, custom_role_name, status, invited_at, invite_token
     `;
 
-    await logActivity(sql, projectId, Number(userId), 'collaborator_invited', result[0].id);
+    await logActivity(sql, projectId, userId, 'collaborator_invited', result[0].id);
 
     // Send invite email (fire-and-forget)
     const projectInfo = await sql`SELECT title FROM production_pipeline WHERE id = ${projectId}`;
-    const inviterInfo = await sql`SELECT name, company_name FROM users WHERE id = ${Number(userId)}`;
+    const inviterInfo = await sql`SELECT name, company_name FROM users WHERE id = ${userId}`;
     const roleLabel = role === 'custom' ? (customRoleName || 'Collaborator') : role.replace(/_/g, ' ');
     sendCollaboratorInviteEmail(email, {
       inviterName: inviterInfo[0]?.name || inviterInfo[0]?.company_name || 'A production company',
@@ -194,8 +194,8 @@ export async function listCollaborators(request: Request, env: Env): Promise<Res
   if (!sql) return jsonResponse({ success: true, data: { collaborators: [] } }, origin);
 
   try {
-    const isOwner = await verifyProjectOwnership(sql, projectId, Number(userId));
-    const collab = await isActiveCollaborator(sql, projectId, Number(userId));
+    const isOwner = await verifyProjectOwnership(sql, projectId, userId);
+    const collab = await isActiveCollaborator(sql, projectId, userId);
     if (!isOwner && !collab.active) return errorResponse('Forbidden', origin, 403);
 
     const collaborators = await sql`
@@ -247,7 +247,7 @@ export async function removeCollaborator(request: Request, env: Env): Promise<Re
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
   try {
-    const isOwner = await verifyProjectOwnership(sql, projectId, Number(userId));
+    const isOwner = await verifyProjectOwnership(sql, projectId, userId);
     if (!isOwner) return errorResponse('Forbidden: not project owner', origin, 403);
 
     const result = await sql`
@@ -259,7 +259,7 @@ export async function removeCollaborator(request: Request, env: Env): Promise<Re
 
     if (result.length === 0) return errorResponse('Collaborator not found', origin, 404);
 
-    await logActivity(sql, projectId, Number(userId), 'collaborator_removed', collaboratorId);
+    await logActivity(sql, projectId, userId, 'collaborator_removed', collaboratorId);
     return jsonResponse({ success: true }, origin);
   } catch (err) {
     const e = err instanceof Error ? err : new Error(String(err));
@@ -284,7 +284,7 @@ export async function updateCollaboratorRole(request: Request, env: Env): Promis
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
   try {
-    const isOwner = await verifyProjectOwnership(sql, projectId, Number(userId));
+    const isOwner = await verifyProjectOwnership(sql, projectId, userId);
     if (!isOwner) return errorResponse('Forbidden: not project owner', origin, 403);
 
     const body = await request.json() as Record<string, unknown>;
@@ -331,7 +331,7 @@ export async function resendInvite(request: Request, env: Env): Promise<Response
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
   try {
-    const isOwner = await verifyProjectOwnership(sql, projectId, Number(userId));
+    const isOwner = await verifyProjectOwnership(sql, projectId, userId);
     if (!isOwner) return errorResponse('Forbidden: not project owner', origin, 403);
 
     // Check if pending and rate limit (1 per 5 min)
@@ -410,11 +410,11 @@ export async function acceptInvite(request: Request, env: Env): Promise<Response
 
     await sql`
       UPDATE project_collaborators
-      SET user_id = ${Number(authResult.user.id)}, status = 'active', accepted_at = NOW()
+      SET user_id = ${authResult.user.id}, status = 'active', accepted_at = NOW()
       WHERE id = ${invite.id}
     `;
 
-    await logActivity(sql, invite.project_id, Number(authResult.user.id), 'invitation_accepted');
+    await logActivity(sql, invite.project_id, authResult.user.id, 'invitation_accepted');
 
     // Notify project owner (fire-and-forget)
     const ownerInfo = await sql`
@@ -479,7 +479,7 @@ export async function getAllTeamCollaborators(request: Request, env: Env): Promi
       FROM project_collaborators pc
       JOIN production_pipeline pp ON pc.project_id = pp.id
       LEFT JOIN users u ON pc.user_id = u.id
-      WHERE pp.production_company_id = ${Number(userId)} AND pc.status != 'removed'
+      WHERE pp.production_company_id = ${userId} AND pc.status != 'removed'
       ORDER BY pc.invited_at DESC
     `;
 
@@ -544,7 +544,7 @@ export async function getMyCollaborations(request: Request, env: Env): Promise<R
       FROM project_collaborators pc
       JOIN production_pipeline pp ON pc.project_id = pp.id
       JOIN users u ON pp.production_company_id = u.id
-      WHERE pc.user_id = ${Number(userId)} AND pc.status = 'active'
+      WHERE pc.user_id = ${userId} AND pc.status = 'active'
       ORDER BY pc.accepted_at DESC
     `;
 
@@ -586,7 +586,7 @@ export async function getCollaborationProject(request: Request, env: Env): Promi
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
   try {
-    const collab = await isActiveCollaborator(sql, projectId, Number(userId));
+    const collab = await isActiveCollaborator(sql, projectId, userId);
     if (!collab.active) return errorResponse('Forbidden', origin, 403);
 
     const result = await sql`
@@ -652,7 +652,7 @@ export async function getCollaborationChecklist(request: Request, env: Env): Pro
   if (!sql) return jsonResponse({ success: true, data: { checklist: {} } }, origin);
 
   try {
-    const collab = await isActiveCollaborator(sql, projectId, Number(userId));
+    const collab = await isActiveCollaborator(sql, projectId, userId);
     if (!collab.active) return errorResponse('Forbidden', origin, 403);
 
     // Get checklist from production_checklists (keyed by project owner)
@@ -692,7 +692,7 @@ export async function toggleCollaborationChecklist(request: Request, env: Env): 
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
   try {
-    const collab = await isActiveCollaborator(sql, projectId, Number(userId));
+    const collab = await isActiveCollaborator(sql, projectId, userId);
     if (!collab.active) return errorResponse('Forbidden', origin, 403);
 
     const body = await request.json() as Record<string, unknown>;
@@ -729,7 +729,7 @@ export async function toggleCollaborationChecklist(request: Request, env: Env): 
       WHERE user_id = ${ownerId} AND pitch_id = ${projectId}
     `;
 
-    await logActivity(sql, projectId, Number(userId), 'checklist_toggled', parseInt(itemId, 10) || undefined);
+    await logActivity(sql, projectId, userId, 'checklist_toggled', parseInt(itemId, 10) || undefined);
 
     return jsonResponse({ success: true, data: { item_id: itemId, completed } }, origin);
   } catch (err) {
@@ -754,7 +754,7 @@ export async function getCollaborationNotes(request: Request, env: Env): Promise
   if (!sql) return jsonResponse({ success: true, data: { notes: [] } }, origin);
 
   try {
-    const collab = await isActiveCollaborator(sql, projectId, Number(userId));
+    const collab = await isActiveCollaborator(sql, projectId, userId);
     if (!collab.active) return errorResponse('Forbidden', origin, 403);
 
     // Get project owner's pitch_id for production_notes lookup
@@ -772,7 +772,7 @@ export async function getCollaborationNotes(request: Request, env: Env): Promise
       SELECT id, content, category, author, created_at, updated_at
       FROM production_notes
       WHERE pitch_id = ${pitchId}
-        AND (shared = true OR user_id = ${Number(userId)})
+        AND (shared = true OR user_id = ${userId})
       ORDER BY created_at ASC
     `, { fallback: [], context: 'collaborator.notes.read' });
 
@@ -801,7 +801,7 @@ export async function addCollaborationNote(request: Request, env: Env): Promise<
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
   try {
-    const collab = await isActiveCollaborator(sql, projectId, Number(authResult.user.id));
+    const collab = await isActiveCollaborator(sql, projectId, authResult.user.id);
     if (!collab.active) return errorResponse('Forbidden', origin, 403);
 
     const body = await request.json() as Record<string, unknown>;
@@ -824,11 +824,11 @@ export async function addCollaborationNote(request: Request, env: Env): Promise<
 
     const result = await sql`
       INSERT INTO production_notes (user_id, pitch_id, content, category, author)
-      VALUES (${Number(authResult.user.id)}, ${pitchId}, ${content}, ${category}, ${author})
+      VALUES (${authResult.user.id}, ${pitchId}, ${content}, ${category}, ${author})
       RETURNING id, content, category, author, created_at, updated_at
     `;
 
-    await logActivity(sql, projectId, Number(authResult.user.id), 'note_added', result[0].id);
+    await logActivity(sql, projectId, authResult.user.id, 'note_added', result[0].id);
 
     return jsonResponse({ success: true, data: { note: result[0] } }, origin, 201);
   } catch (err) {
@@ -854,8 +854,8 @@ export async function getCollaborationActivity(request: Request, env: Env): Prom
 
   try {
     // Allow project owner or active collaborator
-    const isOwner = await verifyProjectOwnership(sql, projectId, Number(userId));
-    const collab = await isActiveCollaborator(sql, projectId, Number(userId));
+    const isOwner = await verifyProjectOwnership(sql, projectId, userId);
+    const collab = await isActiveCollaborator(sql, projectId, userId);
     if (!isOwner && !collab.active) return errorResponse('Forbidden', origin, 403);
 
     const url = new URL(request.url);

--- a/src/handlers/company-verification.ts
+++ b/src/handlers/company-verification.ts
@@ -176,7 +176,7 @@ export async function uploadInsuranceHandler(
 
   await bucket.put(key, fileBuffer, {
     httpMetadata: { contentType },
-    customMetadata: { userId, purpose: 'proof_of_insurance', uploadedAt: new Date().toISOString() },
+    customMetadata: { userId: String(userId), purpose: 'proof_of_insurance', uploadedAt: new Date().toISOString() },
   });
 
   // Upsert the insurance URL into company_verifications (create row if needed)

--- a/src/handlers/creator-dashboard.ts
+++ b/src/handlers/creator-dashboard.ts
@@ -86,8 +86,8 @@ export async function creatorDashboardHandler(request: Request, env: Env): Promi
     ] = await Promise.all([
       safeQuery<{ totalPitches: number; totalFollowers: number }>(() => sql`
         SELECT
-          (SELECT COUNT(*)::int FROM pitches WHERE creator_id::text = ${userId} OR user_id::text = ${userId}) as "totalPitches",
-          (SELECT COUNT(*)::int FROM follows WHERE following_id::text = ${userId}) as "totalFollowers"
+          (SELECT COUNT(*)::int FROM pitches WHERE creator_id = ${userId} OR user_id = ${userId}) as "totalPitches",
+          (SELECT COUNT(*)::int FROM follows WHERE following_id = ${userId}) as "totalFollowers"
       `, { fallback: [{ totalPitches: 0, totalFollowers: 0 }], context: 'creator-dashboard.stats' }),
       safeQuery(() => sql`
         SELECT id, title, logline, genre, status,
@@ -97,7 +97,7 @@ export async function creatorDashboardHandler(request: Request, env: Env): Promi
                COALESCE((SELECT COUNT(*) FROM ndas n WHERE n.pitch_id = pitches.id), 0)::int as "ndaRequests",
                rating, rating_average
         FROM pitches
-        WHERE creator_id::text = ${userId} OR user_id::text = ${userId}
+        WHERE creator_id = ${userId} OR user_id = ${userId}
         ORDER BY updated_at DESC
         LIMIT 5
       `, { fallback: [], context: 'creator-dashboard.recent-pitches' }),
@@ -106,7 +106,7 @@ export async function creatorDashboardHandler(request: Request, env: Env): Promi
           COALESCE(SUM(view_count), 0)::int as total_views,
           COALESCE(AVG(CASE WHEN view_count > 0 THEN (like_count::float / view_count * 100) ELSE 0 END), 0) as avg_engagement
         FROM pitches
-        WHERE creator_id::text = ${userId} OR user_id::text = ${userId}
+        WHERE creator_id = ${userId} OR user_id = ${userId}
       `, { fallback: [{ total_views: 0, avg_engagement: 0 }], context: 'creator-dashboard.analytics' }),
       safeQuery<documentQueries.NDARequest>(() => documentQueries.getUserNDARequests(sql as any, userId, 'received'), { fallback: [], context: 'creator-dashboard.ndas' }),
       safeQuery<investmentQueries.Investment>(() => investmentQueries.getInvestorPortfolio(sql as any, userId, {}), { fallback: [], context: 'creator-dashboard.investments' }),
@@ -251,7 +251,7 @@ export async function creatorRevenueHandler(request: Request, env: Env): Promise
           i.status
         FROM investments i
         JOIN pitches p ON i.pitch_id = p.id
-        WHERE p.user_id::text = ${userId}
+        WHERE p.user_id = ${userId}
           AND i.created_at BETWEEN ${startDate} AND ${endDate}
         GROUP BY DATE_TRUNC('day', i.created_at), i.status
         ORDER BY date DESC
@@ -271,7 +271,7 @@ export async function creatorRevenueHandler(request: Request, env: Env): Promise
           COALESCE(MAX(i.amount), 0) as maximum
         FROM investments i
         JOIN pitches p ON i.pitch_id = p.id
-        WHERE p.user_id::text = ${userId}
+        WHERE p.user_id = ${userId}
           AND i.created_at BETWEEN ${startDate} AND ${endDate}
         GROUP BY i.status
       `,
@@ -288,8 +288,8 @@ export async function creatorRevenueHandler(request: Request, env: Env): Promise
           COALESCE(SUM(i.amount), 0) as total_invested
         FROM investments i
         JOIN pitches p ON i.pitch_id = p.id
-        JOIN users u ON i.investor_id::text = u.id::text
-        WHERE p.user_id::text = ${userId}
+        JOIN users u ON i.investor_id = u.id
+        WHERE p.user_id = ${userId}
           AND i.status IN ('committed', 'funded', 'active')
         GROUP BY u.location, u.company_name
         ORDER BY total_invested DESC
@@ -402,8 +402,8 @@ export async function creatorContractsHandler(request: Request, env: Env): Promi
         i.updated_at as last_updated
       FROM investments i
       JOIN pitches p ON i.pitch_id = p.id
-      LEFT JOIN users u ON i.investor_id::text = u.id::text
-      WHERE p.user_id::text = ${userId}
+      LEFT JOIN users u ON i.investor_id = u.id
+      WHERE p.user_id = ${userId}
         ${status ? sql`AND i.status = ${status}` : sql``}
       ORDER BY COALESCE(i.updated_at, i.created_at) DESC
       LIMIT 100
@@ -420,7 +420,7 @@ export async function creatorContractsHandler(request: Request, env: Env): Promi
         COALESCE(SUM(i.amount) FILTER (WHERE i.status IN ('committed', 'pending')), 0) as total_pipeline_value
       FROM investments i
       JOIN pitches p ON i.pitch_id = p.id
-      WHERE p.user_id::text = ${userId}
+      WHERE p.user_id = ${userId}
     `;
 
     return new Response(JSON.stringify({
@@ -531,7 +531,7 @@ export async function creatorPitchAnalyticsHandler(request: Request, env: Env): 
           FROM investments
           GROUP BY pitch_id
         ) inv_count ON p.id = inv_count.pitch_id
-        WHERE p.user_id::text = ${userId}
+        WHERE p.user_id = ${userId}
         ORDER BY p.created_at DESC
       `, { fallback: [], context: 'creator-dashboard.analytics.all-pitches' });
 
@@ -547,7 +547,7 @@ export async function creatorPitchAnalyticsHandler(request: Request, env: Env): 
         LEFT JOIN pitch_views pv ON p.id = pv.pitch_id
         LEFT JOIN saved_pitches sp ON p.id = sp.pitch_id
         LEFT JOIN nda_requests nr ON p.id = nr.pitch_id
-        WHERE p.user_id::text = ${userId}
+        WHERE p.user_id = ${userId}
       `, { fallback: [{ total_views: 0, unique_viewers: 0, total_saves: 0, total_nda_requests: 0 }], context: 'creator-dashboard.analytics.summary' });
 
       return new Response(JSON.stringify({
@@ -717,9 +717,9 @@ export async function creatorInvestorsHandler(request: Request, env: Env): Promi
           ELSE 'inactive'
         END as activity_status
       FROM users u
-      JOIN investments i ON i.investor_id::text = u.id::text
+      JOIN investments i ON i.investor_id = u.id
       JOIN pitches p ON i.pitch_id = p.id
-      WHERE p.user_id::text = ${userId}
+      WHERE p.user_id = ${userId}
         ${filter === 'active' ? sql`AND i.status IN ('committed', 'funded', 'active')` : sql``}
       GROUP BY u.id, u.name, u.first_name, u.last_name, u.email, u.company_name, u.profile_image, u.location, u.bio
       ORDER BY total_invested DESC
@@ -757,7 +757,7 @@ export async function creatorInvestorsHandler(request: Request, env: Env): Promi
 }
 
 // Helper functions
-async function getRevenueMetrics(sql: any, userId: string) {
+async function getRevenueMetrics(sql: any, userId: number) {
   // `status` exists on both investments (i) and pitches (p); qualify or Postgres
   // throws `column reference "status" is ambiguous`.
   const result = await sql`
@@ -769,7 +769,7 @@ async function getRevenueMetrics(sql: any, userId: string) {
       AVG(CASE WHEN i.status = 'funded' THEN i.amount END) as avg_deal_size
     FROM investments i
     JOIN pitches p ON i.pitch_id = p.id
-    WHERE p.user_id::text = ${userId}
+    WHERE p.user_id = ${userId}
   `;
 
   return {
@@ -781,14 +781,14 @@ async function getRevenueMetrics(sql: any, userId: string) {
   };
 }
 
-async function getViewTrend(sql: any, userId: string) {
+async function getViewTrend(sql: any, userId: number) {
   const result = await sql`
     SELECT
       DATE_TRUNC('day', pv.viewed_at) as date,
       COUNT(*) as views
     FROM pitch_views pv
     JOIN pitches p ON pv.pitch_id = p.id
-    WHERE (p.creator_id::text = ${userId} OR p.user_id::text = ${userId})
+    WHERE (p.creator_id = ${userId} OR p.user_id = ${userId})
       AND pv.viewed_at >= NOW() - INTERVAL '30 days'
     GROUP BY DATE_TRUNC('day', pv.viewed_at)
     ORDER BY date ASC
@@ -807,7 +807,7 @@ async function getContractAlerts(sql: any, userId: string) {
       i.updated_at
     FROM investments i
     JOIN pitches p ON i.pitch_id = p.id
-    WHERE p.user_id::text = ${userId}
+    WHERE p.user_id = ${userId}
       AND i.status = 'pending'
       AND i.created_at < NOW() - INTERVAL '30 days'
   `;

--- a/src/handlers/creator-deals.ts
+++ b/src/handlers/creator-deals.ts
@@ -70,7 +70,7 @@ export async function getCreatorDeals(request: Request, env: Env): Promise<Respo
       FROM production_deals d
       LEFT JOIN pitches p ON d.pitch_id = p.id
       LEFT JOIN users pc ON d.production_company_id = pc.id
-      WHERE d.creator_id = ${Number(userId)}
+      WHERE d.creator_id = ${userId}
         AND (${status} = '' OR d.deal_state::text = ${status})
       ORDER BY d.created_at DESC NULLS LAST
       LIMIT ${limit} OFFSET ${offset}
@@ -78,7 +78,7 @@ export async function getCreatorDeals(request: Request, env: Env): Promise<Respo
 
     const countResult = await safeQuery<{ total: number }>(() => sql`
       SELECT COUNT(*)::int AS total FROM production_deals
-      WHERE creator_id = ${Number(userId)}
+      WHERE creator_id = ${userId}
         AND (${status} = '' OR deal_state::text = ${status})
     `, { fallback: [{ total: 0 }], context: 'creator-deals.count' });
 
@@ -138,8 +138,8 @@ export async function respondToCreatorDeal(request: Request, env: Env): Promise<
       SET deal_state = ${map.state}::investment_deal_state,
           option_amount = COALESCE(${counterAmount}, option_amount),
           notes = COALESCE(notes, '') || ${noteSuffix},
-          state_changed_at = NOW(), state_changed_by = ${Number(userId)}, updated_at = NOW()
-      WHERE id = ${dealId} AND creator_id = ${Number(userId)}
+          state_changed_at = NOW(), state_changed_by = ${userId}, updated_at = NOW()
+      WHERE id = ${dealId} AND creator_id = ${userId}
       RETURNING id, deal_state AS status,
                 COALESCE(option_amount, purchase_price, development_fee, 0) AS amount, pitch_id
     `;
@@ -149,7 +149,7 @@ export async function respondToCreatorDeal(request: Request, env: Env): Promise<
       INSERT INTO notifications (user_id, type, title, message, related_user_id, related_pitch_id, created_at)
       VALUES (
         ${(deal as Record<string, unknown>).production_company_id}, ${map.type}, ${map.title}, ${map.message},
-        ${Number(userId)}, ${(deal as Record<string, unknown>).pitch_id}, NOW()
+        ${userId}, ${(deal as Record<string, unknown>).pitch_id}, NOW()
       )
     `, { fallback: [], context: 'creator-deals.respond.notify' });
 
@@ -158,7 +158,7 @@ export async function respondToCreatorDeal(request: Request, env: Env): Promise<
     if (action === 'counter') {
       await safeQuery(() => sql`
         INSERT INTO deal_messages (deal_id, sender_id, sender_role, kind, body, proposed_amount)
-        VALUES (${dealId}, ${Number(userId)}, 'creator', 'counter', ${message || null}, ${counterAmount})
+        VALUES (${dealId}, ${userId}, 'creator', 'counter', ${message || null}, ${counterAmount})
       `, { fallback: [], context: 'creator-deals.respond.thread-mirror' });
     }
 

--- a/src/handlers/creator-sidebar.ts
+++ b/src/handlers/creator-sidebar.ts
@@ -335,7 +335,7 @@ export async function creatorNdasHandler(
         COALESCE(u.name, u.email) AS requester_name
       FROM nda_requests nr
       JOIN pitches p ON p.id = nr.pitch_id
-      LEFT JOIN users u ON u.id::text = nr.requester_id::text
+      LEFT JOIN users u ON u.id = nr.requester_id
       WHERE (nr.pitch_owner_id = ${userId} OR nr.creator_id = ${userId} OR nr.owner_id = ${userId} OR p.user_id = ${userId})
       ORDER BY nr.requested_at DESC
     `;
@@ -571,7 +571,7 @@ export async function creatorEarningsHandler(
         COALESCE(u.name, u.email) AS investor_name
       FROM investments i
       JOIN pitches p ON p.id = i.pitch_id
-      LEFT JOIN users u ON u.id::text = i.investor_id::text
+      LEFT JOIN users u ON u.id = i.investor_id
       WHERE p.user_id = ${userId}
       ORDER BY i.created_at DESC
       LIMIT 50
@@ -630,7 +630,7 @@ export async function creatorFollowersHandler(
         u.bio,
         f.created_at AS followed_at
       FROM follows f
-      JOIN users u ON u.id::text = f.follower_id::text
+      JOIN users u ON u.id = f.follower_id
       WHERE f.following_id = ${userId}
       ORDER BY f.created_at DESC
       LIMIT 100
@@ -771,12 +771,12 @@ export async function creatorNetworkHandler(
         f.created_at AS connected_since
       FROM follows f
       JOIN users u ON (
-        (f.follower_id::text = ${userId} AND u.id::text = f.following_id::text)
+        (f.follower_id = ${userId} AND u.id = f.following_id)
         OR
-        (f.following_id::text = ${userId} AND u.id::text = f.follower_id::text)
+        (f.following_id = ${userId} AND u.id = f.follower_id)
       )
-      WHERE f.follower_id::text = ${userId}
-         OR f.following_id::text = ${userId}
+      WHERE f.follower_id = ${userId}
+         OR f.following_id = ${userId}
       ORDER BY f.created_at DESC
     `;
 

--- a/src/handlers/creator-value.ts
+++ b/src/handlers/creator-value.ts
@@ -9,9 +9,11 @@
  * - Every metric is fetched INDEPENDENTLY and guarded, so schema drift in one
  *   table degrades that single tile to its fallback rather than 500ing the whole
  *   card (the live worker has well-documented id/column drift — see CLAUDE.md).
- * - All id comparisons cast `::text` on both sides — pitch/creator ids drift
- *   between INTEGER and UUID across history; `::text` is the established
- *   defensive join pattern in this codebase (e.g. creator-dashboard).
+ * - The authenticated user's id is a NUMBER (users.id is INTEGER), so user-id
+ *   comparisons (creator_id/user_id/following_id = ${userId}) are plain numeric.
+ *   Pitch-id comparisons keep `::text` on both sides — pitch ids drift between
+ *   INTEGER and UUID across history; `::text` is the established defensive
+ *   pattern in this codebase (e.g. creator-dashboard).
  * - Pitch ownership is `creator_id OR user_id` (both columns coexist due to drift).
  */
 
@@ -77,7 +79,7 @@ export async function creatorValueHandler(request: Request, env: Env): Promise<R
   const [user, pitchAgg, followers, shareViews, ndaAgg, seals] = await Promise.all([
     guard(() => sql`
       SELECT verification_tier, created_at, username
-      FROM users WHERE id::text = ${userId}
+      FROM users WHERE id = ${userId}
     `, { verification_tier: 'grey', created_at: null, username: null }, 'user'),
 
     guard(() => sql`
@@ -87,11 +89,11 @@ export async function creatorValueHandler(request: Request, env: Env): Promise<R
         COALESCE(SUM(view_count), 0)::int AS views,
         COALESCE(MAX(heat_score), 0)::float AS top_heat
       FROM pitches
-      WHERE creator_id::text = ${userId} OR user_id::text = ${userId}
+      WHERE creator_id = ${userId} OR user_id = ${userId}
     `, { total: 0, published: 0, views: 0, top_heat: 0 }, 'pitches'),
 
     guard(() => sql`
-      SELECT COUNT(*)::int AS v FROM follows WHERE following_id::text = ${userId}
+      SELECT COUNT(*)::int AS v FROM follows WHERE following_id = ${userId}
     `, { v: 0 }, 'followers'),
 
     // Tracked-link reach = portfolio share links + slate share links (moat #5).
@@ -99,8 +101,8 @@ export async function creatorValueHandler(request: Request, env: Env): Promise<R
     // tile reflects ALL share-link reach, not just the older portfolio links.
     guard(() => sql`
       SELECT (
-        COALESCE((SELECT SUM(view_count) FROM portfolio_share_links WHERE creator_id::text = ${userId}), 0)
-        + COALESCE((SELECT SUM(view_count) FROM slate_share_links WHERE creator_id::text = ${userId}), 0)
+        COALESCE((SELECT SUM(view_count) FROM portfolio_share_links WHERE creator_id = ${userId}), 0)
+        + COALESCE((SELECT SUM(view_count) FROM slate_share_links WHERE creator_id = ${userId}), 0)
       )::int AS v
     `, { v: 0 }, 'share_views'),
 
@@ -109,11 +111,11 @@ export async function creatorValueHandler(request: Request, env: Env): Promise<R
       SELECT (
         COALESCE((SELECT COUNT(*) FROM ndas n
           WHERE n.pitch_id::text IN (
-            SELECT id::text FROM pitches WHERE creator_id::text = ${userId} OR user_id::text = ${userId}
+            SELECT id::text FROM pitches WHERE creator_id = ${userId} OR user_id = ${userId}
           )), 0)
         + COALESCE((SELECT COUNT(*) FROM nda_requests nr
           WHERE nr.pitch_id::text IN (
-            SELECT id::text FROM pitches WHERE creator_id::text = ${userId} OR user_id::text = ${userId}
+            SELECT id::text FROM pitches WHERE creator_id = ${userId} OR user_id = ${userId}
           )), 0)
       )::int AS v
     `, { v: 0 }, 'ndas'),
@@ -122,7 +124,7 @@ export async function creatorValueHandler(request: Request, env: Env): Promise<R
       SELECT COUNT(DISTINCT pp.pitch_id)::int AS v
       FROM pitch_provenance pp
       WHERE pp.pitch_id::text IN (
-        SELECT id::text FROM pitches WHERE creator_id::text = ${userId} OR user_id::text = ${userId}
+        SELECT id::text FROM pitches WHERE creator_id = ${userId} OR user_id = ${userId}
       )
     `, { v: 0 }, 'seals'),
   ]);

--- a/src/handlers/deal-messages.ts
+++ b/src/handlers/deal-messages.ts
@@ -120,7 +120,7 @@ export async function postDealMessage(request: Request, env: Env): Promise<Respo
 
     const [message] = await sql`
       INSERT INTO deal_messages (deal_id, sender_id, sender_role, kind, body, proposed_amount, proposed_terms)
-      VALUES (${dealId}, ${Number(userId)}, ${role}, ${kind}, ${text || null}, ${proposedAmount}, ${proposedTerms || null})
+      VALUES (${dealId}, ${userId}, ${role}, ${kind}, ${text || null}, ${proposedAmount}, ${proposedTerms || null})
       RETURNING id, sender_id, sender_role, kind, body, proposed_amount, proposed_terms, created_at
     ` as unknown as Record<string, unknown>[];
 
@@ -134,7 +134,7 @@ export async function postDealMessage(request: Request, env: Env): Promise<Respo
         ${kind === 'counter'
           ? 'The other party proposed new terms on your deal'
           : 'The other party sent a message on your deal'},
-        ${Number(userId)}, ${deal.pitch_id}, NOW()
+        ${userId}, ${deal.pitch_id}, NOW()
       )
     `, { fallback: [], context: 'deal-messages.notify' });
 

--- a/src/handlers/deal-outcome.ts
+++ b/src/handlers/deal-outcome.ts
@@ -127,11 +127,11 @@ export async function markDealOutcome(request: Request, env: Env): Promise<Respo
             outcome_amount = ${amount},
             outcome_terms = ${terms},
             closed_at = ${closeDate}::timestamp,
-            outcome_reported_by = ${Number(userId)},
+            outcome_reported_by = ${userId},
             outcome_reported_at = NOW(),
             outcome_confirmed_by_creator = ${creatorConfirmed},
             outcome_confirmed_by_production = ${productionConfirmed},
-            state_changed_at = NOW(), state_changed_by = ${Number(userId)}, updated_at = NOW()
+            state_changed_at = NOW(), state_changed_by = ${userId}, updated_at = NOW()
         WHERE id = ${dealId}
         RETURNING id, deal_state AS status, outcome::text AS outcome,
                   outcome_amount, outcome_terms, closed_at,
@@ -166,7 +166,7 @@ export async function markDealOutcome(request: Request, env: Env): Promise<Respo
         ${'Deal outcome ' + verb},
         ${'The other party ' + verb + ' this deal as ' + outcome.replace(/_/g, ' ') +
           (mutuallyConfirmed ? ' (now mutually confirmed).' : '. Confirm to finalise the record.')},
-        ${Number(userId)}, ${deal.pitch_id}, NOW()
+        ${userId}, ${deal.pitch_id}, NOW()
       )
     `, { fallback: [], context: 'deal-outcome.notify' });
 

--- a/src/handlers/investor-pitch-data.ts
+++ b/src/handlers/investor-pitch-data.ts
@@ -50,7 +50,7 @@ export async function getInvestorNotes(request: Request, env: Env): Promise<Resp
     const notesResult = await safeQuery(() => sql`
       SELECT id, content, category, is_private, created_at, updated_at
       FROM investor_notes
-      WHERE user_id = ${Number(userId)} AND pitch_id = ${pitchId}
+      WHERE user_id = ${userId} AND pitch_id = ${pitchId}
       ORDER BY created_at ASC
     `, { fallback: [], context: 'investor-pitch-data.notes.list' });
 
@@ -87,7 +87,7 @@ export async function createInvestorNote(request: Request, env: Env): Promise<Re
 
     const [note] = await sql`
       INSERT INTO investor_notes (user_id, pitch_id, content, category, is_private)
-      VALUES (${Number(userId)}, ${pitchId}, ${content}, ${category}, ${isPrivate})
+      VALUES (${userId}, ${pitchId}, ${content}, ${category}, ${isPrivate})
       RETURNING id, content, category, is_private, created_at, updated_at
     `;
 
@@ -119,7 +119,7 @@ export async function deleteInvestorNote(request: Request, env: Env): Promise<Re
   try {
     await sql`
       DELETE FROM investor_notes
-      WHERE id = ${noteId} AND user_id = ${Number(userId)}
+      WHERE id = ${noteId} AND user_id = ${userId}
     `;
 
     return jsonResponse({ success: true }, origin);
@@ -152,7 +152,7 @@ export async function getInvestorDiligence(request: Request, env: Env): Promise<
     const rows = await safeQuery<{ checklist: Record<string, unknown> }>(() => sql`
       SELECT checklist
       FROM investor_diligence_checklists
-      WHERE user_id = ${Number(userId)} AND pitch_id = ${pitchId}
+      WHERE user_id = ${userId} AND pitch_id = ${pitchId}
     `, { fallback: [], context: 'investor-pitch-data.diligence.read' });
 
     const checklist = rows.rows[0]?.checklist || {};
@@ -184,7 +184,7 @@ export async function updateInvestorDiligence(request: Request, env: Env): Promi
 
     await sql`
       INSERT INTO investor_diligence_checklists (user_id, pitch_id, checklist)
-      VALUES (${Number(userId)}, ${pitchId}, ${JSON.stringify(checklist)}::jsonb)
+      VALUES (${userId}, ${pitchId}, ${JSON.stringify(checklist)}::jsonb)
       ON CONFLICT (user_id, pitch_id)
       DO UPDATE SET checklist = ${JSON.stringify(checklist)}::jsonb, updated_at = NOW()
     `;

--- a/src/handlers/investor-sidebar.ts
+++ b/src/handlers/investor-sidebar.ts
@@ -196,7 +196,7 @@ export async function investorSavedPitchesHandler(request: Request, env: Env): P
         COALESCE(u.verified, false) AS creator_verified
       FROM saved_pitches sp
       JOIN pitches p ON p.id::text = sp.pitch_id::text
-      LEFT JOIN users u ON u.id::text = p.user_id::text
+      LEFT JOIN users u ON u.id = p.user_id
       WHERE sp.user_id = ${userId}
       ORDER BY sp.created_at DESC
     `;
@@ -665,12 +665,12 @@ export async function investorNetworkHandler(request: Request, env: Env): Promis
         f.created_at AS connected_since
       FROM follows f
       JOIN users u ON (
-        (f.follower_id::text = ${userId} AND u.id::text = f.following_id::text)
+        (f.follower_id = ${userId} AND u.id = f.following_id)
         OR
-        (f.following_id::text = ${userId} AND u.id::text = f.follower_id::text)
+        (f.following_id = ${userId} AND u.id = f.follower_id)
       )
-      WHERE f.follower_id::text = ${userId}
-         OR f.following_id::text = ${userId}
+      WHERE f.follower_id = ${userId}
+         OR f.following_id = ${userId}
       ORDER BY f.created_at DESC
     `;
 
@@ -707,7 +707,7 @@ export async function investorCoInvestorsHandler(request: Request, env: Env): Pr
       FROM investments i1
       JOIN investments i2 ON i2.pitch_id = i1.pitch_id
         AND i2.investor_id != i1.investor_id
-      JOIN users u ON u.id::text = i2.investor_id::text
+      JOIN users u ON u.id = i2.investor_id
       WHERE i1.investor_id = ${userId}
       GROUP BY u.id, u.name, u.email, u.avatar_url
       ORDER BY shared_investments DESC
@@ -747,7 +747,7 @@ export async function investorCreatorsHandler(request: Request, env: Env): Promi
         COALESCE(SUM(i.amount), 0)::numeric AS total_invested
       FROM investments i
       JOIN pitches p ON p.id::text = i.pitch_id::text
-      JOIN users u ON u.id::text = p.user_id::text
+      JOIN users u ON u.id = p.user_id
       WHERE i.investor_id = ${userId}
       GROUP BY u.id, u.name, u.email, u.avatar_url, u.bio
       ORDER BY total_invested DESC
@@ -1093,7 +1093,7 @@ export async function investorOpportunitiesHandler(request: Request, env: Env): 
           + COALESCE(p.rating_average,0) * 10
         )::int) AS match_score
       FROM pitches p
-      JOIN users u ON u.id::text = p.user_id::text
+      JOIN users u ON u.id = p.user_id
       LEFT JOIN LATERAL (
         SELECT avg_roi FROM market_data
         WHERE genre ILIKE p.genre
@@ -1349,13 +1349,13 @@ export async function investorPitchInvestmentDetailHandler(request: Request, env
       // Watchlist check for current user
       sql`
         SELECT id FROM investor_watchlist
-        WHERE investor_id::text = ${userId} AND pitch_id::text = ${pitchId}
+        WHERE investor_id = ${userId} AND pitch_id::text = ${pitchId}
         LIMIT 1
       `,
       // Interest check for current user
       sql`
         SELECT id, interest_level FROM investment_interests
-        WHERE investor_id::text = ${userId} AND pitch_id::text = ${pitchId}
+        WHERE investor_id = ${userId} AND pitch_id::text = ${pitchId}
         LIMIT 1
       `,
     ]);

--- a/src/handlers/pitch-feedback.ts
+++ b/src/handlers/pitch-feedback.ts
@@ -218,7 +218,7 @@ export async function submitPitchFeedback(request: Request, env: Env): Promise<R
       const viewResult = await safeQuery<{ total_duration: number }>(
         () => sql`
           SELECT COALESCE(MAX(view_duration), 0)::int as total_duration
-          FROM views WHERE pitch_id = ${pitchId} AND viewer_id = ${Number(userId)}
+          FROM views WHERE pitch_id = ${pitchId} AND viewer_id = ${userId}
         `,
         { fallback: [{ total_duration: 0 }], context: 'pitch-feedback.consumption-gate', tags: { pitchId, userId: String(userId) } },
       );
@@ -258,7 +258,7 @@ export async function submitPitchFeedback(request: Request, env: Env): Promise<R
     // the structured submit doesn't carry one.
     const result = await sql`
       INSERT INTO pitch_feedback (pitch_id, reviewer_id, reviewer_type, rating, strengths, weaknesses, suggestions, overall_feedback, is_interested, is_anonymous, reviewer_weight)
-      VALUES (${pitchId}, ${Number(userId)}, ${reviewerType}, ${rating}, ${strengths}, ${weaknesses}, ${suggestions}, ${overallFeedback}, ${isInterested}, ${isAnonymous}, ${reviewerWeight})
+      VALUES (${pitchId}, ${userId}, ${reviewerType}, ${rating}, ${strengths}, ${weaknesses}, ${suggestions}, ${overallFeedback}, ${isInterested}, ${isAnonymous}, ${reviewerWeight})
       ON CONFLICT (pitch_id, reviewer_id) DO UPDATE SET
         reviewer_type = EXCLUDED.reviewer_type,
         rating = COALESCE(EXCLUDED.rating, pitch_feedback.rating),
@@ -278,7 +278,7 @@ export async function submitPitchFeedback(request: Request, env: Env): Promise<R
     // the anonymous flag — null the actor so related_user_id can't unmask the reviewer.
     await notifyPitchOwner(sql, {
       ownerId: Number(pitch.user_id),
-      actorId: isAnonymous ? null : Number(userId),
+      actorId: isAnonymous ? null : userId,
       pitchId,
       type: 'pitch_feedback',
       title: 'New feedback on your pitch',
@@ -329,7 +329,7 @@ export async function updatePitchFeedback(request: Request, env: Env): Promise<R
         overall_feedback = ${overallFeedback},
         is_interested = ${isInterested},
         is_anonymous = ${isAnonymous}
-      WHERE pitch_id = ${pitchId} AND reviewer_id = ${Number(userId)}
+      WHERE pitch_id = ${pitchId} AND reviewer_id = ${userId}
       RETURNING id, created_at
     `;
 
@@ -364,7 +364,7 @@ export async function deletePitchFeedback(request: Request, env: Env): Promise<R
   try {
     const result = await sql`
       DELETE FROM pitch_feedback
-      WHERE pitch_id = ${pitchId} AND reviewer_id = ${Number(userId)}
+      WHERE pitch_id = ${pitchId} AND reviewer_id = ${userId}
       RETURNING id
     `;
 
@@ -535,7 +535,7 @@ export async function getMyFeedback(request: Request, env: Env): Promise<Respons
       SELECT id, rating, strengths, weaknesses, suggestions, overall_feedback,
              is_interested, is_anonymous, reviewer_type, created_at
       FROM pitch_feedback
-      WHERE pitch_id = ${pitchId} AND reviewer_id = ${Number(userId)}
+      WHERE pitch_id = ${pitchId} AND reviewer_id = ${userId}
     `;
 
     return jsonResponse({ success: true, data: feedback || null }, origin);
@@ -579,7 +579,7 @@ export async function getConsumptionStatus(request: Request, env: Env): Promise<
     const viewResult = await safeQuery<{ total_duration: number }>(
       () => sql`
         SELECT COALESCE(MAX(view_duration), 0)::int as total_duration
-        FROM views WHERE pitch_id = ${pitchId} AND viewer_id = ${Number(userId)}
+        FROM views WHERE pitch_id = ${pitchId} AND viewer_id = ${userId}
       `,
       { fallback: [{ total_duration: 0 }], context: 'pitch-feedback.consumption-status', tags: { pitchId, userId: String(userId) } },
     );
@@ -632,7 +632,7 @@ export async function submitAnonymousRating(request: Request, env: Env): Promise
       const reviewerWeight = getRoleWeight(reviewerType);
       await sql`
         INSERT INTO pitch_feedback (pitch_id, reviewer_id, reviewer_type, rating, strengths, weaknesses, suggestions, overall_feedback, is_interested, is_anonymous, reviewer_weight)
-        VALUES (${pitchId}, ${Number(userId)}, ${reviewerType}, ${rating}, ${[]}, ${[]}, ${[]}, ${null}, ${false}, ${false}, ${reviewerWeight})
+        VALUES (${pitchId}, ${userId}, ${reviewerType}, ${rating}, ${[]}, ${[]}, ${[]}, ${null}, ${false}, ${false}, ${reviewerWeight})
         ON CONFLICT (pitch_id, reviewer_id) DO UPDATE SET rating = EXCLUDED.rating
       `;
       await updateRatingStats(sql, pitchId);
@@ -677,7 +677,7 @@ export async function getRatingStatus(request: Request, env: Env): Promise<Respo
   try {
     if (userId) {
       const [row] = await sql`
-        SELECT rating FROM pitch_feedback WHERE pitch_id = ${pitchId} AND reviewer_id = ${Number(userId)}
+        SELECT rating FROM pitch_feedback WHERE pitch_id = ${pitchId} AND reviewer_id = ${userId}
       `;
       return jsonResponse({ success: true, data: { rating: row?.rating ?? null } }, origin);
     }
@@ -726,7 +726,7 @@ export async function submitPitchComment(request: Request, env: Env): Promise<Re
     let userType: string | null = null;
 
     if (userId) {
-      const [user] = await sql`SELECT user_type FROM users WHERE id = ${Number(userId)}`;
+      const [user] = await sql`SELECT user_type FROM users WHERE id = ${userId}`;
       userType = user?.user_type || null;
     }
 
@@ -738,7 +738,7 @@ export async function submitPitchComment(request: Request, env: Env): Promise<Re
 
     const result = await sql`
       INSERT INTO pitch_comments (pitch_id, user_id, user_type, content, ip_hash, is_anonymous)
-      VALUES (${pitchId}, ${userId ? Number(userId) : null}, ${userType}, ${content}, ${ipHash}, ${isAnonymous})
+      VALUES (${pitchId}, ${userId ?? null}, ${userType}, ${content}, ${ipHash}, ${isAnonymous})
       RETURNING id, created_at
     `;
 
@@ -747,7 +747,7 @@ export async function submitPitchComment(request: Request, env: Env): Promise<Re
     // → actorId null so we don't expose a non-existent/identifiable user.
     await notifyPitchOwner(sql, {
       ownerId: Number(pitch.user_id),
-      actorId: userId ? Number(userId) : null,
+      actorId: userId ?? null,
       pitchId,
       type: 'pitch_comment',
       title: 'New comment on your pitch',

--- a/src/handlers/pitch-interactions.ts
+++ b/src/handlers/pitch-interactions.ts
@@ -333,7 +333,7 @@ export async function pitchPublishHandler(request: Request, env: Env): Promise<R
       `;
       if (referral?.inviter_id) {
         const [creatorInfo] = await sql`
-          SELECT name, first_name, last_name FROM users WHERE id = ${Number(userId)} LIMIT 1
+          SELECT name, first_name, last_name FROM users WHERE id = ${userId} LIMIT 1
         `;
         const creatorName = creatorInfo?.name
           || `${creatorInfo?.first_name || ''} ${creatorInfo?.last_name || ''}`.trim()
@@ -349,7 +349,7 @@ export async function pitchPublishHandler(request: Request, env: Env): Promise<R
               'pitch_published',
               ${`New pitch from ${creatorName}`},
               ${`${creatorName} published "${pitchTitle}" — they signed up through your invite`},
-              ${Number(userId)},
+              ${userId},
               ${Number(pitchId)},
               NOW()
             )

--- a/src/handlers/production-dashboard-extended.ts
+++ b/src/handlers/production-dashboard-extended.ts
@@ -157,7 +157,7 @@ export async function productionTalentContactHandler(request: Request, env: Env)
           'talent_contact',
           'Production Company Contact',
           ${message},
-          ${Number(userId)},
+          ${userId},
           NOW()
         )
       `, { fallback: [], context: 'production-dashboard.talent.contact.notify' });
@@ -195,7 +195,7 @@ export async function productionProjectDetailsHandler(request: Request, env: Env
       FROM production_pipeline pp
       LEFT JOIN pitches p ON pp.pitch_id = p.id
       LEFT JOIN users u ON p.user_id = u.id
-      WHERE pp.id = ${projectId} AND pp.production_company_id = ${Number(userId)}
+      WHERE pp.id = ${projectId} AND pp.production_company_id = ${userId}
     `, { fallback: [], context: 'production-dashboard.project.details' });
 
     if (!result.ok) return errorResponse('Failed to fetch project details', origin, 500);
@@ -258,7 +258,7 @@ export async function productionProjectStatusHandler(request: Request, env: Env)
         stage = COALESCE(${stage ?? null}, stage),
         completion_percentage = COALESCE(${completionPercentage ?? null}, completion_percentage),
         updated_at = NOW()
-      WHERE id = ${projectId} AND production_company_id = ${Number(userId)}
+      WHERE id = ${projectId} AND production_company_id = ${userId}
       RETURNING *
     `, { fallback: [], context: 'production-dashboard.project.status.update' });
 
@@ -307,7 +307,7 @@ export async function productionBudgetUpdateHandler(request: Request, env: Env):
         contingency_percentage = COALESCE(${contingencyPercentage ?? null}, contingency_percentage),
         contingency_used = COALESCE(${contingencyUsed ?? null}, contingency_used),
         updated_at = NOW()
-      WHERE id = ${projectId} AND production_company_id = ${Number(userId)}
+      WHERE id = ${projectId} AND production_company_id = ${userId}
       RETURNING id, budget_allocated, budget_spent, budget_remaining, contingency_percentage, contingency_used
     `, { fallback: [], context: 'production-dashboard.project.budget.update' });
 
@@ -345,7 +345,7 @@ export async function productionBudgetVarianceHandler(request: Request, env: Env
                ELSE 0
              END AS variance_percentage
       FROM production_pipeline
-      WHERE id = ${projectId} AND production_company_id = ${Number(userId)}
+      WHERE id = ${projectId} AND production_company_id = ${userId}
     `, { fallback: [], context: 'production-dashboard.project.budget.variance' });
 
     if (!result.ok) {
@@ -604,7 +604,7 @@ export async function productionLocationBookHandler(request: Request, env: Env):
 
     const booking = await sql`
       INSERT INTO location_bookings (location_id, project_id, booked_by, start_date, end_date, total_cost, status)
-      VALUES (${locationId}, ${projectId}, ${Number(userId)}, ${startDate}, ${endDate}, ${totalCost}, 'pending')
+      VALUES (${locationId}, ${projectId}, ${userId}, ${startDate}, ${endDate}, ${totalCost}, 'pending')
       RETURNING *
     `;
 
@@ -743,7 +743,7 @@ export async function productionCrewHireHandler(request: Request, env: Env): Pro
 
     // Get project title for the current_project field — non-critical; fall back to placeholder name
     const projectLookup = await safeQuery<{ title: string | null }>(() => sql`
-      SELECT title FROM production_pipeline WHERE id = ${projectId} AND production_company_id = ${Number(userId)}
+      SELECT title FROM production_pipeline WHERE id = ${projectId} AND production_company_id = ${userId}
     `, { fallback: [], context: 'production-dashboard.crew.hire.project-lookup' });
 
     const projectTitle = projectLookup.rows.length > 0

--- a/src/handlers/production-deals.ts
+++ b/src/handlers/production-deals.ts
@@ -57,7 +57,7 @@ export async function getProductionDeals(request: Request, env: Env): Promise<Re
       FROM production_deals d
       LEFT JOIN pitches p ON d.pitch_id = p.id
       LEFT JOIN users cu ON d.creator_id = cu.id
-      WHERE d.production_company_id = ${Number(userId)}
+      WHERE d.production_company_id = ${userId}
         AND (${status} = '' OR d.deal_state::text = ${status})
       ORDER BY
         CASE WHEN ${orderCol} = 'signed_at' THEN d.state_changed_at END DESC NULLS LAST,
@@ -69,7 +69,7 @@ export async function getProductionDeals(request: Request, env: Env): Promise<Re
 
     const countResult = await safeQuery<{ total: number }>(() => sql`
       SELECT COUNT(*)::int AS total FROM production_deals
-      WHERE production_company_id = ${Number(userId)}
+      WHERE production_company_id = ${userId}
         AND (${status} = '' OR deal_state::text = ${status})
     `, { fallback: [{ total: 0 }], context: 'production-deals.count' });
 
@@ -117,7 +117,7 @@ export async function createProductionDeal(request: Request, env: Env): Promise<
 
     const result = await sql`
       INSERT INTO production_deals (pitch_id, production_company_id, creator_id, deal_type, option_amount, backend_percentage, notes)
-      VALUES (${pitchId}, ${Number(userId)}, ${creatorId}, ${dealType}, ${amount}, ${royaltyPercentage}, ${terms})
+      VALUES (${pitchId}, ${userId}, ${creatorId}, ${dealType}, ${amount}, ${royaltyPercentage}, ${terms})
       RETURNING *, deal_state AS status, option_amount AS amount
     `;
 
@@ -128,7 +128,7 @@ export async function createProductionDeal(request: Request, env: Env): Promise<
         VALUES (
           ${creatorId}, 'deal_proposed', 'New Deal Proposal',
           ${'A production company has proposed a ' + dealType + ' deal for your pitch'},
-          ${Number(userId)}, ${pitchId}, NOW()
+          ${userId}, ${pitchId}, NOW()
         )
       `, { fallback: [], context: 'production-deals.create.notify' });
     }
@@ -166,7 +166,7 @@ export async function getProductionContract(request: Request, env: Env): Promise
       LEFT JOIN pitches p ON d.pitch_id = p.id
       LEFT JOIN users cu ON d.creator_id = cu.id
       LEFT JOIN users pu ON d.production_company_id = pu.id
-      WHERE d.id = ${dealId} AND d.production_company_id = ${Number(userId)}
+      WHERE d.id = ${dealId} AND d.production_company_id = ${userId}
     `, { fallback: [], context: 'production-deals.contract' });
 
     if (!result.ok) return errorResponse('Failed to generate contract', origin, 500);
@@ -228,7 +228,7 @@ export async function getDistributionChannels(request: Request, env: Env): Promi
   try {
     // Verify ownership
     const ownership = await safeQuery<{ id: number }>(() => sql`
-      SELECT id FROM production_pipeline WHERE id = ${projectId} AND production_company_id = ${Number(userId)}
+      SELECT id FROM production_pipeline WHERE id = ${projectId} AND production_company_id = ${userId}
     `, { fallback: [], context: 'production-deals.distribution.ownership' });
 
     if (!ownership.ok) {
@@ -275,7 +275,7 @@ export async function exportProjectData(request: Request, env: Env): Promise<Res
              p.title AS pitch_title, p.genre, p.logline, p.format, p.estimated_budget
       FROM production_pipeline pp
       LEFT JOIN pitches p ON pp.pitch_id = p.id
-      WHERE pp.id = ${projectId} AND pp.production_company_id = ${Number(userId)}
+      WHERE pp.id = ${projectId} AND pp.production_company_id = ${userId}
     `, { fallback: [], context: 'production-deals.export.project' });
 
     if (!projectResult.ok) return errorResponse('Failed to export project data', origin, 500);
@@ -333,7 +333,7 @@ export async function updateProjectMilestone(request: Request, env: Env): Promis
   try {
     // Verify project ownership
     const ownership = await safeQuery<{ id: number }>(() => sql`
-      SELECT id FROM production_pipeline WHERE id = ${projectId} AND production_company_id = ${Number(userId)}
+      SELECT id FROM production_pipeline WHERE id = ${projectId} AND production_company_id = ${userId}
     `, { fallback: [], context: 'production-deals.milestone-update.ownership' });
 
     if (!ownership.ok) return errorResponse('Failed to update milestone', origin, 500);

--- a/src/handlers/production-pitch-data.ts
+++ b/src/handlers/production-pitch-data.ts
@@ -171,7 +171,7 @@ export async function getProductionNotes(request: Request, env: Env): Promise<Re
   if (!sql) return jsonResponse({ success: true, data: { notes: [] } }, origin);
 
   try {
-    const ws = await resolveWorkspace(sql, Number(userId), pitchId);
+    const ws = await resolveWorkspace(sql, userId, pitchId);
     if (!ws || !ws.canView) return jsonResponse({ success: true, data: { notes: [] } }, origin);
 
     // Notes are read across the workspace's authors (`teamUserIds`): a private
@@ -207,7 +207,7 @@ export async function createProductionNote(request: Request, env: Env): Promise<
   const sql = getDb(env);
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
-  const ws = await resolveWorkspace(sql, Number(userId), pitchId);
+  const ws = await resolveWorkspace(sql, userId, pitchId);
   if (!ws || !ws.canEdit) {
     return errorResponse('Not authorized to add production notes to this pitch', origin, 403);
   }
@@ -229,7 +229,7 @@ export async function createProductionNote(request: Request, env: Env): Promise<
 
     const result = await sql`
       INSERT INTO production_notes (user_id, pitch_id, content, category, author, shared)
-      VALUES (${Number(userId)}, ${pitchId}, ${content}, ${category}, ${author}, ${shared})
+      VALUES (${userId}, ${pitchId}, ${content}, ${category}, ${author}, ${shared})
       RETURNING id, content, category, author, shared, created_at, updated_at
     `;
 
@@ -259,7 +259,7 @@ export async function deleteProductionNote(request: Request, env: Env): Promise<
   const sql = getDb(env);
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
-  const ws = await resolveWorkspace(sql, Number(userId), pitchId);
+  const ws = await resolveWorkspace(sql, userId, pitchId);
   if (!ws || !ws.canEdit) return errorResponse('Not authorized to delete this note', origin, 403);
 
   try {
@@ -272,7 +272,7 @@ export async function deleteProductionNote(request: Request, env: Env): Promise<
           RETURNING id`
       : await sql`
           DELETE FROM production_notes
-          WHERE id = ${noteId} AND pitch_id = ${pitchId} AND user_id = ${Number(userId)}
+          WHERE id = ${noteId} AND pitch_id = ${pitchId} AND user_id = ${userId}
           RETURNING id`;
 
     if (result.length === 0) {
@@ -306,7 +306,7 @@ export async function getProductionChecklist(request: Request, env: Env): Promis
   if (!sql) return jsonResponse({ success: true, data: { checklist: {} } }, origin);
 
   try {
-    const ws = await resolveWorkspace(sql, Number(userId), pitchId);
+    const ws = await resolveWorkspace(sql, userId, pitchId);
     if (!ws || !ws.canView) return jsonResponse({ success: true, data: { checklist: {} } }, origin);
 
     const result = await safeQuery<{ checklist: Record<string, unknown> }>(() => sql`
@@ -337,7 +337,7 @@ export async function updateProductionChecklist(request: Request, env: Env): Pro
   const sql = getDb(env);
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
-  const ws = await resolveWorkspace(sql, Number(userId), pitchId);
+  const ws = await resolveWorkspace(sql, userId, pitchId);
   if (!ws || !ws.canEdit) {
     return errorResponse('Not authorized to update production data on this pitch', origin, 403);
   }
@@ -387,7 +387,7 @@ export async function getProductionTeam(request: Request, env: Env): Promise<Res
   if (!sql) return jsonResponse({ success: true, data: { team: [] } }, origin);
 
   try {
-    const ws = await resolveWorkspace(sql, Number(userId), pitchId);
+    const ws = await resolveWorkspace(sql, userId, pitchId);
     if (!ws || !ws.canView) return jsonResponse({ success: true, data: { team: [] } }, origin);
 
     const result = await safeQuery<{ team: unknown[] }>(() => sql`
@@ -418,7 +418,7 @@ export async function updateProductionTeam(request: Request, env: Env): Promise<
   const sql = getDb(env);
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
-  const ws = await resolveWorkspace(sql, Number(userId), pitchId);
+  const ws = await resolveWorkspace(sql, userId, pitchId);
   if (!ws || !ws.canEdit) {
     return errorResponse('Not authorized to update production data on this pitch', origin, 403);
   }
@@ -470,7 +470,7 @@ export async function toggleNoteShared(request: Request, env: Env): Promise<Resp
   const sql = getDb(env);
   if (!sql) return errorResponse('Database unavailable', origin, 503);
 
-  const ws = await resolveWorkspace(sql, Number(userId), pitchId);
+  const ws = await resolveWorkspace(sql, userId, pitchId);
   if (!ws || !ws.canEdit) return errorResponse('Not authorized to share this note', origin, 403);
 
   try {
@@ -485,7 +485,7 @@ export async function toggleNoteShared(request: Request, env: Env): Promise<Resp
           RETURNING id, shared`
       : await sql`
           UPDATE production_notes SET shared = ${shared}, updated_at = NOW()
-          WHERE id = ${noteId} AND pitch_id = ${pitchId} AND user_id = ${Number(userId)}
+          WHERE id = ${noteId} AND pitch_id = ${pitchId} AND user_id = ${userId}
           RETURNING id, shared`;
 
     if (result.length === 0) {
@@ -525,7 +525,7 @@ export async function getCreatorPitchFeedback(request: Request, env: Env): Promi
   try {
     // Verify the caller owns this pitch
     const pitchCheck = await sql`
-      SELECT id FROM pitches WHERE id = ${pitchId} AND user_id = ${Number(userId)}
+      SELECT id FROM pitches WHERE id = ${pitchId} AND user_id = ${userId}
     `;
     if (pitchCheck.length === 0) {
       return errorResponse('Not your pitch', origin, 403);
@@ -627,7 +627,7 @@ export async function getProductionSlate(request: Request, env: Env): Promise<Re
   const origin = request.headers.get('Origin');
   const userId = await getUserId(request, env);
   if (!userId) return errorResponse('Unauthorized', origin, 401);
-  const me = Number(userId);
+  const me = userId;
 
   const emptyCounts = { evaluating: 0, reviewing: 0, packaging: 0, ready: 0 };
   const sql = getDb(env);

--- a/src/handlers/production-sidebar.ts
+++ b/src/handlers/production-sidebar.ts
@@ -92,7 +92,7 @@ export async function productionStatsHandler(
           COUNT(*) FILTER (WHERE status = 'completed')::int AS completed_projects,
           COALESCE(SUM(budget_allocated), 0) AS total_budget_allocated
         FROM production_pipeline
-        WHERE production_company_id::text = ${String(userId)}
+        WHERE production_company_id = ${userId}
       `, { fallback: [], context: 'production-sidebar.stats.project-stats' });
       degraded = degraded || projectStats.errored;
 
@@ -117,7 +117,7 @@ export async function productionStatsHandler(
           ), 0) AS monthly_revenue
         FROM investments i
         JOIN production_pipeline pp ON i.pitch_id = pp.pitch_id
-        WHERE pp.production_company_id::text = ${String(userId)}
+        WHERE pp.production_company_id = ${userId}
           AND i.status IN ('active', 'funded', 'committed', 'completed')
       `, { fallback: [], context: 'production-sidebar.stats.revenue' });
       degraded = degraded || revenueStats.errored;
@@ -220,7 +220,7 @@ export async function productionActivityHandler(
           priority,
           created_at
         FROM notifications
-        WHERE user_id = ${Number(userId)}
+        WHERE user_id = ${userId}
         ${timeFilter}
         ORDER BY created_at DESC
         LIMIT ${limit}
@@ -229,7 +229,7 @@ export async function productionActivityHandler(
       safeQuery<{ total: number }>(() => sql`
         SELECT COUNT(*)::int AS total
         FROM notifications
-        WHERE user_id = ${Number(userId)}
+        WHERE user_id = ${userId}
         ${timeFilter}
       `, { fallback: [{ total: 0 }], context: 'production-sidebar.activity.count' }),
     ]);
@@ -505,7 +505,7 @@ export async function productionRevenueHandler(
         ), 0) AS yearly_revenue
       FROM investments i
       JOIN production_pipeline pp ON i.pitch_id = pp.pitch_id
-      WHERE pp.production_company_id::text = ${String(userId)}
+      WHERE pp.production_company_id = ${userId}
         AND i.status IN ('active', 'funded', 'committed', 'completed')
     `, { fallback: [], context: 'production-sidebar.revenue.summary' });
 
@@ -525,7 +525,7 @@ export async function productionRevenueHandler(
       LEFT JOIN pitches p ON pp.pitch_id = p.id
       LEFT JOIN investments i ON i.pitch_id = pp.pitch_id
         AND i.status IN ('active', 'funded', 'committed', 'completed')
-      WHERE pp.production_company_id::text = ${String(userId)}
+      WHERE pp.production_company_id = ${userId}
       GROUP BY pp.id, pp.title, p.title
       ORDER BY revenue DESC
       LIMIT 20
@@ -540,7 +540,7 @@ export async function productionRevenueHandler(
         COUNT(i.id)::int AS investment_count
       FROM investments i
       JOIN production_pipeline pp ON i.pitch_id = pp.pitch_id
-      WHERE pp.production_company_id::text = ${String(userId)}
+      WHERE pp.production_company_id = ${userId}
         AND i.status IN ('active', 'funded', 'committed', 'completed')
         AND i.created_at >= NOW() - INTERVAL '12 months'
       GROUP BY DATE_TRUNC('month', i.created_at)
@@ -573,7 +573,7 @@ export async function productionRevenueHandler(
         SELECT
           AVG(COALESCE(NULLIF(option_amount, 0), NULLIF(purchase_price, 0), NULLIF(development_fee, 0))) AS avg_deal
         FROM production_deals
-        WHERE production_company_id = ${Number(userId)}
+        WHERE production_company_id = ${userId}
           AND deal_state NOT IN ('rejected', 'cancelled')
       `, { fallback: [], context: 'production-sidebar.revenue.deal-stats' });
 
@@ -597,7 +597,7 @@ export async function productionRevenueHandler(
       JOIN pitches p ON pp.pitch_id = p.id
       LEFT JOIN investments i ON i.pitch_id = pp.pitch_id
         AND i.status IN ('active', 'funded', 'committed', 'completed')
-      WHERE pp.production_company_id::text = ${String(userId)}
+      WHERE pp.production_company_id = ${userId}
       GROUP BY p.format
       ORDER BY revenue DESC
     `, { fallback: [], context: 'production-sidebar.revenue.by-category' });
@@ -690,14 +690,14 @@ export async function productionSavedPitchesHandler(
         FROM saved_pitches sp
         JOIN pitches p ON sp.pitch_id = p.id
         JOIN users u ON p.user_id = u.id
-        WHERE sp.user_id = ${Number(userId)}
+        WHERE sp.user_id = ${userId}
         ORDER BY sp.saved_at DESC
         LIMIT 50
       `, { fallback: [], context: 'production-sidebar.saved-pitches.list' }),
       safeQuery<{ total: number }>(() => sql`
         SELECT COUNT(*)::int AS total
         FROM saved_pitches
-        WHERE user_id = ${Number(userId)}
+        WHERE user_id = ${userId}
       `, { fallback: [{ total: 0 }], context: 'production-sidebar.saved-pitches.count' }),
     ]);
 

--- a/src/handlers/slate-share.ts
+++ b/src/handlers/slate-share.ts
@@ -45,7 +45,7 @@ export async function createSlateShareLinkHandler(request: Request, env: Env): P
     const slateId = parseInt(paramId(request, 'id', 2) || '', 10); // /api/slates/:id/share-links
     if (!slateId || Number.isNaN(slateId)) return errorResponse('Invalid slate id', origin);
 
-    const [owned] = await sql`SELECT id FROM slates WHERE id = ${slateId} AND user_id::text = ${String(userId)}`;
+    const [owned] = await sql`SELECT id FROM slates WHERE id = ${slateId} AND user_id = ${userId}`;
     if (!owned) return errorResponse('Slate not found', origin, 404);
 
     const body = await request.json().catch(() => ({})) as Record<string, unknown>;
@@ -54,7 +54,7 @@ export async function createSlateShareLinkHandler(request: Request, env: Env): P
 
     const [link] = await sql`
       INSERT INTO slate_share_links (token, slate_id, creator_id, label)
-      VALUES (${token}, ${slateId}, ${Number(userId)}, ${label})
+      VALUES (${token}, ${slateId}, ${userId}, ${label})
       RETURNING id, token, label, view_count, created_at
     `;
     return jsonResponse({ success: true, data: { link } }, origin, 201);
@@ -80,7 +80,7 @@ export async function listSlateShareLinksHandler(request: Request, env: Env): Pr
     const links = await sql`
       SELECT id, token, label, view_count, last_viewed_at, revoked_at, created_at
       FROM slate_share_links
-      WHERE slate_id = ${slateId} AND creator_id::text = ${String(userId)}
+      WHERE slate_id = ${slateId} AND creator_id = ${userId}
       ORDER BY created_at DESC
     `;
     return jsonResponse({ success: true, data: { links } }, origin);
@@ -105,7 +105,7 @@ export async function revokeSlateShareLinkHandler(request: Request, env: Env): P
 
     const [revoked] = await sql`
       UPDATE slate_share_links SET revoked_at = NOW()
-      WHERE id = ${linkId} AND creator_id::text = ${String(userId)} AND revoked_at IS NULL
+      WHERE id = ${linkId} AND creator_id = ${userId} AND revoked_at IS NULL
       RETURNING id
     `;
     if (!revoked) return errorResponse('Link not found', origin, 404);

--- a/src/handlers/views.ts
+++ b/src/handlers/views.ts
@@ -136,7 +136,7 @@ export async function getViewAnalyticsHandler(request: Request, env: Env): Promi
         COUNT(DISTINCT v.viewer_id)::int AS unique_viewers
       FROM views v
       JOIN pitches p ON p.id = v.pitch_id
-      WHERE p.user_id::text = ${userId}
+      WHERE p.user_id = ${userId}
         ${pitchId ? sql`AND v.pitch_id = ${parseInt(pitchId)}` : sql``}
       GROUP BY period
       ORDER BY period DESC
@@ -154,7 +154,7 @@ export async function getViewAnalyticsHandler(request: Request, env: Env): Promi
       FROM views v
       JOIN pitches p ON p.id = v.pitch_id
       LEFT JOIN users u ON u.id = v.viewer_id
-      WHERE p.user_id::text = ${userId}
+      WHERE p.user_id = ${userId}
         AND v.viewer_id IS NOT NULL
       GROUP BY u.id, u.name, u.user_type
       ORDER BY view_count DESC
@@ -248,7 +248,7 @@ export async function getPitchViewersHandler(request: Request, env: Env): Promis
     const PAID_TIERS = new Set(['creator', 'creator_plus', 'creator_unlimited']);
     let isPaid = false;
     try {
-      const [u] = await sql`SELECT subscription_tier FROM users WHERE id::text = ${String(userId)}`;
+      const [u] = await sql`SELECT subscription_tier FROM users WHERE id = ${userId}`;
       isPaid = PAID_TIERS.has(String((u as Record<string, unknown>)?.subscription_tier ?? ''));
     } catch { isPaid = false; }
 

--- a/src/services/company-verification.service.ts
+++ b/src/services/company-verification.service.ts
@@ -35,7 +35,7 @@ export interface AutoCheckResults {
 }
 
 export interface VerificationSubmission {
-  userId: string;
+  userId: number;
   companyName: string;
   region: 'usa' | 'uk' | 'other';
   ein?: string;
@@ -448,7 +448,7 @@ export async function submitVerification(
 
 export async function getVerificationStatus(
   sql: ReturnType<typeof neon<false, false>>,
-  userId: string,
+  userId: number,
 ): Promise<Record<string, unknown> | null> {
   const rows = await sql`
     SELECT id, company_name, region, ein, company_number, website_url,
@@ -478,7 +478,7 @@ export async function listVerifications(
     ? await sql`
         SELECT cv.*, u.email, u.name as user_name, u.username
         FROM company_verifications cv
-        JOIN users u ON cv.user_id::text = u.id::text
+        JOIN users u ON cv.user_id = u.id
         WHERE cv.status = ${statusFilter}
         ORDER BY cv.submitted_at DESC
         LIMIT ${limit} OFFSET ${offset}
@@ -486,7 +486,7 @@ export async function listVerifications(
     : await sql`
         SELECT cv.*, u.email, u.name as user_name, u.username
         FROM company_verifications cv
-        JOIN users u ON cv.user_id::text = u.id::text
+        JOIN users u ON cv.user_id = u.id
         ORDER BY cv.submitted_at DESC
         LIMIT ${limit} OFFSET ${offset}
       `
@@ -498,7 +498,7 @@ export async function listVerifications(
 export async function reviewVerification(
   sql: ReturnType<typeof neon<false, false>>,
   verificationId: string,
-  reviewerId: string,
+  reviewerId: number,
   approved: boolean,
   rejectionReason?: string,
 ): Promise<Record<string, unknown> | null> {
@@ -515,7 +515,7 @@ export async function reviewVerification(
 
   // Update trust badge tier on user
   if (rows.length > 0) {
-    await updateUserVerificationTier(sql, String(rows[0].user_id));
+    await updateUserVerificationTier(sql, Number(rows[0].user_id));
   }
 
   return rows.length > 0 ? rows[0] : null;
@@ -523,7 +523,7 @@ export async function reviewVerification(
 
 export async function isProductionVerified(
   sql: ReturnType<typeof neon<false, false>>,
-  userId: string,
+  userId: number,
 ): Promise<boolean> {
   const rows = await sql`
     SELECT 1 FROM company_verifications
@@ -558,7 +558,7 @@ export function calculateVerificationTier(
 
 export async function updateUserVerificationTier(
   sql: ReturnType<typeof neon<false, false>>,
-  userId: string,
+  userId: number,
 ): Promise<void> {
   const rows = await sql`
     SELECT status, auto_checks FROM company_verifications
@@ -569,5 +569,5 @@ export async function updateUserVerificationTier(
     ? calculateVerificationTier(rows[0].status, rows[0].auto_checks)
     : null;
 
-  await sql`UPDATE users SET verification_tier = ${tier} WHERE id::text = ${userId}`;
+  await sql`UPDATE users SET verification_tier = ${tier} WHERE id = ${userId}`;
 }

--- a/src/utils/auth-extract.ts
+++ b/src/utils/auth-extract.ts
@@ -14,7 +14,7 @@ import { verifyJWT, extractJWT, type JWTPayload } from './worker-jwt';
 import { neon } from '@neondatabase/serverless';
 
 export interface AuthenticatedUser {
-  id: string;
+  id: number;
   email: string;
   name: string;
   userType: string;
@@ -53,15 +53,18 @@ export async function getAuthenticatedUser(
   if (token) {
     const payload = await verifyJWT(token, jwtSecret);
     if (payload) {
-      return {
-        authenticated: true,
-        user: {
-          id: payload.sub,
-          email: payload.email,
-          name: payload.name,
-          userType: payload.userType
-        }
-      };
+      const id = Number(payload.sub);
+      if (!Number.isNaN(id)) {
+        return {
+          authenticated: true,
+          user: {
+            id,
+            email: payload.email,
+            name: payload.name,
+            userType: payload.userType
+          }
+        };
+      }
     }
   }
 
@@ -80,12 +83,13 @@ export async function getAuthenticatedUser(
           if (sessionData) {
             const session = JSON.parse(sessionData);
             // Check if session is expired
-            if (new Date(session.expiresAt) > new Date()) {
+            const kvUserId = Number(session.userId);
+            if (new Date(session.expiresAt) > new Date() && !Number.isNaN(kvUserId)) {
               console.log(`[Auth] Session from KV: userId=${session.userId}, userType=${session.userType}`);
               return {
                 authenticated: true,
                 user: {
-                  id: String(session.userId),
+                  id: kvUserId,
                   email: session.userEmail || '',
                   name: session.userName || session.userEmail?.split('@')[0] || '',
                   userType: session.userType || 'creator'
@@ -107,7 +111,7 @@ export async function getAuthenticatedUser(
                    u.id as uid, u.email, u.username, u.user_type,
                    u.first_name, u.last_name, u.name as display_name
             FROM sessions s
-            JOIN users u ON s.user_id::text = u.id::text
+            JOIN users u ON s.user_id = u.id
             WHERE s.id = ${sessionId}
               AND s.expires_at > NOW()
             LIMIT 1
@@ -140,10 +144,19 @@ export async function getAuthenticatedUser(
               }
             }
 
+            const dbUserId = Number(session.user_id);
+            if (Number.isNaN(dbUserId)) {
+              return {
+                authenticated: false,
+                user: null,
+                error: 'Invalid user id in session'
+              };
+            }
+
             return {
               authenticated: true,
               user: {
-                id: String(session.user_id),
+                id: dbUserId,
                 email: session.email || '',
                 name: userName,
                 userType: session.user_type || 'creator'
@@ -170,7 +183,7 @@ export async function getAuthenticatedUser(
 export async function getUserId(
   request: Request,
   env: AuthEnv
-): Promise<string | null> {
+): Promise<number | null> {
   // First try to get from auth
   const authResult = await getAuthenticatedUser(request, env);
   if (authResult.authenticated && authResult.user) {
@@ -182,7 +195,10 @@ export async function getUserId(
   const userIdParam = url.searchParams.get('userId');
   if (userIdParam) {
     console.warn('Using userId from query param - this is deprecated');
-    return userIdParam;
+    const id = Number(userIdParam);
+    if (!Number.isNaN(id)) {
+      return id;
+    }
   }
 
   return null;

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -928,7 +928,7 @@ class RouteRegistry {
                   u.bio, u.profile_image,
                   COALESCE(u.name, u.username, u.email) as name
            FROM sessions s
-           JOIN users u ON s.user_id::text = u.id::text
+           JOIN users u ON s.user_id = u.id
            WHERE s.id = $1
            AND s.expires_at > NOW()
            LIMIT 1`,
@@ -4693,7 +4693,7 @@ class RouteRegistry {
 
         // Create session
         const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days
-        const sessionId = await this.sessionStore!.createSession(String(user.id), expiresAt);
+        const sessionId = await this.sessionStore!.createSession(user.id, expiresAt);
 
         // Store session in KV if available
         const kvStore = this.env.SESSION_STORE || this.env.SESSIONS_KV || this.env.KV || this.env.CACHE;
@@ -4957,7 +4957,7 @@ class RouteRegistry {
 
         // Create new session
         const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days
-        const sessionId = await this.sessionStore!.createSession(String(user.id), expiresAt);
+        const sessionId = await this.sessionStore!.createSession(user.id, expiresAt);
 
         // Store session in KV if available (check for all possible KV bindings)
         const kvStore = this.env.SESSION_STORE || this.env.SESSIONS_KV || this.env.KV || this.env.CACHE;
@@ -6434,13 +6434,13 @@ pitchey_analytics_datapoints_per_minute 1250
             SELECT 1 FROM likes WHERE user_id = ${authResult.user.id} AND pitch_id = ${pitchId} LIMIT 1
           `;
           isLiked = likeResult.length > 0;
-          // Per-user save state. saved_pitches uses user_id::text comparison to
-          // tolerate id-type drift (matches checkPitchSaved). Wrapped so a missing
+          // Per-user save state. saved_pitches.user_id is an integer users FK
+          // compared directly against the numeric auth user id. Wrapped so a missing
           // table in older envs can't 500 the whole pitch view.
           try {
             const saveResult = await sql`
               SELECT 1 FROM saved_pitches
-              WHERE user_id::text = ${String(authResult.user.id)} AND pitch_id = ${pitchId}
+              WHERE user_id = ${authResult.user.id} AND pitch_id = ${pitchId}
               LIMIT 1
             `;
             isSaved = saveResult.length > 0;
@@ -8607,7 +8607,7 @@ pitchey_analytics_datapoints_per_minute 1250
       const creatorId: number = this.safeParseInt(pitch.user_id) || 0;
 
       // Can't request an NDA on your own pitch.
-      if (creatorId === Number(authResult.user.id)) {
+      if (creatorId === authResult.user.id) {
         return builder.error(ErrorCode.BAD_REQUEST, 'You cannot request an NDA on your own pitch');
       }
 
@@ -11237,7 +11237,7 @@ pitchey_analytics_datapoints_per_minute 1250
       const stripe = new StripeService(stripeKey);
       const origin = request.headers.get('Origin') || (this.env as any).FRONTEND_URL || 'https://pitchey-5o8.pages.dev';
       const returnUrl = `${origin}/creator/settings/profile?identity=return`;
-      const session = await stripe.createIdentityVerificationSession({ userId: Number(userId), returnUrl });
+      const session = await stripe.createIdentityVerificationSession({ userId, returnUrl });
       await sql`UPDATE users SET identity_session_id = ${session.id}, identity_status = ${session.status} WHERE id = ${userId}`;
       return builder.success({ url: session.url, status: session.status });
     } catch (err) {
@@ -14128,7 +14128,7 @@ pitchey_analytics_datapoints_per_minute 1250
     const limit = parseInt(url.searchParams.get('limit') || '30');
     const offset = parseInt(url.searchParams.get('offset') || '0');
 
-    const items = await getActivityFeed(this.env, Number(authResult.user.id), { limit, offset });
+    const items = await getActivityFeed(this.env, authResult.user.id, { limit, offset });
     return builder.success({ items });
   }
 
@@ -14146,7 +14146,7 @@ pitchey_analytics_datapoints_per_minute 1250
       return builder.error(ErrorCode.VALIDATION_ERROR, 'Invalid pitch id');
     }
 
-    const progress = await getFeedbackProgress(this.env, pitchId, Number(authResult.user.id));
+    const progress = await getFeedbackProgress(this.env, pitchId, authResult.user.id);
     return builder.success({ progress });
   }
 
@@ -16351,7 +16351,7 @@ pitchey_analytics_datapoints_per_minute 1250
         FROM ndas n
         JOIN pitches p ON n.pitch_id = p.id
         LEFT JOIN users u ON n.signer_id = u.id
-        WHERE p.user_id::text = ${String(authResult.user.id)}
+        WHERE p.user_id = ${authResult.user.id}
           AND n.status = 'signed'
         ORDER BY n.signed_at DESC
       `;
@@ -18729,12 +18729,12 @@ Signatures: [To be completed upon signing]
         LEFT JOIN LATERAL (
           SELECT n.status, n.expires_at
           FROM ndas n
-          WHERE n.pitch_id = p.id AND n.signer_id::text = $1::text
+          WHERE n.pitch_id = p.id AND n.signer_id = $1
           ORDER BY n.created_at DESC
           LIMIT 1
         ) nda ON true
-        WHERE sp.user_id::text = $1::text
-        AND p.user_id::text != $1::text
+        WHERE sp.user_id = $1
+        AND p.user_id != $1
         ${genreFilter ? `AND p.genre = $2` : ''}
         ORDER BY sp.created_at DESC
       `, genreFilter ? [authCheck.user.id, genreFilter] : [authCheck.user.id]);
@@ -18964,7 +18964,7 @@ Signatures: [To be completed upon signing]
       }
 
       const rows = await this.db.query(
-        'SELECT id, created_at FROM saved_pitches WHERE user_id::text = $1::text AND pitch_id = $2',
+        'SELECT id, created_at FROM saved_pitches WHERE user_id = $1 AND pitch_id = $2',
         [authCheck.user.id, pitchId]
       );
 
@@ -19011,7 +19011,7 @@ Signatures: [To be completed upon signing]
       const body = await request.json() as { notes?: string };
 
       const rows = await this.db.query(
-        `UPDATE saved_pitches SET notes = $1 WHERE id = $2 AND user_id::text = $3::text
+        `UPDATE saved_pitches SET notes = $1 WHERE id = $2 AND user_id = $3
          RETURNING id, pitch_id, notes, created_at as saved_at`,
         [body.notes ?? null, savedPitchId, authCheck.user.id]
       );
@@ -19049,7 +19049,7 @@ Signatures: [To be completed upon signing]
 
       // Total saved count
       const totalRows = await this.db.query(
-        'SELECT COUNT(*)::int as count FROM saved_pitches WHERE user_id::text = $1::text',
+        'SELECT COUNT(*)::int as count FROM saved_pitches WHERE user_id = $1',
         [userId]
       );
       const totalSaved = totalRows?.[0]?.count || 0;
@@ -19058,7 +19058,7 @@ Signatures: [To be completed upon signing]
       const genreRows = await this.db.query(
         `SELECT p.genre, COUNT(*)::int as count
          FROM saved_pitches sp JOIN pitches p ON p.id = sp.pitch_id
-         WHERE sp.user_id::text = $1::text AND p.genre IS NOT NULL
+         WHERE sp.user_id = $1 AND p.genre IS NOT NULL
          GROUP BY p.genre`,
         [userId]
       );
@@ -19073,7 +19073,7 @@ Signatures: [To be completed upon signing]
       const formatRows = await this.db.query(
         `SELECT p.format, COUNT(*)::int as count
          FROM saved_pitches sp JOIN pitches p ON p.id = sp.pitch_id
-         WHERE sp.user_id::text = $1::text AND p.format IS NOT NULL
+         WHERE sp.user_id = $1 AND p.format IS NOT NULL
          GROUP BY p.format`,
         [userId]
       );
@@ -19087,7 +19087,7 @@ Signatures: [To be completed upon signing]
       // Recently added (last 7 days)
       const recentRows = await this.db.query(
         `SELECT COUNT(*)::int as count FROM saved_pitches
-         WHERE user_id::text = $1::text AND created_at >= NOW() - INTERVAL '7 days'`,
+         WHERE user_id = $1 AND created_at >= NOW() - INTERVAL '7 days'`,
         [userId]
       );
       const recentlyAdded = recentRows?.[0]?.count || 0;
@@ -19618,7 +19618,7 @@ Signatures: [To be completed upon signing]
           FROM saved_pitches sp
           JOIN pitches p ON sp.pitch_id = p.id
           LEFT JOIN "user" u ON p.user_id::text = u.id::text
-          WHERE sp.user_id::text = $1::text
+          WHERE sp.user_id = $1
           ORDER BY sp.created_at DESC
           LIMIT $2 OFFSET $3
         `, [authCheck.user.id, limit, offset]);
@@ -19640,7 +19640,7 @@ Signatures: [To be completed upon signing]
           FROM saved_pitches sp
           JOIN pitches p ON sp.pitch_id = p.id
           LEFT JOIN users u ON p.user_id = u.id
-          WHERE sp.user_id::text = $1::text
+          WHERE sp.user_id = $1
           ORDER BY sp.created_at DESC
           LIMIT $2 OFFSET $3
         `, [authCheck.user.id, limit, offset]);
@@ -20215,7 +20215,7 @@ Signatures: [To be completed upon signing]
           COALESCE(SUM(p.view_count), 0) as total_views
         FROM pitches p
         WHERE p.status = 'published'
-          AND p.user_id::text != $1::text
+          AND p.user_id != $1
           AND p.created_at >= NOW() - INTERVAL '${days} days'
         GROUP BY p.genre
         ORDER BY project_count DESC


### PR DESCRIPTION
Resolves the **userId string/number schism** (#363) at the root. Canonical = **number** (DB `users.id` is INTEGER; ~437 sites already assume number; only the auth boundary stringified). Built by a multi-agent workflow (boundary → parallel file sweep → integration-to-green → independent verify), then re-verified by hand.

## The fix (boundary)
`getUserId()`/`getAuthenticatedUser()` now return `Promise<number|null>`; `AuthenticatedUser.id` is `number`. Every auth path coerces with `Number(...)` + a `Number.isNaN` guard (a non-numeric id → unauthenticated, **fail-safe**). The session join drops its `::text` bridge.

## The sweep (162 edits / 29 files)
Removed redundant `parseInt/Number/String(userId)` coercions and `col::text = ${userId}` user-id query casts (→ native integer comparison). **Surgical**: entity ids (`pitchId`/`conversationId`/`messageId`/`.id`) untouched; **pitch-id `::text` casts deliberately KEPT** (they genuinely drift INTEGER/UUID).

## Effect: worker tsc **40 → 31** (net −9)
The schism's symptoms self-resolve, several **without editing the files**:
- **`slates.ts` (8 errors)** — fixed via the boundary; `authGuard`'s original `userId: number` now receives a number. **Supersedes #358** (its `string` fix is the wrong direction under number canonical and would conflict).
- **`media-access` own-media + `messaging-simple` self-DM guard** — now valid `number === number`. **Supersedes #364**.

## Reconciliation with the open PRs

| PR | Status under this sweep |
|---|---|
| **#358** (slates → string) | **Superseded — close it** (sweep fixes slates the right way; contradicts) |
| **#364** (always-false → String()) | **Superseded — close it** (sweep fixes those via number) |
| #356 (Env secrets) | Independent — still needed (covers 7 of the remaining 31) |
| #357 (db proxy) | Independent — still needed (2) |
| #359 (collaborator/creator-value/promo trio) | Independent — still needed (8) |
| #360 (worker-integrated generic) | Independent — still needed (5) |
| #361 (notification latent bug) | Issue — the remaining 9 |

The **31 remaining errors are all non-userId** and fully covered by #356/#357/#359/#360 + #361. Sweep + those PRs → ~0.

## Verified independently
No new errors (the 1 "new" is a pre-existing error line-shifted by a comment edit), **no `any`/`as`/`@ts-ignore` silencing added**, entity ids intact, no residual `::text = ${userId}`, `build:worker` bundles. Passes the #362 type-gate (31 < 40 baseline).

Closes #363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)