### PR TITLE
fix(R0.1): surface backend outages as degraded, not a silently-empty marketplace

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { GlobalErrorBoundary } from '@shared/components/feedback/ConsoleErrorBou
 import { Toaster } from 'react-hot-toast';
 import ToastProvider from '@shared/components/feedback/ToastProvider';
 import { NotificationToastProvider } from '@shared/components/feedback/NotificationToastContainer';
+import { ServiceDegradedBanner } from '@shared/components/feedback/ServiceDegradedBanner';
 import LogoSplash from '@/components/LogoSplash';
 // Import safe context provider (without legacy AuthProvider)
 import { AppContextProviderSafe } from '@shared/contexts/AppContextProviderSafe';
@@ -408,6 +409,9 @@ function App() {
                 billing, slates, opportunities all "saved" with zero visible feedback). */}
             <Toaster position="top-right" toastOptions={{ duration: 4000 }} />
             <Router>
+              {/* App-wide degraded banner (R0.1) — shows on any 5xx, so a Neon outage
+                  reads as "temporarily unavailable" instead of a silently-empty marketplace. */}
+              <ServiceDegradedBanner />
               <Suspense fallback={<LogoSplash message="Optimizing your experience…" />}>
                 <Routes>
           {/* Homepage - Only render on exact path match */}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -6,6 +6,7 @@
 
 import { sessionCache } from '../store/sessionCache';
 import { sessionManager } from './session-manager';
+import { useServiceStatusStore } from '../store/serviceStatusStore';
 import type { 
   ApiResponse, 
   Pitch, 
@@ -173,7 +174,14 @@ class ApiClient {
 
       
       const response = await fetch(url, fetchOptions);
-      
+
+      // Global degraded signal (R0.1): a 5xx (e.g. the public pitch endpoints now
+      // return 503 on a Neon compute-quota 402 instead of a fake-empty 200) flips the
+      // app-wide banner; any non-5xx response clears it. Self-healing, guarded in-store.
+      if (response) {
+        useServiceStatusStore.getState().setDegraded(response.status >= 500);
+      }
+
       // Add null checking for response
       if (!response) {
         console.error('Fetch returned null response');

--- a/frontend/src/shared/components/feedback/ServiceDegradedBanner.tsx
+++ b/frontend/src/shared/components/feedback/ServiceDegradedBanner.tsx
@@ -1,0 +1,29 @@
+import { AlertTriangle } from 'lucide-react';
+import { useServiceStatusStore } from '../../../store/serviceStatusStore';
+
+// App-wide degraded banner (R0.1). Shows when any API request returns a 5xx —
+// e.g. a Neon compute-quota 402 now surfaces as a 503 from the public pitch
+// endpoints, so an outage reads as "temporarily unavailable" here instead of as a
+// silently-empty marketplace. Auto-hides on the next successful (non-5xx) response.
+export function ServiceDegradedBanner() {
+  const degraded = useServiceStatusStore((s) => s.degraded);
+  if (!degraded) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed top-0 inset-x-0 z-[1000] bg-amber-500 text-white shadow-md"
+    >
+      <div className="max-w-7xl mx-auto px-4 py-2 flex items-center justify-center gap-2 text-center text-sm font-medium">
+        <AlertTriangle className="w-4 h-4 shrink-0" aria-hidden />
+        <span>
+          We&rsquo;re having trouble reaching our servers. Some content may be temporarily
+          unavailable &mdash; please try again shortly.
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default ServiceDegradedBanner;

--- a/frontend/src/shared/components/feedback/__tests__/ServiceDegradedBanner.test.tsx
+++ b/frontend/src/shared/components/feedback/__tests__/ServiceDegradedBanner.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ServiceDegradedBanner } from '../ServiceDegradedBanner';
+import { useServiceStatusStore } from '../../../../store/serviceStatusStore';
+
+describe('ServiceDegradedBanner (R0.1)', () => {
+  beforeEach(() => {
+    useServiceStatusStore.setState({ degraded: false });
+  });
+
+  it('renders nothing when the service is healthy', () => {
+    const { container } = render(<ServiceDegradedBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the degraded message when degraded', () => {
+    useServiceStatusStore.setState({ degraded: true });
+    render(<ServiceDegradedBanner />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByText(/temporarily\s+unavailable/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/store/__tests__/serviceStatusStore.test.ts
+++ b/frontend/src/store/__tests__/serviceStatusStore.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useServiceStatusStore } from '../serviceStatusStore';
+
+describe('serviceStatusStore (R0.1 degraded signal)', () => {
+  beforeEach(() => {
+    useServiceStatusStore.setState({ degraded: false });
+  });
+
+  it('defaults to not degraded', () => {
+    expect(useServiceStatusStore.getState().degraded).toBe(false);
+  });
+
+  it('flips to degraded on a 5xx signal', () => {
+    useServiceStatusStore.getState().setDegraded(true);
+    expect(useServiceStatusStore.getState().degraded).toBe(true);
+  });
+
+  it('clears on the next healthy response', () => {
+    useServiceStatusStore.getState().setDegraded(true);
+    useServiceStatusStore.getState().setDegraded(false);
+    expect(useServiceStatusStore.getState().degraded).toBe(false);
+  });
+
+  it('is a no-op when the value is unchanged (guarded — no needless churn)', () => {
+    const before = useServiceStatusStore.getState();
+    before.setDegraded(false); // already false
+    // Same state object reference proves set() was not called.
+    expect(useServiceStatusStore.getState()).toBe(before);
+  });
+});

--- a/frontend/src/store/serviceStatusStore.ts
+++ b/frontend/src/store/serviceStatusStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+
+// Global "is the backend degraded" signal (R0.1).
+//
+// Set by the api-client when a request returns a 5xx (e.g. a Neon compute-quota
+// 402 now surfaces as a 503 from the public pitch endpoints instead of a fake-empty
+// 200), and cleared on the next successful response. A single <ServiceDegradedBanner>
+// subscribes to this so an outage reads as "temporarily unavailable" app-wide rather
+// than rendering as a silently-empty marketplace.
+
+interface ServiceStatusState {
+  degraded: boolean;
+  setDegraded: (degraded: boolean) => void;
+}
+
+export const useServiceStatusStore = create<ServiceStatusState>((set, get) => ({
+  degraded: false,
+  // Guard so a 2xx on every request doesn't churn subscribers when nothing changed.
+  setDegraded: (degraded: boolean) => {
+    if (get().degraded !== degraded) set({ degraded });
+  },
+}));

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -9560,15 +9560,9 @@ pitchey_analytics_datapoints_per_minute 1250
 
     } catch (error) {
       console.error('Error in browsePitches:', error);
-      return builder.success({
-        success: true,
-        items: [],
-        tab: tab,
-        total: 0,
-        page: page,
-        limit: limit,
-        hasMore: false
-      });
+      // Surface failures as 503 instead of a fake-empty 200 (R0.1 — silent-empty
+      // marketplace). A Neon 402 here must read as "degraded", not "no pitches".
+      return builder.error(ErrorCode.SERVICE_UNAVAILABLE, 'Pitches are temporarily unavailable');
     }
   }
 
@@ -12413,8 +12407,10 @@ pitchey_analytics_datapoints_per_minute 1250
     } catch (error) {
       console.error('[DEBUG] Error in getPublicPitches:', error);
       console.error('[DEBUG] Error stack:', error instanceof Error ? error.stack : 'unknown');
-      // Return empty array on error to prevent frontend crash
-      return builder.success([]);
+      // Surface DB/upstream failures as 503 — NOT an empty 200. A swallowed error here
+      // (e.g. a Neon compute-quota 402) rendered the marketplace as silently empty,
+      // indistinguishable from "no pitches" (R0.1). Let the client show a degraded state.
+      return builder.error(ErrorCode.SERVICE_UNAVAILABLE, 'Pitches are temporarily unavailable');
     }
   }
 


### PR DESCRIPTION
## Problem

A Neon compute-quota **402** (which took prod down 2026-04-30 #65 and 2026-06-22) rendered the marketplace as **"No pitches found"** — indistinguishable from a genuinely empty catalog — so an outage read as "broken/empty" instead of "degraded." This is Band-0 item **R0.1** from the evolution roadmap.

## Root cause — two swallows in series

1. **Backend:** `getPublicPitches` (`/api/pitches/public`) and `browsePitches` (`/api/browse`) caught *any* error (incl. a 402) and returned `builder.success([])` / `success({items:[]})` — a **200 with an empty list**.
2. **Frontend:** nothing distinguished "empty" from "down"; the marketplace's existing error+Retry UI never fired because it never saw an error.

## Fix

- **Backend:** both catch blocks now return **503** (`ErrorCode.SERVICE_UNAVAILABLE`) instead of a fake-empty 200 — consistent with the sibling public endpoints (`trending`/`new`/`featured`/`search`), which already 503/500 on error.
- **Frontend (global, not per-page):** a tiny `serviceStatusStore` degraded flag that the **api-client** flips on any 5xx and clears on the next non-5xx response (guarded, self-healing); one app-wide **`<ServiceDegradedBanner>`** renders "temporarily unavailable." Covers every page and future endpoints with no per-page refactor.

Satisfies the R0.1 verify criterion: a forced 402 surfaces as an explicit degraded state in `/api/health` (already `degraded` on DB error) **+ UI**, not an empty marketplace.

## Scope note

This is the **code-hardening** half of R0.1. The durable fix for the recurring outage is a **Neon plan/billing decision** (out of scope here, for Karl) — see `reference_neon_compute_quota`. This PR ensures that when it *does* recur, it reads as degraded, not broken.

## Verification

- Worker `tsc` **0 errors**, bundles, catch-swallow gate **0 untagged**.
- Frontend type-check clean; **32** existing browse/api tests pass + **6 new** store/banner tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)