### PR TITLE
feat(moat): "matching your thesis" section on the investor dashboard (#7 phase 2)

### DIFF
--- a/frontend/src/components/ThesisMatchesSection.tsx
+++ b/frontend/src/components/ThesisMatchesSection.tsx
@@ -1,0 +1,67 @@
+// ThesisMatchesSection — the investor-facing demand→supply view (moat #7 phase 2).
+// Surfaces published pitches that match the investor's structured thesis, on the
+// investor dashboard. Self-contained and non-intrusive: renders nothing while loading,
+// on error, or when there are no matches (e.g. the investor hasn't set genres yet).
+import { useEffect, useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { Sparkles } from 'lucide-react';
+import { InvestorThesisService, type ThesisMatch } from '../services/investor-thesis.service';
+
+export default function ThesisMatchesSection() {
+  const [matches, setMatches] = useState<ThesisMatch[]>([]);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    InvestorThesisService.getThesisMatches()
+      .then((m) => { if (alive) setMatches(m); })
+      .catch(() => { if (alive) setMatches([]); })
+      .finally(() => { if (alive) setLoading(false); });
+    return () => { alive = false; };
+  }, []);
+
+  if (loading || matches.length === 0) return null;
+
+  return (
+    <section className="mb-8">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <Sparkles className="w-5 h-5 text-indigo-600" />
+          <h2 className="text-lg font-semibold text-gray-900">Matching your thesis</h2>
+          <span className="inline-flex items-center justify-center text-xs font-medium px-2 py-0.5 rounded-full bg-indigo-100 text-indigo-700">
+            {matches.length}
+          </span>
+        </div>
+        <Link to="/investor/settings/profile" className="text-sm font-medium text-indigo-600 hover:text-indigo-700">
+          Edit thesis
+        </Link>
+      </div>
+      <p className="text-sm text-gray-500 mb-4">Published pitches that fit your investment mandate.</p>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {matches.slice(0, 6).map((m) => (
+          <button
+            key={m.id}
+            type="button"
+            onClick={() => { void navigate(`/pitch/${m.id}`); }}
+            className="text-left bg-white rounded-xl shadow-sm hover:shadow-md transition-shadow border border-gray-100 p-4"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <p className="font-medium text-gray-900 truncate">{m.title}</p>
+              {m.matchScore > 1 && (
+                <span className="shrink-0 text-xs font-medium px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700">
+                  strong match
+                </span>
+              )}
+            </div>
+            <div className="mt-2 flex flex-wrap gap-1">
+              {m.genre && <span className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-600">{m.genre}</span>}
+              {m.format && <span className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-600">{m.format}</span>}
+            </div>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/InvestorDashboard.tsx
+++ b/frontend/src/pages/InvestorDashboard.tsx
@@ -32,6 +32,7 @@ import {
   Search
 } from 'lucide-react';
 import QuickActionsPanel, { type QuickAction } from '../components/dashboard/QuickActionsPanel';
+import ThesisMatchesSection from '../components/ThesisMatchesSection';
 import { useBetterAuthStore } from '../store/betterAuthStore';
 import api from '../lib/api';
 // Using the enhanced Investor-specific navigation
@@ -488,6 +489,9 @@ function InvestorDashboard() {
 
         {/* Quick Actions */}
         <QuickActionsPanel className="mb-8" actions={quickActions} columns={3} />
+
+        {/* Demand→supply (moat #7): published pitches matching the investor's thesis */}
+        <ThesisMatchesSection />
 
         {/* Tab Navigation — segmented control (investor-indigo active pill, icons).
             Natural-width tabs with horizontal scroll since there are seven. */}

--- a/frontend/src/services/investor-thesis.service.ts
+++ b/frontend/src/services/investor-thesis.service.ts
@@ -51,6 +51,25 @@ interface RawMatchingInvestor {
   check_size_max_usd?: number | null;
 }
 
+// A published pitch that matches the investor's thesis (camelCase, for the dashboard view).
+export interface ThesisMatch {
+  id: number;
+  title: string;
+  genre: string | null;
+  format: string | null;
+  creatorId: number | null;
+  matchScore: number;
+}
+
+interface RawThesisMatch {
+  id: number;
+  title?: string | null;
+  genre?: string | null;
+  format?: string | null;
+  creator_id?: number | null;
+  match_score?: number | null;
+}
+
 // A clean empty mandate — used as the initial form state and as a safe default
 // when the backend returns an as-yet-unfilled thesis.
 export const EMPTY_THESIS: InvestorThesis = {
@@ -131,6 +150,28 @@ export class InvestorThesisService {
         positioning: r.positioning ?? '',
         checkSizeMinUsd: r.check_size_min_usd ?? null,
         checkSizeMaxUsd: r.check_size_max_usd ?? null,
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  // Published pitches that match the authenticated investor's thesis (the investor-facing
+  // demand→supply view). Read-only; returns [] on any error so the section stays invisible
+  // rather than breaking the dashboard.
+  static async getThesisMatches(): Promise<ThesisMatch[]> {
+    try {
+      const response = await apiClient.get<{ success: boolean; matches: RawThesisMatch[] }>(
+        '/api/investor/thesis/matches',
+      );
+      if (!response.success) return [];
+      return (response.data?.matches ?? []).map((r) => ({
+        id: r.id,
+        title: r.title ?? 'Untitled',
+        genre: r.genre ?? null,
+        format: r.format ?? null,
+        creatorId: r.creator_id ?? null,
+        matchScore: r.match_score ?? 0,
       }));
     } catch {
       return [];


### PR DESCRIPTION
The **investor-facing half** of the demand↔supply loop (the creator-facing half shipped in #373). On the investor dashboard, surfaces published pitches matching the investor's structured thesis — **their curated deal flow**.

## What
- **`investor-thesis.service.ts`** → `getThesisMatches()` hits the live, prod-verified `GET /api/investor/thesis/matches`; returns `[]` on any error.
- **`ThesisMatchesSection.tsx`** — self-contained; renders **nothing** while loading / on error / when there are no matches (e.g. genres unset) — never breaks the dashboard. Up to 6 clickable cards (title, genre, format, a "strong match" badge when `match_score > 1`) + an "Edit thesis" link.
- Mounted after Quick Actions on `InvestorDashboard`.

## Verified
- Frontend **type-check clean**; dashboard test suite passes (non-breaking by design).
- Endpoint already **live + proven end-to-end against prod data** (#371).

## Moat #7 now full-stack, both directions
schema (live) → matching (live) → notify (live) → **creator panel (#373)** + **investor section (this PR)**.

## Follow-ups
Public thesis rendering on the investor profile · the reverse notify hook (thesis-save → creators).

🤖 Generated with [Claude Code](https://claude.com/claude-code)