### PR TITLE
feat(moat): deal-servicing roadmap (R2.3) + liquidity-gate admin tile

### DIFF
--- a/docs/deal-servicing-roadmap-2026-06-27.md
+++ b/docs/deal-servicing-roadmap-2026-06-27.md
@@ -1,0 +1,138 @@
+# Deal-Servicing Roadmap (R2.3) — Pitchey
+
+> **Status: SCOPE ONLY.** This document scopes the deal-servicing build. It does **not** authorize starting it.
+> Per `evolution-roadmap-2026-06-26.md` (R2.3) and `project_moat_inventory`, the build below is
+> **liquidity-gated** — see §5. Generated 2026-06-27, grounded against live repo state (not memory).
+
+## 0. Why this exists, and why it doesn't start yet
+
+R2.3 is the "next strategic build after moat #7 lands." Moat #7 (structured investor thesis) **has landed**
+(migration 116 live, matching engine live, verified end-to-end 2026-06-26). So the schema prerequisite is met.
+
+But the **governing lens of the entire moat review is disintermediation** (`project_moat_inventory`, deep-research
+`wf_8a3c39a4-82b`): Pitchey sits in the highest-leakage quadrant (heterogeneous, high-variance, long-comms, complex
+deals = film). The peer-reviewed finding is that *better intro-quality without on-platform deal-servicing value
+accelerates off-platform leakage*. The defense against that is exactly the build scoped here — **but building it
+onto sparse, pre-launch liquidity produces an empty, abandoned escrow flow that signals "broken," not "premium."**
+
+So this roadmap's first job is to make the **trigger** explicit and measurable (§5), so the build starts the day
+liquidity is real and not one sprint before.
+
+## 1. Current state — what already ships (do not rebuild)
+
+The deal *record* and *conversation* layers are **live in production**. Verified in `src/worker-integrated.ts` +
+`src/handlers/`:
+
+| Layer | Status | Where |
+|---|---|---|
+| Deal record (`production_deals`: type, state machine, option/purchase/backend/dev-fee/territory/notes) | **LIVE** | insert path fixed mig 111 |
+| Producer proposes → Creator Deal Inbox → accept/counter/reject (#6) | **LIVE** | `creator-deals.ts`, `production-deals.ts` |
+| Both-sided **outcome capture** (closed_on/off_platform / dead + mutual confirm) — P1 | **LIVE** | mig 114, `deal-outcome.ts` |
+| **Reputation loop** (gold on mutually-confirmed honored deal) — P2 | **LIVE** | `creator-reputation.ts` Path B |
+| Structured **negotiation thread** `deal_messages` (message/counter + €proposal) — P3 | **LIVE** | mig 115, `deal-messages.ts` |
+| Deal-sheet **view** (`getProductionContract` → contract JSON) | **LIVE but a view** | `production-deals.ts:145` — a rendered summary, **not** a signed instrument |
+
+**The disintermediation thread is intentionally PAUSED at P3.** P1–P3 capture *that a deal happened and what it
+was*, even when money moves off-platform. They are the cheap, pre-liquidity-safe half of the moat. ✅ Done.
+
+## 2. The gap — what "deal-servicing" actually means
+
+Everything above is **system-of-record + messaging**. None of it touches money or produces a binding artifact.
+Deal-servicing = giving parties a reason to **transact on-platform** rather than just record that they transacted
+elsewhere. Verified orphan / schema-only today:
+
+- `escrow_accounts` — schema-only since migration 003. **Zero handlers wired.**
+- `contracts` / `contract_signatures` — schema-only since migration 004. **Zero handlers wired.**
+  (Orphan `src/handlers/contracts.ts` exists but is **not** the live `/api/creator/contracts` route — that uses
+  `creator-dashboard.ts:creatorContractsHandler`. Do not revive the orphan.)
+- **No Stripe Connect.** The only `connect` hit in the worker is an incidental Stripe health-check string.
+- **No money movement, no take-rate.** Subscriptions are the only revenue. Investments are intent-only.
+
+This gap *is* the long-term moat (the thing that makes leaving expensive). It is also the most dangerous thing to
+ship early.
+
+## 3. The build — P5, decomposed (LIQUIDITY-GATED — see §5 before starting)
+
+Sequenced so each slice is independently shippable and each earlier slice de-risks the next. Reuse the live
+`production_deals` / `deal_messages` spine throughout — **do not** introduce a parallel deal object, **do not**
+revive orphaned `contracts.ts` or the parked `src/workflows/` (#60) / `crawl4ai` (#61).
+
+### P5.0 — Binding deal-sheet + e-signature (the cheapest real lock-in)
+- **What:** promote `getProductionContract`'s JSON deal-sheet from a *view* into a **signable instrument**.
+  Port the **Standard-NDA sign engine to Neon** (it already does click-to-sign + content-hash sealing for NDAs —
+  same primitive, new document type). Persist into a real `deal_signatures` table keyed to `production_deals.id`
+  (do **not** reuse the orphan `contract_signatures` schema; write a fresh migration matching the live spine).
+- **Why first:** no payments, no Connect, no PCI surface. Pure switching-cost: a co-signed, hash-sealed deal sheet
+  living on Pitchey is a reason to come back. Reuses an engine that already exists and is trusted (provenance #4).
+- **Outcome capture already exists** (P1) — sign-on-platform feeds the *same* mutual-confirm → reputation loop.
+
+### P5.1 — Stripe Connect onboarding (rails, no flow yet)
+- **What:** connected-account onboarding for the **paying side** (production/investor). Express accounts.
+  Store `stripe_connect_account_id`; gate "ready to transact" on `charges_enabled`/`payouts_enabled`.
+- **Why before money:** onboarding/KYC is the slowest, highest-drop-off step. Land it as its own slice so the
+  payment slice isn't also debugging KYC. **No `application_fee` yet** — prove onboarding completes first.
+- **Hard dependency:** a billing/account decision (who is the platform of record; EUR→GBP adaptive-pricing issue
+  already tracked in `project_stripe_live` applies here too).
+
+### P5.2 — Milestone-gated payment (option fee first, the simplest money)
+- **What:** the **option payment** (smallest, most common first transaction) moves on-platform: production funds an
+  option → held → released to creator on a milestone the deal already models. Milestones already exist conceptually
+  in the deal state machine; wire the *first* one to a real transfer.
+- **Take-rate:** `application_fee_amount` on the transfer is **the first real take-rate the platform has ever had.**
+  Start small and visible; do not bury it.
+- **Escrow:** use Stripe's hold/capture or a separate-charges-and-transfers pattern. **Do not** revive the
+  `escrow_accounts` table as a ledger you reconcile by hand — let Stripe be the ledger.
+
+### P5.3 — Full milestone payout schedule
+- Generalize P5.2 from "option fee" to the deal's full milestone set (development fee, purchase tranches, backend).
+  Only meaningful once P5.2 has real volume.
+
+### P4 (reputation decay) — deferred, post-launch, destructive
+Tracked separately in `project_moat_inventory` (P4). Reverses the promote-only invariant; **nothing to decay
+pre-launch** (1 demo gold creator, 0 honored deals). Do not bundle into P5. Revisit when a real gold cohort exists.
+
+## 4. Explicit non-goals (the DO-NOT-BUILD list, deal-servicing edition)
+
+- ❌ Revive `escrow_accounts` / `contracts` / `contract_signatures` migration schemas as the data model — they
+  predate the live `production_deals` spine and will fork it. New migrations, keyed to the live spine, only.
+- ❌ Revive `src/handlers/contracts.ts` or `src/workflows/investment-*` (#60) — parked by decision, not pending.
+- ❌ Hand-rolled escrow ledger. Stripe is the money source-of-truth.
+- ❌ A second deal object / a "deals v2." Extend `production_deals` + `deal_messages`.
+- ❌ Take-rate before liquidity. A fee on zero deals is friction with no offsetting value — pure leakage incentive.
+
+## 5. The liquidity gate (the actual trigger — measure before building)
+
+**Do not start P5.0 until these are observed.** Per `project_moat_inventory` Open Questions 1 & 2, liquidity must
+be *proven*, not assumed, because #3 (de-charge NDA) was declined — the cold-start push relies on #1/#5/saved-search.
+
+Proposed concrete triggers (tune with Karl; these are the scope's recommendation, not a decision):
+
+| Signal | Why it's the gate | Source |
+|---|---|---|
+| **≥ N verified buyers signing NDAs / week**, trend non-decreasing | proves the demand side is live, not seeded | NDA-graph density (Open Q2) |
+| **≥ M `production_deals` reaching a terminal outcome / month** | proves deals actually *close*, not just open | `production_deals.outcome` (P1 data) |
+| **≥ X% of closed deals marked `closed_off_platform`** | this is the leakage P5 is designed to capture — high = strong ROI | `deal_outcome` enum |
+| Mutual-confirm rate healthy | proves both sides report back (P2 working) | outcome_confirmed_by_* |
+
+The fourth row is the sharpest: **off-platform-close rate is the direct evidence that deal-servicing would pay for
+itself.** If deals are closing off-platform at volume, P5.0 (binding sign) → P5.2 (option payment) is justified and
+should start. If they're not closing at all, the bottleneck is liquidity (Band-0/Band-2 demand-side work), not
+servicing — and P5 would ship onto a vacuum.
+
+**Instrumentation to add *now* (cheap, pre-gate):** a unit-economics tile (Five-Pillars P2, already TODO) reading
+the four signals above off the live `production_deals` outcome columns. This is the only deal-servicing-adjacent
+*code* worth writing pre-liquidity — it's the dashboard that tells you when to start the rest.
+
+## 6. Recommended next action
+
+1. **Land the gate instrument, not the build.** Add the §5 four-signal tile to the admin/unit-economics surface
+   (reads existing mig-114 columns; no new schema). This makes the trigger observable.
+2. **Hold P5.0–P5.3 until §5 fires.** When it does, P5.0 (binding e-sign, reusing the NDA sign engine) is the
+   first slice — lowest risk, no payment surface, real switching cost.
+3. **Karl decision needed before any P5 money slice:** platform-of-record / Connect account model + take-rate %
+   (and the EUR→GBP adaptive-pricing question from `project_stripe_live`).
+
+---
+*Grounding: verified live route wiring + handlers in `src/worker-integrated.ts`, `src/handlers/deal-outcome.ts`,
+`deal-messages.ts`, `production-deals.ts`; escrow/contracts confirmed schema-only (migrations 003/004) with zero
+worker imports; no Stripe Connect present. Strategy anchored on `project_moat_inventory` governing lens.*

--- a/docs/evolution-roadmap-2026-06-26.md
+++ b/docs/evolution-roadmap-2026-06-26.md
@@ -1,0 +1,79 @@
+# Evolution Roadmap — Pitchey
+Generated from audit: backend-health investigation + autonomous-harness findings (2026-06-25/26)
+Generated: 2026-06-26
+
+## Executive Summary
+The backend isn't under-developed — it's a fast, broad codebase whose migration-era debt was never reconciled because there was no guardrail forcing it. That guardrail now exists (worker type-gate, ratcheted to 9) and the worst debt is cleared: worker `tsc` 40 → 9, the userId string/number schism fixed at the root, 2 live runtime bugs closed. This roadmap prioritizes the **remaining liabilities that can actually hurt a pre-launch product** (a recurring total prod-outage; a notification path that may be silently dropping user messages) before deepening the **monetization moat** (structured investor intent → matching → deal-servicing). Sequencing rule: **stop the bleeding that's real, clear the cheap dead weight, then deepen the moat — and don't let either block the others.**
+
+## The Defensible Core (what we're protecting and extending)
+The moat is the **cross-role NDA-intent graph** — creators, investors, and production expressing real intent (NDAs signed, deals recorded, theses declared) in a way time + liquidity make hard to copy (per `project_moat_inventory`). Band 2 deepens exactly this: turning investor "thesis" from free text into a **structured, queryable record** (moat #7) so intent becomes matchable, then building the deal-servicing layer on top.
+
+## Sequenced Plan
+
+### Now — Active Liabilities [Band 0]
+
+- **R0.1 Neon compute-quota → recurring total production outage** — `risk: critical` `gates: required`
+  - **Defect:** the current Neon plan can hit a compute-time quota → HTTP 402 on every query → login 503s, marketplace silently empty (errors swallowed). Took prod **fully down twice** (2026-04-30 #65, 2026-06-22).
+  - **Why now:** it's not hypothetical — it has recurred, and for a pre-launch product a total outage on launch day outranks every feature. `retryable:true` resets per window but the trigger is unmanaged.
+  - **Shape of fix:** primarily a **plan/billing decision** (the durable fix), plus code hardening: a fail-loud health signal (not silent-empty), and a degradation banner so a 402 reads as "degraded" not "broken/empty". Do NOT paper over it with more swallowed retries.
+  - **Verify:** a forced 402 (staging) surfaces as an explicit degraded state in `/api/health` + UI, not an empty marketplace; alerting fires within minutes, not the hourly cron.
+
+- **R0.2 Notification category filter silently drops user notifications** — `risk: high` `gates: required` (issue #361)
+  - **Defect:** `notification.service.ts` reads `investmentNotifications` / `ndaNotifications` / `pitchUpdateNotifications` + quiet-hours fields the loader **never sets** → `undefined` → those categories are **always blocked**; quiet-hours inert. (These are the 9 remaining worker `tsc` errors.)
+  - **Why now:** if the `sendNotification → determineChannels` path is live (plausibly is, via `notification-integration.service`), users are **not receiving NDA/investment/pitch-update notifications** — directly undermines the demand→supply loop. The compiler can't see it (values launder through mis-typed objects).
+  - **Shape of fix:** **confirm liveness FIRST** (vs the direct-insert `notify()` path), then align reads to the loaded fields (`investmentNotifications`→`investmentAlerts`) and decide whether nda/pitch-update/quiet-hours become real columns or are removed. Type-add LAST (so the type follows reality). NOT a blind type fix.
+  - **Verify:** an investment/NDA notification is actually delivered for a user with default prefs; worker `tsc` → 0; gate baseline lowered 9 → 0.
+
+### Next — Inert Liabilities & Honesty Debt [Band 1 + pinned Band 3]
+
+- **R1.1 Delete 15 confirmed-orphan handler/route files** — `risk: low` `gates: optional`
+  - **Action:** delete the 15 files the `dead-route-sweep` confirmed dead (re-confirmed 2026-06-26) — never imported into `worker-integrated.ts`, several in frameworks (Express/Oak/standalone-Hono) that can't run in the Worker. The harness already generated the gated execute prompt (`orphan-batch-delete`).
+  - **Kills claim:** removes a chunk of the #308 "~179 orphan files" overhang that confuses every audit (and these docs).
+  - **Verify:** per-file `grep` shows zero importers at delete-time; PROTECTED paths (#60/#61) excluded; `build:worker` bundles; worker `tsc` unchanged.
+
+- **R1.2 Resolve `gdpr-handler.ts` + `documentation.ts` (revive-or-delete)** — `risk: low` `gates: optional`
+  - **Action:** make the 2 `needs-human` calls the harness surfaced. `gdpr-handler` is a REVIVE cluster (compliance) — likely keep + wire, not delete. `documentation` — confirm parked-scaffold vs abandoned.
+  - **Kills claim:** stops these from re-tripping the sweep nightly.
+  - **Verify:** a written verdict per file + (if revive) a one-line spec for wiring, (if delete) zero importers.
+
+- **R1.3 Reconcile the 4 stale in-flight PRs** — `risk: low→medium` `gates: recommended for #352/#349`
+  - **Action:** the feature work that predates this session is diverging from `main`. Rebase **#352** (moat #7 schema, +753) and **#349** (activity event-sourcing, +498) onto current `main` and resolve conflicts; merge the docs **#337** (state-of-app + CI-gates-required) and **#351** (drift cleanup).
+  - **Kills claim (Band 3):** #337/#351 are the honesty-debt fix — they make the docs/CLAUDE.md match reality (and #337 makes CI gates *required*, a real de-risk).
+  - **Verify:** each rebased PR green on current main; no regressions vs the just-merged health work.
+
+- **R1.4 Frontend orphan audit** — `risk: low` `gates: optional` (issue #104)
+  - **Action:** the frontend has a parallel unmeasured orphan tree (the #308 numbers are backend-reliable only). Run `knip`/`ts-prune` to measure before any deletion.
+  - **Verify:** a reliable frontend orphan inventory (measure-only; no deletes this pass).
+
+### Then — Moat Deepening [Band 2]
+
+- **R2.1 Structured investment-thesis → matching/notify (moat #7)** — `risk: medium` `gates: recommended`
+  - **Extends:** the cross-role NDA-intent graph — the named monetization foundation. PR **#352** builds the structured `investor_thesis` schema (was free-text `users.bio`).
+  - **Compounds because:** once investor intent is a structured, queryable record, it powers **matching** (genre/format/stage) and **proactive notify** to creators — the demand→supply loop that makes the marketplace liquid. This is the highest-compounding item: every other moat feature (deal-servicing) sits on top of queryable intent.
+  - **Named gap closed:** investor intent is currently unqueryable text; phase-2 (public thesis rendering + matching/notify) is the unlock.
+  - **Verify:** an investor thesis persists structured; a matching query returns relevant creators; a creator gets notified on a thesis match (and that notification actually delivers — depends on R0.2).
+
+- **R2.2 Activity-feed event-sourcing** — `risk: medium` `gates: recommended` (PR #349)
+  - **Extends:** the engagement/demand-supply loop — `activity_feed` only recorded `pitch_published`; #349 instruments all 8 engagement events so the feed reflects real activity.
+  - **Compounds because:** a live feed drives retention + the producer→writer acquisition loop (per `project_acquisition_loop`).
+  - **Verify:** saves/comments/deals/NDA events appear in the feed; the creator `/api/creator/activities` UNION stays fresh.
+
+- **R2.3 Deal-servicing roadmap (post-#7)** — `risk: medium` `gates: recommended`
+  - **Extends:** the moat from listing/intro toward deal-servicing (escrow/contracts are currently orphan; no take-rate). Per `project_moat_inventory`, this is the **next strategic build after #7 lands** — scope it, don't start it before R2.1.
+
+## Sequencing Rationale
+**R0.1 leads** because a recurring *total* outage on a pre-launch product is the only thing here that can kill the launch outright — and its durable fix is a decision (plan), not code, so it should be raised immediately even while engineering continues elsewhere. **R0.2 is second** because it's a live, user-facing silent failure on the exact loop (notifications) the moat depends on — but it requires a liveness check first, so it's a focused investigation, not a blind fix. **R1.1 jumps ahead of most things** because it's nearly free (the harness already drafted the gated prompt) and clears dead weight that pollutes every future audit. **R1.3 (rebase the stale PRs) is the unblock** — it's the friction point between everything just merged and everything queued; #352 in particular *is* the Band-2 moat item, so reconciling it is the prerequisite to R2.1. **R2.1 starts in parallel once Band 0 is in flight** — moat work is long and shouldn't wait behind cleanup; it's the highest-compounding item and everything strategic (R2.3) sits on it. Band 3 (docs honesty) rides on R1.3 rather than standing alone.
+
+## Risk Register (for downstream gating)
+
+| ID | Title | Band | risk | gates | error-handling-adjacent? |
+|----|-------|------|------|-------|--------------------------|
+| R0.1 | Neon compute-quota prod-outage | 0 | critical | required | **yes** (DB path, health, swallowed 402s) |
+| R0.2 | Notification category filter drops messages | 0 | high | required | **yes** (DB reads + notification delivery) |
+| R1.1 | Delete 15 confirmed-orphan files | 1 | low | optional | no |
+| R1.2 | gdpr-handler / documentation revive-or-delete | 1 | low | optional | **yes** (gdpr = compliance/data path, if revived) |
+| R1.3 | Rebase 4 stale PRs (#352/#349/#337/#351) | 1 | low→med | recommended | **yes** (#352 schema, #349 event writes) |
+| R1.4 | Frontend orphan audit (#104) | 1 | low | optional | no |
+| R2.1 | Structured thesis → matching/notify (moat #7) | 2 | medium | recommended | **yes** (schema + notify writes) |
+| R2.2 | Activity-feed event-sourcing (#349) | 2 | medium | recommended | **yes** (engagement event writes) |
+| R2.3 | Deal-servicing roadmap (scope) | 2 | medium | recommended | n/a (scope only) |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -182,6 +182,7 @@ const AdminDashboard = lazyRetry(() => import('@portals/admin/pages/AdminDashboa
 const UserManagement = lazyRetry(() => import('@portals/admin/pages/UserManagement'));
 const ContentModeration = lazyRetry(() => import('@portals/admin/pages/ContentModeration'));
 const AdminAnalytics = lazyRetry(() => import('@portals/admin/pages/AdminAnalytics'));
+const AdminLiquidity = lazyRetry(() => import('@portals/admin/pages/AdminLiquidity'));
 const AdminSystemHealth = lazyRetry(() => import('@portals/admin/pages/AdminSystemHealth'));
 const AdminAuditLog = lazyRetry(() => import('@portals/admin/pages/AdminAuditLog'));
 const AdminGDPR = lazyRetry(() => import('@portals/admin/pages/AdminGDPR'));
@@ -655,6 +656,11 @@ function App() {
             <Route path="analytics" element={
               <PermissionRoute requires={Permission.ADMIN_ACCESS} redirectTo="/login">
                 <AdminAnalytics />
+              </PermissionRoute>
+            } />
+            <Route path="liquidity" element={
+              <PermissionRoute requires={Permission.ADMIN_ACCESS} redirectTo="/login">
+                <AdminLiquidity />
               </PermissionRoute>
             } />
             <Route path="system-health" element={

--- a/frontend/src/config/navigation.routes.ts
+++ b/frontend/src/config/navigation.routes.ts
@@ -206,6 +206,7 @@ export const WATCHER_ROUTES = {
 export const ADMIN_ROUTES = {
   dashboard: '/admin/dashboard',
   analytics: '/admin/analytics',
+  liquidity: '/admin/liquidity',
   systemHealth: '/admin/system-health',
   users: '/admin/users',
   content: '/admin/content',

--- a/frontend/src/portals/admin/pages/AdminLiquidity.tsx
+++ b/frontend/src/portals/admin/pages/AdminLiquidity.tsx
@@ -1,0 +1,193 @@
+import React, { useState, useEffect } from 'react';
+import { Gauge, Users, FileSignature, ArrowUpRight, CheckCircle2, XCircle, AlertTriangle } from 'lucide-react';
+import { adminService } from '../services/admin.service';
+
+// Liquidity Gate — the pre-build trigger for the deal-servicing roadmap (R2.3).
+// Reads four signals off live tables. Thresholds are DRAFT (advisory, tune with Karl);
+// the gate verdict is a recommendation of WHEN to start the P5 deal-servicing build,
+// NOT a decision. See docs/deal-servicing-roadmap-2026-06-27.md §5.
+
+interface BuyersSignal { currentWeek: number; weeks: { week: string; count: number }[]; trendNonDecreasing: boolean; threshold: number; pass: boolean }
+interface DealsSignal { currentMonth: number; months: { month: string; count: number }[]; threshold: number; pass: boolean }
+interface OffPlatformSignal { rate: number; offPlatform: number; totalCloses: number; meaningfulLeakage: boolean; threshold: number }
+interface ConfirmSignal { rate: number; confirmed: number; withOutcome: number; threshold: number; pass: boolean }
+interface LiquidityData {
+  buyersSigningNdas: BuyersSignal;
+  dealsReachingOutcome: DealsSignal;
+  offPlatformCloseRate: OffPlatformSignal;
+  mutualConfirmRate: ConfirmSignal;
+  gate: { open: boolean; thresholdsAreDraft: boolean };
+}
+
+const pct = (n: number) => `${Math.round(n * 100)}%`;
+
+function StatusPill({ ok, okLabel = 'Met', noLabel = 'Not met' }: { ok: boolean; okLabel?: string; noLabel?: string }) {
+  return ok ? (
+    <span className="inline-flex items-center gap-1 text-xs font-medium text-green-700 bg-green-50 px-2 py-0.5 rounded-full">
+      <CheckCircle2 className="w-3.5 h-3.5" /> {okLabel}
+    </span>
+  ) : (
+    <span className="inline-flex items-center gap-1 text-xs font-medium text-gray-600 bg-gray-100 px-2 py-0.5 rounded-full">
+      <XCircle className="w-3.5 h-3.5" /> {noLabel}
+    </span>
+  );
+}
+
+function SignalCard({
+  icon: Icon, title, value, sub, pill, threshold, spark,
+}: {
+  icon: React.ElementType; title: string; value: string; sub: string;
+  pill: React.ReactNode; threshold: string; spark?: { label: string; count: number }[];
+}) {
+  const max = spark && spark.length ? Math.max(...spark.map(s => s.count), 1) : 1;
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6 flex flex-col gap-3">
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-2 text-gray-500">
+          <Icon className="w-5 h-5" />
+          <span className="text-sm font-medium">{title}</span>
+        </div>
+        {pill}
+      </div>
+      <div className="text-3xl font-bold text-gray-900">{value}</div>
+      <div className="text-sm text-gray-500">{sub}</div>
+      {spark && spark.length > 0 && (
+        <div className="flex items-end gap-1 h-12 mt-1" aria-hidden>
+          {spark.map((s, i) => (
+            <div key={i} className="flex-1 bg-purple-200 rounded-sm" style={{ height: `${Math.max(6, (s.count / max) * 100)}%` }} title={`${s.label}: ${s.count}`} />
+          ))}
+        </div>
+      )}
+      <div className="text-xs text-gray-400 border-t border-gray-100 pt-2">Draft threshold: {threshold}</div>
+    </div>
+  );
+}
+
+export default function AdminLiquidity() {
+  const [data, setData] = useState<LiquidityData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    adminService.getLiquidity()
+      .then((result) => { if (!cancelled) setData(result); })
+      .catch((err) => {
+        const e = err instanceof Error ? err : new Error(String(err));
+        if (!cancelled) setError(e.message);
+      })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const Header = (
+    <div className="space-y-1">
+      <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+        <Gauge className="w-6 h-6 text-purple-600" /> Liquidity Gate
+      </h1>
+      <p className="text-sm text-gray-500 max-w-3xl">
+        The pre-build trigger for the deal-servicing roadmap (R2.3). When these signals fire, the
+        deal-servicing build (binding e-sign → escrow/payouts → take-rate) is justified. Thresholds
+        below are <span className="font-medium">draft — tune with Karl</span>; the verdict is advisory.
+      </p>
+    </div>
+  );
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        {Header}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="bg-white rounded-lg border border-gray-200 p-6 animate-pulse">
+              <div className="h-4 bg-gray-200 rounded w-1/2 mb-4" />
+              <div className="h-8 bg-gray-200 rounded w-3/4" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-6">
+        {Header}
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
+          Failed to load liquidity signals: {error}
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return <div className="space-y-6">{Header}</div>;
+
+  const { buyersSigningNdas: b, dealsReachingOutcome: d, offPlatformCloseRate: o, mutualConfirmRate: m, gate } = data;
+
+  return (
+    <div className="space-y-6">
+      {Header}
+
+      {/* Advisory gate verdict */}
+      <div className={`rounded-lg border p-5 flex items-start gap-3 ${gate.open ? 'bg-green-50 border-green-200' : 'bg-amber-50 border-amber-200'}`}>
+        {gate.open ? <CheckCircle2 className="w-6 h-6 text-green-600 mt-0.5" /> : <AlertTriangle className="w-6 h-6 text-amber-600 mt-0.5" />}
+        <div>
+          <div className={`font-semibold ${gate.open ? 'text-green-800' : 'text-amber-800'}`}>
+            Gate {gate.open ? 'OPEN — liquidity supports starting the deal-servicing build' : 'CLOSED — hold the deal-servicing build'}
+          </div>
+          <p className={`text-sm mt-1 ${gate.open ? 'text-green-700' : 'text-amber-700'}`}>
+            {gate.open
+              ? 'All four signals are met. Per the roadmap, P5.0 (binding e-sign) is the first slice. This is a recommendation — confirm with Karl before starting.'
+              : 'One or more signals are below the draft thresholds. Building deal-servicing onto sparse liquidity produces an empty, abandoned flow. Keep deepening demand first.'}
+          </p>
+          <p className="text-xs mt-2 opacity-70">Advisory only · thresholds are draft and unconfirmed.</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <SignalCard
+          icon={Users}
+          title="Buyers signing NDAs / wk"
+          value={String(b.currentWeek)}
+          sub={b.trendNonDecreasing ? 'Trend non-decreasing (8 wks)' : 'Trend not yet non-decreasing'}
+          pill={<StatusPill ok={b.pass} />}
+          threshold={`≥ ${b.threshold}/wk + rising`}
+          spark={b.weeks.map(w => ({ label: w.week, count: w.count }))}
+        />
+        <SignalCard
+          icon={FileSignature}
+          title="Deals reaching outcome / mo"
+          value={String(d.currentMonth)}
+          sub="Terminal outcome recorded (6 mo)"
+          pill={<StatusPill ok={d.pass} />}
+          threshold={`≥ ${d.threshold}/mo`}
+          spark={d.months.map(mo => ({ label: mo.month, count: mo.count }))}
+        />
+        <SignalCard
+          icon={ArrowUpRight}
+          title="Off-platform close rate"
+          value={pct(o.rate)}
+          sub={`${o.offPlatform} of ${o.totalCloses} closes off-platform`}
+          pill={<StatusPill ok={o.meaningfulLeakage} okLabel="Worth capturing" noLabel="Low leakage" />}
+          threshold={`≥ ${pct(o.threshold)} = ROI signal`}
+        />
+        <SignalCard
+          icon={CheckCircle2}
+          title="Mutual-confirm rate"
+          value={pct(m.rate)}
+          sub={`${m.confirmed} of ${m.withOutcome} outcomes co-confirmed`}
+          pill={<StatusPill ok={m.pass} />}
+          threshold={`≥ ${pct(m.threshold)}`}
+        />
+      </div>
+
+      <p className="text-xs text-gray-400">
+        The off-platform-close rate is the sharpest signal: a high rate means parties are closing the deals
+        Pitchey introduced somewhere else — exactly the leakage on-platform deal-servicing is designed to capture.
+        Source: live <code>ndas</code> + <code>production_deals</code> outcome columns (migration 114). No new schema.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/portals/admin/services/admin.service.ts
+++ b/frontend/src/portals/admin/services/admin.service.ts
@@ -334,6 +334,16 @@ class AdminService {
     return handleResponse<any>(response);
   }
 
+  // Liquidity gate — the pre-build trigger for the deal-servicing roadmap (R2.3).
+  async getLiquidity(): Promise<any> {
+    const response = await fetch(`${API_BASE_URL}/api/admin/liquidity`, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include'
+    });
+    return handleResponse<any>(response);
+  }
+
   // System Health
   async getSystemHealth(): Promise<any> {
     const response = await fetch(`${API_BASE_URL}/api/admin/system/health`, {

--- a/frontend/src/shared/components/layout/EnhancedAdminNav.tsx
+++ b/frontend/src/shared/components/layout/EnhancedAdminNav.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import {
   Home, BarChart3, Activity, Users, FileText, Shield,
   DollarSign, FileBarChart, ClipboardList, Lock, Settings,
-  BadgeCheck, Ticket
+  BadgeCheck, Ticket, Gauge
 } from 'lucide-react';
 import { ADMIN_ROUTES } from '@/config/navigation.routes';
 
@@ -25,6 +25,7 @@ export const adminNavigationSections: NavigationSection[] = [
     items: [
       { label: 'Overview', path: ADMIN_ROUTES.dashboard, icon: Home },
       { label: 'Analytics', path: ADMIN_ROUTES.analytics, icon: BarChart3 },
+      { label: 'Liquidity Gate', path: ADMIN_ROUTES.liquidity, icon: Gauge },
       { label: 'System Health', path: ADMIN_ROUTES.systemHealth, icon: Activity },
     ],
   },

--- a/src/worker-modules/admin-endpoints.ts
+++ b/src/worker-modules/admin-endpoints.ts
@@ -254,7 +254,11 @@ export class AdminEndpointsHandler {
       if (method === 'GET' && relevantPath[0] === 'analytics') {
         return await this.handleAdminAnalytics(request, corsHeaders, userAuth);
       }
-      
+
+      if (method === 'GET' && relevantPath[0] === 'liquidity') {
+        return await this.handleLiquidityGate(request, corsHeaders, userAuth);
+      }
+
       if (method === 'GET' && relevantPath[0] === 'transactions') {
         return await this.handleGetTransactions(request, corsHeaders, userAuth);
       }
@@ -1555,6 +1559,107 @@ export class AdminEndpointsHandler {
           activeUsers: Number(a.active_users || 0),
           activityGrowthRate: growth(Number(a.active_users || 0), Number(a.prev_active_users || 0))
         }
+      }, corsHeaders);
+
+    } catch (error) {
+      await this.logger.captureError(error instanceof Error ? error : new Error(String(error)));
+      return this.bareJson(empty, corsHeaders);
+    }
+  }
+
+  // Liquidity Gate — the pre-build trigger for the deal-servicing roadmap (R2.3).
+  // Reads four signals off LIVE tables (ndas, users, production_deals mig-114
+  // outcome columns) — zero new schema. The thresholds are DRAFT (advisory, to be
+  // tuned with Karl); the `gate.open` verdict is a recommendation, NOT a decision.
+  // See docs/deal-servicing-roadmap-2026-06-27.md §5. The sharpest signal is the
+  // off-platform-close rate: high = on-platform servicing would capture real leakage.
+  private async handleLiquidityGate(_request: Request, corsHeaders: Record<string, string>, _userAuth: AuthPayload): Promise<Response> {
+    // DRAFT thresholds — surfaced in the payload so the UI can label them as such.
+    const THRESHOLDS = {
+      buyersPerWeek: 5,        // ≥ N verified buyers signing NDAs / week
+      dealsPerMonth: 3,        // ≥ M deals reaching a terminal outcome / month
+      offPlatformRate: 0.25,   // ≥ X off-platform-close share = meaningful leakage to capture
+      mutualConfirmRate: 0.5,  // ≥ X both-sides-confirm = parties actually report back (P2 working)
+    };
+
+    const empty = {
+      buyersSigningNdas: { currentWeek: 0, weeks: [] as { week: string; count: number }[], trendNonDecreasing: false, threshold: THRESHOLDS.buyersPerWeek, pass: false },
+      dealsReachingOutcome: { currentMonth: 0, months: [] as { month: string; count: number }[], threshold: THRESHOLDS.dealsPerMonth, pass: false },
+      offPlatformCloseRate: { rate: 0, offPlatform: 0, totalCloses: 0, meaningfulLeakage: false, threshold: THRESHOLDS.offPlatformRate },
+      mutualConfirmRate: { rate: 0, confirmed: 0, withOutcome: 0, threshold: THRESHOLDS.mutualConfirmRate, pass: false },
+      gate: { open: false, thresholdsAreDraft: true },
+    };
+
+    try {
+      const sql = this.getSqlClient();
+      if (!sql) return this.bareJson(empty, corsHeaders);
+
+      // Signal 1 — distinct buyer-type (investor/production) NDA signers per ISO week, last 8 weeks.
+      const weekRows = await sql`
+        SELECT to_char(date_trunc('week', n.signed_at), 'YYYY-MM-DD') AS week,
+               COUNT(DISTINCT n.signer_id)::int AS count
+        FROM ndas n
+        JOIN users u ON u.id = n.signer_id
+        WHERE n.signed_at IS NOT NULL
+          AND n.signed_at >= date_trunc('week', NOW()) - INTERVAL '7 weeks'
+          AND u.user_type IN ('investor', 'production')
+        GROUP BY 1
+        ORDER BY 1 ASC
+      `;
+
+      // Signal 2 — deals reaching a terminal outcome per month, last 6 months.
+      const monthRows = await sql`
+        SELECT to_char(date_trunc('month', COALESCE(outcome_reported_at, closed_at)), 'YYYY-MM') AS month,
+               COUNT(*)::int AS count
+        FROM production_deals
+        WHERE outcome IS NOT NULL
+          AND COALESCE(outcome_reported_at, closed_at) >= date_trunc('month', NOW()) - INTERVAL '5 months'
+        GROUP BY 1
+        ORDER BY 1 ASC
+      `;
+
+      // Signals 3 & 4 — close mix + mutual-confirm, all-time over deals with an outcome.
+      const [agg] = await sql`
+        SELECT
+          COUNT(*) FILTER (WHERE outcome = 'closed_off_platform')::int AS off_platform,
+          COUNT(*) FILTER (WHERE outcome IN ('closed_on_platform', 'closed_off_platform'))::int AS total_closes,
+          COUNT(*) FILTER (WHERE outcome IS NOT NULL)::int AS with_outcome,
+          COUNT(*) FILTER (WHERE outcome IS NOT NULL AND outcome_confirmed_by_creator AND outcome_confirmed_by_production)::int AS mutually_confirmed
+        FROM production_deals
+      `;
+
+      const weeks = (weekRows || []).map((r: any) => ({ week: String(r.week), count: Number(r.count || 0) }));
+      const months = (monthRows || []).map((r: any) => ({ month: String(r.month), count: Number(r.count || 0) }));
+
+      // Current-week / current-month figures (0 if no row for the bucket).
+      const currentWeekKey = weeks.length ? weeks[weeks.length - 1].week : '';
+      const currentWeek = weeks.find(w => w.week === currentWeekKey)?.count ?? 0;
+      const currentMonth = months.length ? months[months.length - 1].count : 0;
+
+      // Trend: non-decreasing across the observed weekly buckets (need ≥2 to judge).
+      const trendNonDecreasing = weeks.length >= 2 && weeks.every((w, i) => i === 0 || w.count >= weeks[i - 1].count);
+
+      const a: any = agg || {};
+      const offPlatform = Number(a.off_platform || 0);
+      const totalCloses = Number(a.total_closes || 0);
+      const withOutcome = Number(a.with_outcome || 0);
+      const mutuallyConfirmed = Number(a.mutually_confirmed || 0);
+      const offRate = totalCloses > 0 ? offPlatform / totalCloses : 0;
+      const confirmRate = withOutcome > 0 ? mutuallyConfirmed / withOutcome : 0;
+
+      const s1Pass = currentWeek >= THRESHOLDS.buyersPerWeek && trendNonDecreasing;
+      const s2Pass = currentMonth >= THRESHOLDS.dealsPerMonth;
+      const s3Leak = offRate >= THRESHOLDS.offPlatformRate;
+      const s4Pass = confirmRate >= THRESHOLDS.mutualConfirmRate;
+
+      return this.bareJson({
+        buyersSigningNdas: { currentWeek, weeks, trendNonDecreasing, threshold: THRESHOLDS.buyersPerWeek, pass: s1Pass },
+        dealsReachingOutcome: { currentMonth, months, threshold: THRESHOLDS.dealsPerMonth, pass: s2Pass },
+        offPlatformCloseRate: { rate: offRate, offPlatform, totalCloses, meaningfulLeakage: s3Leak, threshold: THRESHOLDS.offPlatformRate },
+        mutualConfirmRate: { rate: confirmRate, confirmed: mutuallyConfirmed, withOutcome, threshold: THRESHOLDS.mutualConfirmRate, pass: s4Pass },
+        // Advisory verdict: liquidity is real AND deals close AND the leak is worth
+        // capturing AND both sides report back. All four together = start P5.0.
+        gate: { open: s1Pass && s2Pass && s3Leak && s4Pass, thresholdsAreDraft: true },
       }, corsHeaders);
 
     } catch (error) {


### PR DESCRIPTION
## What

Scopes the deal-servicing build (R2.3) and ships the one piece of pre-gate code worth writing now: an admin **Liquidity Gate** tile that measures when the build is justified.

Per `project_moat_inventory`'s governing lens (disintermediation), deal-servicing is **liquidity-gated** and must NOT start pre-launch. Verified against live code: P1–P3 deal-servicing already ships (record / inbox / outcome / reputation / `deal_messages`); `escrow_accounts` (mig 003) + `contracts`/`contract_signatures` (mig 004) are schema-only orphans with zero handlers; no Stripe Connect.

## Changes

- **`docs/deal-servicing-roadmap-2026-06-27.md`** — scopes P5 (binding e-sign reusing the NDA sign engine → Connect onboarding → milestone option payment + first take-rate → full payouts), explicit non-goals, and a measurable liquidity trigger.
- **Liquidity Gate tile** — `GET /api/admin/liquidity` (`handleLiquidityGate`, admin-intercepted dispatch case — no route-register / no `/api/admin/*` exclusion trap). Reads 4 signals off live `ndas` + `production_deals` (mig 114): buyers signing NDAs/wk, deals reaching outcome/mo, **off-platform-close rate** (sharpest ROI signal), mutual-confirm rate. Draft thresholds drive an **advisory** gate verdict (tune with Karl — not a decision).
- Frontend: `AdminLiquidity.tsx` page + "Liquidity Gate" admin nav + `/admin/liquidity` route + `adminService.getLiquidity()`.
- Carries `docs/evolution-roadmap-2026-06-26.md` (the audit basis the roadmap references; absent on main).

## Verification

- Worker `tsc` **0 errors**, frontend type-check clean, worker bundles.
- All 3 signal queries run **read-only against live prod** — zero schema drift. Real data (~1 buyer/wk, 0 closed deals) → gate correctly renders **CLOSED**. The instrument tells the truth about pre-launch sparsity rather than faking readiness.

Zero new schema. Read-only admin surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)