### PR TITLE
feat(moat): matching-investors panel on creator pitch view (#7 phase 2, slice 3)

### DIFF
--- a/frontend/src/components/MatchingInvestorsPanel.tsx
+++ b/frontend/src/components/MatchingInvestorsPanel.tsx
@@ -1,0 +1,75 @@
+// MatchingInvestorsPanel — the creator-facing demand signal (moat #7 phase 2).
+// Shows public investor theses whose genres include this pitch's genre, so a creator
+// can see which investors' stated mandates match their work. Self-contained and
+// non-intrusive: renders nothing while loading, on error, or when there are no matches.
+import { useEffect, useState } from 'react';
+import { InvestorThesisService, type MatchingInvestor } from '../services/investor-thesis.service';
+
+function checkSize(min: number | null, max: number | null): string | null {
+  const fmt = (n: number) => (n >= 1_000_000 ? `$${(n / 1_000_000).toFixed(n % 1_000_000 ? 1 : 0)}M` : `$${Math.round(n / 1000)}K`);
+  if (min != null && max != null) return `${fmt(min)}–${fmt(max)}`;
+  if (min != null) return `${fmt(min)}+`;
+  if (max != null) return `up to ${fmt(max)}`;
+  return null;
+}
+
+export default function MatchingInvestorsPanel({ pitchId }: { pitchId: number }) {
+  const [investors, setInvestors] = useState<MatchingInvestor[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    InvestorThesisService.getMatchingInvestors(pitchId)
+      .then((list) => { if (alive) setInvestors(list); })
+      .catch(() => { if (alive) setInvestors([]); })
+      .finally(() => { if (alive) setLoading(false); });
+    return () => { alive = false; };
+  }, [pitchId]);
+
+  // Stay invisible unless there's something to show — never clutter the pitch view.
+  if (loading || investors.length === 0) return null;
+
+  return (
+    <div className="bg-white rounded-xl shadow-lg p-6 mt-6 border border-indigo-100">
+      <div className="flex items-center gap-2 mb-1">
+        <h3 className="text-lg font-semibold text-gray-900">Investors interested in this genre</h3>
+        <span className="inline-flex items-center justify-center text-xs font-medium px-2 py-0.5 rounded-full bg-indigo-100 text-indigo-700">
+          {investors.length}
+        </span>
+      </div>
+      <p className="text-sm text-gray-500 mb-4">
+        Public investment theses whose mandate matches this pitch.
+      </p>
+      <ul className="divide-y divide-gray-100">
+        {investors.map((inv) => {
+          const size = checkSize(inv.checkSizeMinUsd, inv.checkSizeMaxUsd);
+          return (
+            <li key={inv.investorId} className="py-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="font-medium text-gray-900 truncate">
+                    {inv.companyName || inv.username || 'Investor'}
+                  </p>
+                  {inv.genres.length > 0 && (
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {inv.genres.slice(0, 6).map((g) => (
+                        <span key={g} className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-600">{g}</span>
+                      ))}
+                    </div>
+                  )}
+                  {inv.positioning && (
+                    <p className="mt-1.5 text-sm text-gray-600 line-clamp-2">{inv.positioning}</p>
+                  )}
+                </div>
+                {size && (
+                  <span className="shrink-0 text-xs font-medium text-indigo-600 whitespace-nowrap">{size}</span>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/portals/creator/pages/CreatorPitchView.tsx
+++ b/frontend/src/portals/creator/pages/CreatorPitchView.tsx
@@ -27,6 +27,7 @@ import { useBetterAuthStore } from '@/store/betterAuthStore';
 import FormatDisplay from '@/components/FormatDisplay';
 import FeedbackDisplay from '@/components/feedback/FeedbackDisplay';
 import WhoViewedPanel from '@features/analytics/components/WhoViewedPanel';
+import MatchingInvestorsPanel from '@/components/MatchingInvestorsPanel';
 import FollowButton from '@features/browse/components/FollowButton';
 import InterestedCard from '@features/pitches/components/InterestedCard';
 import CollaborationWorkspace from '@features/pitches/components/CollaborationWorkspace';
@@ -496,6 +497,11 @@ const CreatorPitchView: React.FC = () => {
                   )}
                 </div>
               </div>
+            )}
+
+            {/* Demand signal (moat #7): investors whose thesis matches this pitch */}
+            {activeTab === 'overview' && isOwner && id && (
+              <MatchingInvestorsPanel pitchId={Number(id)} />
             )}
 
             {activeTab === 'analytics' && isOwner && analytics && (

--- a/frontend/src/services/investor-thesis.service.ts
+++ b/frontend/src/services/investor-thesis.service.ts
@@ -27,6 +27,30 @@ export interface InvestorThesis {
   isPublic: boolean;
 }
 
+// An investor whose thesis matches a given pitch (camelCase, surfaced to the creator).
+export interface MatchingInvestor {
+  investorId: number;
+  username: string | null;
+  companyName: string | null;
+  genres: string[];
+  formats: string[];
+  positioning: string;
+  checkSizeMinUsd: number | null;
+  checkSizeMaxUsd: number | null;
+}
+
+// The raw snake_case shape the backend returns for matching investors.
+interface RawMatchingInvestor {
+  investor_id: number;
+  username?: string | null;
+  company_name?: string | null;
+  genres?: string[];
+  formats?: string[];
+  positioning?: string | null;
+  check_size_min_usd?: number | null;
+  check_size_max_usd?: number | null;
+}
+
 // A clean empty mandate — used as the initial form state and as a safe default
 // when the backend returns an as-yet-unfilled thesis.
 export const EMPTY_THESIS: InvestorThesis = {
@@ -87,6 +111,30 @@ export class InvestorThesisService {
     }
     // Backend echoes the saved thesis; fall back to the submitted value if it doesn't.
     return normalize(response.data?.thesis ?? thesis);
+  }
+
+  // Public investor theses whose genres include this pitch's genre — the
+  // creator-facing demand signal (moat #7 matching). Read-only; returns [] on any
+  // error so the panel degrades to nothing rather than breaking the pitch view.
+  static async getMatchingInvestors(pitchId: number): Promise<MatchingInvestor[]> {
+    try {
+      const response = await apiClient.get<{ success: boolean; investors: RawMatchingInvestor[] }>(
+        `/api/pitches/${pitchId}/matching-investors`,
+      );
+      if (!response.success) return [];
+      return (response.data?.investors ?? []).map((r) => ({
+        investorId: r.investor_id,
+        username: r.username ?? null,
+        companyName: r.company_name ?? null,
+        genres: Array.isArray(r.genres) ? r.genres : [],
+        formats: Array.isArray(r.formats) ? r.formats : [],
+        positioning: r.positioning ?? '',
+        checkSizeMinUsd: r.check_size_min_usd ?? null,
+        checkSizeMaxUsd: r.check_size_max_usd ?? null,
+      }));
+    } catch {
+      return [];
+    }
   }
 }
 


### PR DESCRIPTION
Roadmap **R2.1 slice 3** — the frontend that makes the verified matching backend **visible**. On a creator's own pitch (Overview tab), shows the public investor theses whose genres match this pitch: **the creator-facing demand signal**.

## What
- **`investor-thesis.service.ts`** → `getMatchingInvestors(pitchId)` hits the live `GET /api/pitches/:id/matching-investors`, snake_case→camelCase, returns `[]` on any error.
- **`MatchingInvestorsPanel.tsx`** — self-contained; renders **nothing** while loading / on error / when there are no matches (never clutters or breaks the pitch view). Shows each investor's company/name, matched genres, positioning, and check-size range.
- Mounted **owner-only** on the Overview tab of `CreatorPitchView`.

## Verified
- Frontend **type-check clean**.
- **CreatorPitchView's 6 tests still pass** — the panel is non-breaking by design (invisible unless the endpoint returns matches).
- The backend endpoint is already **live + proven against prod data** (#371; verified end-to-end yesterday).

## Follow-ups
- Investor-facing side: `GET /api/investor/thesis/matches` on the investor dashboard.
- Public thesis rendering on the investor profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)