### PR TITLE
feat(moat): notify matching investors on pitch publish (#7 phase 2, slice 2)

### DIFF
--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -2916,6 +2916,25 @@ class RouteRegistry {
                 console.debug('Failed to persist follower pitch-published notifications:', e);
               }
 
+              // Notify matching investors (moat #7 phase 2): public theses whose genres
+              // include this pitch's genre get a bell notification — turning stated
+              // investor intent into curated deal flow. Capped + fire-and-forget; an
+              // absent investor_thesis table (migration not applied) degrades silently.
+              try {
+                await this.db.query(
+                  `INSERT INTO notifications (user_id, type, title, message, related_pitch_id, related_user_id, action_url, is_read, created_at)
+                   SELECT it.investor_id, 'pitch_update', $1, $2, $3, $4, $5, false, NOW()
+                   FROM investor_thesis it
+                   WHERE it.is_public = TRUE
+                     AND it.investor_id <> $4
+                     AND (SELECT genre FROM pitches WHERE id = $3) = ANY(it.genres)
+                   LIMIT 25`,
+                  ['A new pitch matches your thesis', `"${pitch.title}" — a newly published pitch fits your investment thesis.`, pitch.id, Number(userId), `/pitch/${pitch.id}`]
+                );
+              } catch (e) {
+                console.debug('Failed to persist matching-investor notifications (investor_thesis may be absent):', e);
+              }
+
               // Persist to the activity feed (one actor row; fanned out at read time).
               // recordActivity never throws — safe to await inline.
               await recordActivity(this.env, {


### PR DESCRIPTION
Roadmap **R2.1 slice 2** — closes the demand↔supply loop. On pitch publish, fan out a bell notification to every **public investor thesis whose genres include the pitch's genre**. Stated investor intent (#352) becomes **curated, pushed deal flow** — the moat-#7 payoff. Builds on slice 1's matching engine (#371).

## How
Hooked into the existing `POST /api/pitches/:id/publish` block, right after the follower notifications — reusing the **live direct-insert pattern** (omits `priority` due to the drifted `notifications_priority_check`; the path #361 proved reliable). One bulk `INSERT…SELECT`, self-excludes the creator, **capped at 25**, **fire-and-forget** in try/catch.

## Safety
An absent `investor_thesis` table (migration not applied in an env) **degrades silently and never blocks publishing**. worker `tsc` 0 (gate passes); bundles.

## Verification — honest status
Type-clean + defensive (the notify can never 500 the publish). The genre-match `INSERT…SELECT` **hasn't been run against a live schema here** — post-deploy smoke: publish a pitch whose genre an investor's thesis lists → that investor gets a bell.

## Follow-ups
- Reverse hook (creator notified on a new matching thesis) — needs diff-on-save (notify only on newly-added genres) — deferred.
- Frontend "matching investors" surface on PitchDetail = slice 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)