### PR TITLE
ci(worker): lower type-check gate baseline 40 → 9 (lock in the cleanup)

### DIFF
--- a/scripts/worker-typecheck-gate.mjs
+++ b/scripts/worker-typecheck-gate.mjs
@@ -21,10 +21,9 @@ import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 
 // ── The baseline. Lower it (never raise it) as worker type errors are fixed. ──
-const BASELINE = 40;
-// 2026-06-25: 40 on main at gate creation. 9 of these are the notification latent-bug
-// (issue #361, intentionally unfixed). The 5 fix PRs (#356–#360) drop it to 9 once
-// merged — lower BASELINE to 9 in a follow-up after they land.
+const BASELINE = 9;
+// 2026-06-25: lowered 40 -> 9 after the userId sweep (#365) + fix PRs (#356-360) merged.
+// The 9 remaining are the notification latent bug (issue #361, intentionally unfixed).
 
 const LIST = process.argv.includes('--list');
 


### PR DESCRIPTION
The userId sweep (#365) + fixes (#356/#357/#359/#360) merged, dropping worker `tsc` errors **40 → 9**. This lowers the ratchet baseline to **9** so the gate now blocks any worker type error above 9 — locking in the cleanup.

The 9 remaining are all in `notification.service.ts` (issue **#361**, intentionally unfixed — needs a product/liveness call, not a type-add). When #361 lands, lower the baseline toward 0.

Verified: gate passes at baseline 9 on main (9 == 9).