### PR TITLE
fix(notifications): category filter no longer silently drops messages (#361) — worker tsc → 0

### DIFF
--- a/scripts/worker-typecheck-gate.mjs
+++ b/scripts/worker-typecheck-gate.mjs
@@ -21,9 +21,9 @@ import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 
 // ── The baseline. Lower it (never raise it) as worker type errors are fixed. ──
-const BASELINE = 9;
-// 2026-06-25: lowered 40 -> 9 after the userId sweep (#365) + fix PRs (#356-360) merged.
-// The 9 remaining are the notification latent bug (issue #361, intentionally unfixed).
+const BASELINE = 0;
+// 2026-06-26: lowered 9 -> 0 after fixing the notification category-filter bug (#361).
+// The worker now type-checks clean; the gate blocks ANY worker type error.
 
 const LIST = process.argv.includes('--list');
 

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -85,6 +85,15 @@ export interface NotificationPreferences {
   messageNotifications: boolean;
   systemNotifications: boolean;
 
+  // Quiet-hours (optional): the columns are NOT in the live notification_preferences
+  // table yet, so getUserPreferences() never sets these — they are always undefined,
+  // and isInQuietHours() therefore returns false (the feature is inert until the
+  // columns + loader mapping are added). Typed optional so the type matches reality.
+  quietHoursEnabled?: boolean;
+  quietHoursStart?: string;
+  quietHoursEnd?: string;
+  timezone?: string;
+
   createdAt: Date;
   updatedAt: Date;
 }
@@ -969,13 +978,18 @@ export class NotificationService {
       case 'nda_rejection':
       case 'nda_expiration':
       case 'nda_reminder':
-        return preferences.ndaNotifications;
+        // No dedicated pref column — NDA notifications are transactional/important,
+        // always allowed (previously read a non-existent `ndaNotifications` → undefined
+        // → silently blocked). See issue #361.
+        return true;
       case 'investment':
-        return preferences.investmentNotifications;
+        return preferences.investmentAlerts; // was `investmentNotifications` (not a loaded field) → always blocked
       case 'message':
         return preferences.messageNotifications;
       case 'pitch_update':
-        return preferences.pitchUpdateNotifications;
+        // No dedicated pref column — relevant to followers, allowed by default
+        // (previously read a non-existent `pitchUpdateNotifications` → silently blocked).
+        return true;
       case 'system':
         return preferences.systemNotifications;
       case 'marketing':


### PR DESCRIPTION
Roadmap **R0.2** (Band 0). Fixes the last tracked latent bug — and takes the worker to **0 type errors**.

## Liveness verdict (verified BEFORE fixing)
**Live but bounded.** The buggy filter is reachable: `POST /api/notifications/send` (registered `worker-integrated.ts:2246`) → `handleNotificationRoute` → `notificationRoutes.sendNotification` → `notification.service.sendNotification` → `determineChannels` → `isCategoryAllowed`. But the **primary flows (NDA via `nda-workflow.service`, follows, etc.) use direct `INSERT INTO notifications` and bypass the filter.** So the bug silently mis-filtered only notifications sent through the generic `/send` endpoint, for categories investment/nda/pitch-update.

## The bug
`isCategoryAllowed` read prefs `getUserPreferences()` never sets (`investmentNotifications`, `ndaNotifications`, `pitchUpdateNotifications`) → `undefined` → those categories always blocked; `isInQuietHours` read non-existent quiet-hours fields. (The last 9 worker `tsc` errors.)

## The fix — reads now follow the loaded data, not the reverse
- `investment` → `investmentAlerts` (the real column; *this was the silent drop*).
- `nda_*` / `pitch_update` → **allowed by default** (transactional / follower-relevant; no opt-out column exists — were silently blocked).
- quiet-hours fields typed **optional** with a comment: columns aren't in the live table → always undefined → `isInQuietHours` returns false (inert until columns added). Type matches reality; quiet-hours behavior unchanged.

## Gate
- **worker `tsc` 9 → 0** — the entire worker now type-checks clean.
- **Type-gate baseline lowered 9 → 0** (same PR) — it now blocks *any* worker type error.
- `build:worker` bundles; no new catch/swallow.

Note: verified by logic + the type-checker; a live smoke on `/api/notifications/send` with an investment-category payload is the final post-deploy confirmation.

Closes #361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)