### PR TITLE
feat(moat): binding deal-sheet e-signature (deal-servicing P5.0)

### DIFF
--- a/frontend/src/components/dashboard/CreatorDealInbox.tsx
+++ b/frontend/src/components/dashboard/CreatorDealInbox.tsx
@@ -3,6 +3,7 @@ import { Handshake, Check, X, Reply, Flag, CheckCircle2, MessageSquare } from 'l
 import apiClient from '../../lib/api-client';
 import { formatNumber } from '@shared/utils/formatters';
 import DealThread from '../deals/DealThread';
+import DealSignPanel from '../deals/DealSignPanel';
 
 // Creator Deal Inbox (moat #6) — production deals proposed to the creator, with
 // accept / counter / reject. Self-contained; renders null when there are no deals
@@ -318,6 +319,7 @@ export default function CreatorDealInbox() {
                   <MessageSquare className="w-4 h-4" /> {threadFor === d.id ? 'Hide discussion' : 'Discuss'}
                 </button>
                 {threadFor === d.id && <DealThread dealId={d.id} />}
+                {threadFor === d.id && <DealSignPanel dealId={d.id} />}
               </div>
             </li>
           );

--- a/frontend/src/components/deals/DealSignPanel.tsx
+++ b/frontend/src/components/deals/DealSignPanel.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Loader2, ShieldCheck, PenLine, AlertTriangle } from 'lucide-react';
+import apiClient from '../../lib/api-client';
+
+// Binding deal-sheet e-signature (deal-servicing P5.0). Deal-scoped, role-neutral —
+// shared by the creator deal inbox and the production deals page, mounted next to
+// DealThread. A co-signed, hash-sealed deal sheet living on Pitchey is the cheapest
+// real on-platform lock-in: no payments, no take-rate — just switching cost.
+
+interface DealSignature {
+  party: 'creator' | 'production';
+  signedName: string;
+  signedAt: string;
+  contentHash: string;
+  matchesCurrent: boolean;
+}
+
+interface SignatureState {
+  dealId: number;
+  currentHash: string;
+  algorithm: string;
+  fullyExecuted: boolean;
+  hasStaleSignature: boolean;
+  viewerParty: 'creator' | 'production';
+  viewerSigned: boolean;
+  signatures: DealSignature[];
+}
+
+const PARTY_LABEL: Record<string, string> = { creator: 'Creator', production: 'Production' };
+const shortHash = (h: string) => (h ? `${h.slice(0, 8)}…${h.slice(-6)}` : '');
+
+export default function DealSignPanel({ dealId }: { dealId: number }) {
+  const [state, setState] = useState<SignatureState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [fullName, setFullName] = useState('');
+  const [agreed, setAgreed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await apiClient.get<SignatureState>(`/api/deals/${dealId}/signatures`);
+      setState(res?.success && res.data ? res.data : null);
+    } catch {
+      setState(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [dealId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const sign = useCallback(async () => {
+    if (!fullName.trim() || !agreed) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await apiClient.post<{ fullyExecuted: boolean }>(
+        `/api/deals/${dealId}/sign`,
+        { fullName: fullName.trim(), agreed: true },
+      );
+      if (!res?.success) {
+        const msg = typeof res?.error === 'string' ? res.error : (res?.error as { message?: string } | undefined)?.message;
+        setError(msg || 'Could not sign the deal sheet. Please try again.');
+        return;
+      }
+      setFullName('');
+      setAgreed(false);
+      await load();
+    } catch {
+      setError('Could not sign the deal sheet. Please try again.');
+    } finally {
+      setBusy(false);
+    }
+  }, [dealId, fullName, agreed, load]);
+
+  if (loading) {
+    return (
+      <div className="mt-3 flex items-center gap-2 text-xs text-gray-400 py-2">
+        <Loader2 className="w-3.5 h-3.5 animate-spin" /> Loading deal sheet…
+      </div>
+    );
+  }
+  if (!state) return null;
+
+  const signedParties = new Set(state.signatures.filter(s => s.matchesCurrent).map(s => s.party));
+
+  return (
+    <div className="mt-3 rounded-lg border border-gray-200 bg-white p-3">
+      {/* Header — seal status */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <ShieldCheck className={`w-4 h-4 ${state.fullyExecuted ? 'text-green-600' : 'text-gray-400'}`} />
+          <span className="text-sm font-medium text-gray-800">Binding deal sheet</span>
+          {state.fullyExecuted ? (
+            <span className="text-[10px] font-semibold rounded-full px-2 py-0.5 bg-green-100 text-green-700">
+              Fully executed
+            </span>
+          ) : (
+            <span className="text-[10px] font-medium rounded-full px-2 py-0.5 bg-amber-100 text-amber-700">
+              Awaiting signatures
+            </span>
+          )}
+        </div>
+        {state.currentHash && (
+          <span className="font-mono text-[10px] text-gray-400" title={`${state.algorithm}: ${state.currentHash}`}>
+            seal {shortHash(state.currentHash)}
+          </span>
+        )}
+      </div>
+
+      {/* Tamper warning */}
+      {state.hasStaleSignature && (
+        <div className="mt-2 flex items-start gap-2 rounded-md bg-amber-50 border border-amber-200 p-2">
+          <AlertTriangle className="w-3.5 h-3.5 text-amber-600 mt-0.5 shrink-0" />
+          <p className="text-xs text-amber-800">
+            A deal term changed after a party signed. Earlier signatures no longer match the current
+            sheet and are shown as stale — re-sign to bind the updated terms.
+          </p>
+        </div>
+      )}
+
+      {/* Both-party signature status */}
+      <ul className="mt-3 space-y-1.5">
+        {(['creator', 'production'] as const).map((party) => {
+          const sig = state.signatures.find(s => s.party === party);
+          const current = signedParties.has(party);
+          return (
+            <li key={party} className="flex items-center justify-between text-sm">
+              <span className="text-gray-600">{PARTY_LABEL[party]}</span>
+              {sig ? (
+                <span className={`text-xs ${current ? 'text-green-700' : 'text-amber-700'}`}>
+                  {current ? 'Signed' : 'Signed (stale)'} · {sig.signedName}
+                  <span className="text-gray-400"> · {new Date(sig.signedAt).toLocaleDateString()}</span>
+                </span>
+              ) : (
+                <span className="text-xs text-gray-400">Not signed</span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+
+      {/* Sign action — only the viewer's own side, only if they haven't signed the current sheet */}
+      {state.viewerSigned ? (
+        <p className="mt-3 flex items-center gap-1.5 text-xs text-green-700">
+          <ShieldCheck className="w-3.5 h-3.5" /> You signed this version as {PARTY_LABEL[state.viewerParty]}.
+        </p>
+      ) : (
+        <div className="mt-3 border-t border-gray-100 pt-3">
+          <label className="block text-xs text-gray-500 mb-1" htmlFor={`sign-name-${dealId}`}>
+            Type your full legal name to sign as {PARTY_LABEL[state.viewerParty]}
+          </label>
+          <input
+            id={`sign-name-${dealId}`}
+            type="text"
+            value={fullName}
+            onChange={(e) => setFullName(e.target.value)}
+            className="w-full border border-gray-200 rounded-lg px-2 py-1.5 text-sm"
+            placeholder="Full legal name"
+          />
+          <label className="mt-2 flex items-start gap-2 text-xs text-gray-600">
+            <input
+              type="checkbox"
+              checked={agreed}
+              onChange={(e) => setAgreed(e.target.checked)}
+              className="mt-0.5"
+            />
+            <span>
+              I agree to the deal terms shown above. My typed name is my electronic signature and
+              binds the same as a handwritten one; this signature seals the current terms.
+            </span>
+          </label>
+          {error && <p className="mt-2 text-xs text-red-600">{error}</p>}
+          <button
+            type="button"
+            disabled={busy || !fullName.trim() || !agreed}
+            onClick={() => void sign()}
+            className="mt-2 inline-flex items-center gap-1.5 bg-purple-600 hover:bg-purple-700 disabled:opacity-50 text-white text-sm font-medium rounded-lg px-3 py-1.5"
+          >
+            {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <PenLine className="w-4 h-4" />}
+            Sign deal sheet
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/deals/__tests__/DealSignPanel.test.tsx
+++ b/frontend/src/components/deals/__tests__/DealSignPanel.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+vi.mock('../../../lib/api-client', () => ({
+  default: { get: (...a: unknown[]) => mockGet(...a), post: (...a: unknown[]) => mockPost(...a) },
+}));
+
+import DealSignPanel from '../DealSignPanel';
+
+const state = (over: Record<string, unknown> = {}) => ({
+  success: true,
+  data: {
+    dealId: 7,
+    currentHash: 'a'.repeat(64),
+    algorithm: 'sha256',
+    fullyExecuted: false,
+    hasStaleSignature: false,
+    viewerParty: 'creator',
+    viewerSigned: false,
+    signatures: [],
+    ...over,
+  },
+});
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockPost.mockReset();
+  mockPost.mockResolvedValue({ success: true, data: { fullyExecuted: false } });
+});
+
+describe('DealSignPanel', () => {
+  it('loads signature state for the deal', async () => {
+    mockGet.mockResolvedValue(state());
+    render(<DealSignPanel dealId={7} />);
+    await waitFor(() => expect(mockGet).toHaveBeenCalledWith('/api/deals/7/signatures'));
+    expect(screen.getByText('Binding deal sheet')).toBeInTheDocument();
+    expect(screen.getByText('Awaiting signatures')).toBeInTheDocument();
+  });
+
+  it('shows the fully-executed badge when both parties have signed the current sheet', async () => {
+    mockGet.mockResolvedValue(state({
+      fullyExecuted: true,
+      viewerSigned: true,
+      signatures: [
+        { party: 'creator', signedName: 'Alex', signedAt: '2026-06-27T00:00:00Z', contentHash: 'a'.repeat(64), matchesCurrent: true },
+        { party: 'production', signedName: 'Stellar', signedAt: '2026-06-27T00:00:00Z', contentHash: 'a'.repeat(64), matchesCurrent: true },
+      ],
+    }));
+    render(<DealSignPanel dealId={7} />);
+    await waitFor(() => expect(screen.getByText('Fully executed')).toBeInTheDocument());
+    expect(screen.getByText(/You signed this version/)).toBeInTheDocument();
+  });
+
+  it('surfaces a tamper warning when a signature is stale', async () => {
+    mockGet.mockResolvedValue(state({
+      hasStaleSignature: true,
+      signatures: [
+        { party: 'production', signedName: 'Stellar', signedAt: '2026-06-27T00:00:00Z', contentHash: 'b'.repeat(64), matchesCurrent: false },
+      ],
+    }));
+    render(<DealSignPanel dealId={7} />);
+    await waitFor(() => expect(screen.getByText(/A deal term changed after a party signed/)).toBeInTheDocument());
+    expect(screen.getByText(/Signed \(stale\)/)).toBeInTheDocument();
+  });
+
+  it('requires a typed name and agreement before the sign button is enabled', async () => {
+    mockGet.mockResolvedValue(state());
+    render(<DealSignPanel dealId={7} />);
+    await waitFor(() => screen.getByText('Sign deal sheet'));
+    const btn = screen.getByRole('button', { name: /Sign deal sheet/ });
+    expect(btn).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText('Full legal name'), { target: { value: 'Alex Creator' } });
+    expect(btn).toBeDisabled(); // still need agreement
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(btn).toBeEnabled();
+  });
+
+  it('posts the signature and reloads on sign', async () => {
+    mockGet.mockResolvedValue(state());
+    render(<DealSignPanel dealId={7} />);
+    await waitFor(() => screen.getByText('Sign deal sheet'));
+
+    fireEvent.change(screen.getByPlaceholderText('Full legal name'), { target: { value: 'Alex Creator' } });
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByRole('button', { name: /Sign deal sheet/ }));
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith(
+      '/api/deals/7/sign',
+      { fullName: 'Alex Creator', agreed: true },
+    ));
+    // reload after a successful sign
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2));
+  });
+});

--- a/frontend/src/portals/production/pages/ProductionDeals.tsx
+++ b/frontend/src/portals/production/pages/ProductionDeals.tsx
@@ -4,6 +4,7 @@ import apiClient from '@/lib/api-client';
 import { ProductionService } from '../services/production.service';
 import { formatNumber } from '@shared/utils/formatters';
 import DealThread from '@/components/deals/DealThread';
+import DealSignPanel from '@/components/deals/DealSignPanel';
 
 // Production Deals page (disintermediation defense P1 — deal system-of-record).
 // The producer's view of deals they've proposed, with the both-sided "mark outcome"
@@ -253,6 +254,7 @@ export default function ProductionDeals() {
                     <MessageSquare className="w-4 h-4" /> {threadFor === d.id ? 'Hide discussion' : 'Discuss'}
                   </button>
                   {threadFor === d.id && <DealThread dealId={d.id} />}
+                  {threadFor === d.id && <DealSignPanel dealId={d.id} />}
                 </div>
               </li>
             );

--- a/src/db/migrations/117_deal_signatures.sql
+++ b/src/db/migrations/117_deal_signatures.sql
@@ -1,0 +1,45 @@
+-- 117_deal_signatures.sql
+--
+-- P5.0 (deal-servicing roadmap): promote the deal-sheet from a rendered VIEW
+-- (getProductionContract) into a BINDING, hash-sealed, co-signed instrument.
+--
+-- This is the cheapest real on-platform lock-in: no payments, no Stripe Connect,
+-- no take-rate, no PCI surface. A co-signed, content-hash-sealed deal sheet that
+-- lives on Pitchey is a reason for both parties to transact on-platform rather
+-- than just record (P1) that they transacted elsewhere.
+--
+-- Reuses the proven primitives:
+--   * the Standard-NDA click-to-sign engine (signNDA) — typed name + agree + audit
+--   * the provenance SHA-256 seal (sha256Hex / crypto.subtle) — content_hash pins
+--     EXACTLY the deal terms a party agreed to, so a later mutation is detectable.
+--
+-- Keyed to the LIVE `production_deals` spine — NOT the orphan `contract_signatures`
+-- schema (migration 004, never wired). Additive only.
+--
+-- One signature per (deal, signer). `party` records which side signed so the
+-- "fully executed" check is "both creator AND production have a row". `content_hash`
+-- is the seal of the canonical deal sheet at the moment of signing; the read path
+-- compares it to the live sheet's hash to surface tampering (a term changed after
+-- one party signed).
+
+CREATE TABLE IF NOT EXISTS deal_signatures (
+  id              SERIAL PRIMARY KEY,
+  deal_id         INTEGER NOT NULL REFERENCES production_deals(id) ON DELETE CASCADE,
+  signer_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  party           VARCHAR(20) NOT NULL CHECK (party IN ('creator', 'production')),
+  status          VARCHAR(20) NOT NULL DEFAULT 'signed'
+                    CHECK (status IN ('signed', 'revoked')),
+  content_hash    VARCHAR(64) NOT NULL,      -- sha256 of the canonical deal sheet at signing
+  algorithm       VARCHAR(20) NOT NULL DEFAULT 'sha256',
+  signed_name     TEXT NOT NULL,             -- typed full legal name
+  signed_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  ip_address      INET,
+  user_agent      TEXT,
+  signature_data  JSONB,                     -- {agreed:true, title, ...} — the click-to-sign payload
+  revoked_at      TIMESTAMPTZ,
+  UNIQUE (deal_id, signer_id)
+);
+
+-- Fast "is this deal fully executed / who has signed" lookup.
+CREATE INDEX IF NOT EXISTS idx_deal_signatures_deal
+  ON deal_signatures (deal_id, status);

--- a/src/handlers/deal-signing.ts
+++ b/src/handlers/deal-signing.ts
@@ -1,0 +1,221 @@
+/**
+ * Deal-sheet e-signature — P5.0 of the deal-servicing roadmap.
+ *
+ * Promotes the deal sheet (getProductionContract) from a rendered VIEW into a
+ * BINDING, hash-sealed, co-signed instrument. This is the cheapest real on-platform
+ * lock-in: NO payments, NO Stripe Connect, NO take-rate, NO PCI surface. A co-signed,
+ * content-hash-sealed deal sheet living on Pitchey is a switching cost — a reason to
+ * transact on-platform rather than just record (P1) a deal that happened elsewhere.
+ *
+ * BOTH-SIDED, mirroring deal-outcome.ts: either party (the deal's creator or its
+ * production company) may sign; the caller's role is resolved from the deal row, not
+ * the route. A deal is "fully executed" when BOTH parties have a current signature
+ * (content_hash matching the live deal sheet). If a term is changed after one party
+ * signs, the live hash diverges and the read path flags the stale signature — so the
+ * sheet cannot be silently altered post-signature.
+ *
+ * Wired:
+ *   POST /api/deals/:id/sign        — sign (or re-affirm) the current deal sheet
+ *   GET  /api/deals/:id/signatures  — both parties' signature state + tamper check
+ */
+
+import { getDb } from '../db/connection';
+import type { Env } from '../db/connection';
+import { getCorsHeaders } from '../utils/response';
+import { getUserId } from '../utils/auth-extract';
+import { safeQuery } from '../db/safe-query';
+import { sealDealSheet } from '../services/deal-signing';
+
+function jsonResponse(data: unknown, origin: string | null, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...getCorsHeaders(origin) },
+  });
+}
+function errorResponse(message: string, origin: string | null, status = 400): Response {
+  return jsonResponse({ success: false, error: message }, origin, status);
+}
+
+// The columns needed to (a) party-gate and (b) seal the binding terms.
+const DEAL_COLUMNS = `
+  id, pitch_id, creator_id, production_company_id,
+  deal_type, option_amount, purchase_price, backend_percentage,
+  development_fee, rights_territory, notes
+`;
+
+interface SignatureRow {
+  signer_id: number;
+  party: string;
+  status: string;
+  content_hash: string;
+  signed_name: string;
+  signed_at: string;
+}
+
+function dealIdFromPath(url: string, segmentFromEnd: number): number {
+  const parts = new URL(url).pathname.split('/');
+  return Number(parts[parts.length - segmentFromEnd]);
+}
+
+/** POST /api/deals/:id/sign — sign or re-affirm the current deal sheet. */
+export async function signDeal(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+  const userId = await getUserId(request, env);
+  if (!userId) return errorResponse('Unauthorized', origin, 401);
+
+  const sql = getDb(env);
+  if (!sql) return errorResponse('Database unavailable', origin, 503);
+
+  try {
+    const dealId = dealIdFromPath(request.url, 2); // /api/deals/:id/sign
+    if (!dealId || Number.isNaN(dealId)) return errorResponse('Invalid deal id', origin);
+
+    const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+    const signedName = typeof body.fullName === 'string' ? body.fullName.trim().slice(0, 200) : '';
+    const agreed = body.agreed === true || body.acceptTerms === true;
+    if (!signedName) return errorResponse('A typed full legal name is required to sign', origin);
+    if (!agreed) return errorResponse('You must agree to the deal terms to sign', origin);
+
+    const [deal] = await sql.query(
+      `SELECT ${DEAL_COLUMNS} FROM production_deals WHERE id = $1`,
+      [dealId],
+    ) as unknown as Record<string, unknown>[];
+    if (!deal) return errorResponse('Deal not found', origin, 404);
+
+    const isCreator = String(deal.creator_id) === String(userId);
+    const isProduction = String(deal.production_company_id) === String(userId);
+    if (!isCreator && !isProduction) return errorResponse('Forbidden', origin, 403);
+    const party = isCreator ? 'creator' : 'production';
+
+    // Seal the CURRENT deal sheet — this is exactly what the signer is binding to.
+    const seal = await sealDealSheet(deal);
+
+    const ip = request.headers.get('CF-Connecting-IP') || request.headers.get('X-Forwarded-For') || null;
+    const ua = request.headers.get('User-Agent') || null;
+    const signatureData = JSON.stringify({
+      agreed: true,
+      fullName: signedName,
+      title: typeof body.title === 'string' ? body.title.slice(0, 200) : '',
+      signedAt: new Date().toISOString(),
+    });
+
+    // One signature per (deal, signer); re-signing re-affirms against the current hash.
+    await sql`
+      INSERT INTO deal_signatures
+        (deal_id, signer_id, party, status, content_hash, algorithm, signed_name, signed_at, ip_address, user_agent, signature_data)
+      VALUES
+        (${dealId}, ${userId}, ${party}, 'signed', ${seal.hash}, ${seal.algorithm}, ${signedName}, NOW(), ${ip}, ${ua}, ${signatureData})
+      ON CONFLICT (deal_id, signer_id) DO UPDATE SET
+        status = 'signed',
+        content_hash = EXCLUDED.content_hash,
+        algorithm = EXCLUDED.algorithm,
+        signed_name = EXCLUDED.signed_name,
+        signed_at = NOW(),
+        ip_address = EXCLUDED.ip_address,
+        user_agent = EXCLUDED.user_agent,
+        signature_data = EXCLUDED.signature_data,
+        revoked_at = NULL
+    `;
+
+    // Did this complete a fully-executed (both parties, current hash) deal sheet?
+    const sigs = await sql`
+      SELECT signer_id, party, status, content_hash
+      FROM deal_signatures WHERE deal_id = ${dealId} AND status = 'signed'
+    ` as unknown as SignatureRow[];
+    const creatorSigned = sigs.some(s => s.party === 'creator' && s.content_hash === seal.hash);
+    const productionSigned = sigs.some(s => s.party === 'production' && s.content_hash === seal.hash);
+    const fullyExecuted = creatorSigned && productionSigned;
+
+    // Notify the counterparty — best-effort, mirrors deal-outcome.notify.
+    const counterpartyId = isCreator ? deal.production_company_id : deal.creator_id;
+    await safeQuery(() => sql`
+      INSERT INTO notifications (user_id, type, title, message, related_user_id, related_pitch_id, created_at)
+      VALUES (
+        ${counterpartyId as number}, 'deal_signed',
+        ${fullyExecuted ? 'Deal sheet fully executed' : 'Deal sheet signed'},
+        ${fullyExecuted
+          ? 'Both parties have signed the deal sheet. It is now a sealed, binding record on Pitchey.'
+          : 'The other party signed the deal sheet. Sign to make it a sealed, binding record.'},
+        ${userId}, ${deal.pitch_id as number | null}, NOW()
+      )
+    `, { fallback: [], context: 'deal-signing.notify' });
+
+    return jsonResponse({
+      success: true,
+      data: { dealId, party, contentHash: seal.hash, fullyExecuted },
+    }, origin);
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error('signDeal error:', e.message);
+    return errorResponse('Failed to sign deal sheet', origin, 500);
+  }
+}
+
+/** GET /api/deals/:id/signatures — both parties' signature state + tamper check. */
+export async function getDealSignatures(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+  const userId = await getUserId(request, env);
+  if (!userId) return errorResponse('Unauthorized', origin, 401);
+
+  const sql = getDb(env);
+  if (!sql) return errorResponse('Database unavailable', origin, 503);
+
+  try {
+    const dealId = dealIdFromPath(request.url, 1); // /api/deals/:id/signatures
+    if (!dealId || Number.isNaN(dealId)) return errorResponse('Invalid deal id', origin);
+
+    const [deal] = await sql.query(
+      `SELECT ${DEAL_COLUMNS} FROM production_deals WHERE id = $1`,
+      [dealId],
+    ) as unknown as Record<string, unknown>[];
+    if (!deal) return errorResponse('Deal not found', origin, 404);
+
+    const isCreator = String(deal.creator_id) === String(userId);
+    const isProduction = String(deal.production_company_id) === String(userId);
+    if (!isCreator && !isProduction) return errorResponse('Forbidden', origin, 403);
+    const viewerParty = isCreator ? 'creator' : 'production';
+
+    // Seal the live sheet — the reference hash every signature is compared against.
+    const seal = await sealDealSheet(deal);
+
+    const result = await safeQuery<SignatureRow>(() => sql`
+      SELECT signer_id, party, status, content_hash, signed_name, signed_at
+      FROM deal_signatures
+      WHERE deal_id = ${dealId} AND status = 'signed'
+      ORDER BY signed_at ASC
+    `, { fallback: [], context: 'deal-signing.list' });
+    if (!result.ok) return errorResponse('Failed to load signatures', origin, 500);
+
+    const signatures = result.rows.map(s => ({
+      party: s.party,
+      signedName: s.signed_name,
+      signedAt: s.signed_at,
+      contentHash: s.content_hash,
+      // false ⇒ a term changed after this party signed (stale/ tampered signature).
+      matchesCurrent: s.content_hash === seal.hash,
+    }));
+
+    const creatorCurrent = signatures.some(s => s.party === 'creator' && s.matchesCurrent);
+    const productionCurrent = signatures.some(s => s.party === 'production' && s.matchesCurrent);
+
+    return jsonResponse({
+      success: true,
+      data: {
+        dealId,
+        currentHash: seal.hash,
+        algorithm: seal.algorithm,
+        fullyExecuted: creatorCurrent && productionCurrent,
+        // true ⇒ at least one signature was made against an older version of the sheet.
+        hasStaleSignature: signatures.some(s => !s.matchesCurrent),
+        // viewer context — lets the UI show "you signed" vs the sign action.
+        viewerParty,
+        viewerSigned: signatures.some(s => s.party === viewerParty && s.matchesCurrent),
+        signatures,
+      },
+    }, origin);
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error('getDealSignatures error:', e.message);
+    return errorResponse('Failed to load deal signatures', origin, 500);
+  }
+}

--- a/src/services/__tests__/deal-signing.test.ts
+++ b/src/services/__tests__/deal-signing.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import {
+  dealSheetTerms,
+  canonicalDealSheet,
+  sealDealSheet,
+} from '../deal-signing';
+
+// A representative raw `production_deals` (joined) row.
+const baseDeal: Record<string, unknown> = {
+  id: 42,
+  pitch_id: 7,
+  creator_id: 100,
+  production_company_id: 200,
+  deal_type: 'option',
+  option_amount: 5000,
+  purchase_price: 250000,
+  backend_percentage: 5,
+  development_fee: 10000,
+  rights_territory: 'Worldwide',
+  notes: 'First-look, 18-month option.',
+  // Joined/cosmetic fields the seal must IGNORE:
+  creator_name: 'Alex Creator',
+  production_name: 'Stellar',
+  created_at: '2026-06-27T00:00:00Z',
+  deal_state: 'accepted',
+};
+
+describe('deal-signing seal', () => {
+  it('is deterministic — same terms produce the same hash', async () => {
+    const a = await sealDealSheet(baseDeal);
+    const b = await sealDealSheet({ ...baseDeal });
+    expect(a.hash).toBe(b.hash);
+    expect(a.hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(a.algorithm).toBe('sha256');
+  });
+
+  it('ignores cosmetic / joined fields — only binding terms affect the hash', async () => {
+    const a = await sealDealSheet(baseDeal);
+    const b = await sealDealSheet({
+      ...baseDeal,
+      creator_name: 'DIFFERENT NAME',
+      production_name: 'Other Co',
+      created_at: '1999-01-01T00:00:00Z',
+      deal_state: 'completed',
+      some_future_column: 'whatever',
+    });
+    expect(a.hash).toBe(b.hash);
+  });
+
+  it('detects tampering — changing any binding term changes the hash', async () => {
+    const original = await sealDealSheet(baseDeal);
+    const mutations: Array<Partial<Record<string, unknown>>> = [
+      { option_amount: 5001 },
+      { purchase_price: 250001 },
+      { backend_percentage: 6 },
+      { development_fee: 0 },
+      { rights_territory: 'North America' },
+      { deal_type: 'purchase' },
+      { notes: 'Altered terms.' },
+    ];
+    for (const m of mutations) {
+      const tampered = await sealDealSheet({ ...baseDeal, ...m });
+      expect(tampered.hash, `mutation ${JSON.stringify(m)} should change the hash`)
+        .not.toBe(original.hash);
+    }
+  });
+
+  it('treats numeric and string-numeric term values as equal (DB driver drift)', async () => {
+    const a = await sealDealSheet(baseDeal);
+    const b = await sealDealSheet({
+      ...baseDeal,
+      option_amount: '5000',
+      purchase_price: '250000',
+      backend_percentage: '5',
+    });
+    expect(a.hash).toBe(b.hash);
+  });
+
+  it('normalizes null/undefined notes and territory to empty, not the string "null"', () => {
+    const t1 = dealSheetTerms({ ...baseDeal, notes: null, rights_territory: undefined });
+    expect(t1.notes).toBe('');
+    expect(t1.rights_territory).toBe('');
+    const canon = canonicalDealSheet(t1);
+    expect(canon).toContain('notes=');
+    expect(canon).not.toContain('notes=null');
+    expect(canon.startsWith('pitchey:deal-sheet:v1')).toBe(true);
+  });
+});

--- a/src/services/deal-signing.ts
+++ b/src/services/deal-signing.ts
@@ -1,0 +1,87 @@
+// Deal-sheet sealing — P5.0 of the deal-servicing roadmap.
+//
+// Produces a DETERMINISTIC canonical serialization of a production deal's binding
+// terms and a SHA-256 seal of it, so that:
+//   1. both parties signing the same deal hash IDENTICAL bytes (the seal is shared), and
+//   2. mutating a term after a party signed changes the live hash, making the prior
+//      signature's `content_hash` no longer match — i.e. tampering is detectable.
+//
+// Reuses the provenance seal primitive (`sha256Hex` → crypto.subtle) rather than
+// re-implementing hashing. This file deliberately holds NO money/Stripe logic — P5.0
+// is pure switching-cost (a co-signed, hash-sealed instrument), nothing more.
+
+import { sha256Hex } from './pitch-provenance';
+
+// The binding terms of a deal, in a FIXED order. Anything that changes what the
+// parties agreed to belongs here; anything cosmetic (display names, timestamps that
+// don't bind) does not. Order is load-bearing — it is part of the canonical form.
+export interface DealSheetTerms {
+  deal_id: number;
+  pitch_id: number | null;
+  creator_id: number;
+  production_company_id: number;
+  deal_type: string;
+  option_amount: number;
+  purchase_price: number;
+  backend_percentage: number;
+  development_fee: number;
+  rights_territory: string;
+  notes: string;
+}
+
+// Pull the binding terms off a raw `production_deals` (joined) row in a way that is
+// stable regardless of column ordering or extra joined fields.
+export function dealSheetTerms(deal: Record<string, unknown>): DealSheetTerms {
+  const num = (v: unknown): number => {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : 0;
+  };
+  const str = (v: unknown): string => (v == null ? '' : String(v));
+  return {
+    deal_id: num(deal.id),
+    pitch_id: deal.pitch_id == null ? null : num(deal.pitch_id),
+    creator_id: num(deal.creator_id),
+    production_company_id: num(deal.production_company_id),
+    deal_type: str(deal.deal_type),
+    option_amount: num(deal.option_amount),
+    purchase_price: num(deal.purchase_price),
+    backend_percentage: num(deal.backend_percentage),
+    development_fee: num(deal.development_fee),
+    rights_territory: str(deal.rights_territory),
+    notes: str(deal.notes),
+  };
+}
+
+// Deterministic canonical string. Explicit field order + a version tag so the seal
+// is reproducible and survives JSON key-ordering differences. The `v1` tag lets a
+// future terms change re-version without silently invalidating old seals.
+export function canonicalDealSheet(terms: DealSheetTerms): string {
+  const ordered: Array<[keyof DealSheetTerms, string | number | null]> = [
+    ['deal_id', terms.deal_id],
+    ['pitch_id', terms.pitch_id],
+    ['creator_id', terms.creator_id],
+    ['production_company_id', terms.production_company_id],
+    ['deal_type', terms.deal_type],
+    ['option_amount', terms.option_amount],
+    ['purchase_price', terms.purchase_price],
+    ['backend_percentage', terms.backend_percentage],
+    ['development_fee', terms.development_fee],
+    ['rights_territory', terms.rights_territory],
+    ['notes', terms.notes],
+  ];
+  return 'pitchey:deal-sheet:v1\n' +
+    ordered.map(([k, v]) => `${k}=${v == null ? '' : v}`).join('\n');
+}
+
+export interface DealSeal {
+  hash: string;
+  algorithm: 'sha256';
+  canonical: string;
+}
+
+// Seal a deal row → { hash } usable both at sign-time (persist) and read-time (compare).
+export async function sealDealSheet(deal: Record<string, unknown>): Promise<DealSeal> {
+  const canonical = canonicalDealSheet(dealSheetTerms(deal));
+  const hash = await sha256Hex(canonical);
+  return { hash, algorithm: 'sha256', canonical };
+}

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -3714,6 +3714,15 @@ class RouteRegistry {
       const { postDealMessage } = await import('./handlers/deal-messages');
       return postDealMessage(req, this.env);
     });
+    // Binding deal-sheet e-signature (deal-servicing P5.0) — both-sided, hash-sealed.
+    this.register('POST', '/api/deals/:id/sign', async (req) => {
+      const { signDeal } = await import('./handlers/deal-signing');
+      return signDeal(req, this.env);
+    });
+    this.register('GET', '/api/deals/:id/signatures', async (req) => {
+      const { getDealSignatures } = await import('./handlers/deal-signing');
+      return getDealSignatures(req, this.env);
+    });
     this.register('GET', '/api/creator/pitches/analytics', async (req) => {
       const { creatorPitchesAnalyticsHandler } = await import('./handlers/creator-sidebar');
       return creatorPitchesAnalyticsHandler(req, this.env);


### PR DESCRIPTION
## What

Promotes the deal sheet from a rendered **view** (`getProductionContract`) into a **binding, hash-sealed, co-signed instrument** — the first slice (P5.0) of the deal-servicing roadmap.

The cheapest real on-platform lock-in: **no payments, no Stripe Connect, no take-rate, no PCI surface** — pure switching cost. A co-signed, content-hash-sealed deal sheet living on Pitchey is a reason to transact on-platform rather than just record (P1) a deal that happened off-platform.

Built entirely on **verified-live primitives**: reuses the provenance SHA-256 seal (`crypto.subtle`) and the Standard-NDA click-to-sign pattern. Keyed to the live `production_deals` spine — **not** the orphan `contract_signatures` schema (mig 004, never wired).

## The design property that matters

`content_hash` seals **exactly** the terms a party signed. Edit any binding term after a signature and the live hash diverges:
- `GET /signatures` returns `matchesCurrent: false` on the stale signature + `hasStaleSignature: true`
- `fullyExecuted` requires **both** parties signed against the **current** hash

So the sheet can't be silently altered post-signature.

## Changes

**Backend (P5.0a)**
- `117_deal_signatures.sql` — keyed to `production_deals(id)`, `UNIQUE(deal_id, signer_id)`
- `services/deal-signing.ts` — deterministic canonical deal sheet + SHA-256 seal (reuses `sha256Hex`)
- `handlers/deal-signing.ts` — `POST /api/deals/:id/sign`, `GET /api/deals/:id/signatures` (both-sided; party resolved from the deal row; tamper check)
- 5 seal unit tests

**Frontend (P5.0b)**
- `DealSignPanel` — seal status, both-party state, tamper warning, click-to-sign (typed name + agree)
- mounted next to `DealThread` in `ProductionDeals` + `CreatorDealInbox`
- 5 component tests

## Verification gates

- [x] **G1 — worker `tsc` 0** (`tsc -p tsconfig.json`, the worker is not type-checked in CI)
- [x] **G2 — frontend `tsc` 0** (`tsc -p tsconfig.app.json`)
- [x] **G3 — catch-swallow 0 untagged** (`catch-swallow-gate.mjs --include-worker --threshold 0`)
- [x] **G4 — both builds clean** (`build:worker` + frontend `build`)
- [x] **G5 — seal correctness** — 5 tests: determinism, cosmetic-field immunity, tamper detection on every binding term, string/number drift, null normalization
- [x] **G6 — frontend panel** — 5 tests; existing `CreatorDealInbox` test still green (panel only mounts when a deal is expanded)
- [x] **G7 — migration 117 validated on a Neon branch** — FKs to `production_deals`/`users` resolved, CHECKs + `UNIQUE(deal_id, signer_id)` present (the `ON CONFLICT` target)

## Ship steps after merge (held for owner)

1. Apply migration 117 to prod + record in `schema_migrations`
2. `wrangler deploy` (worker) + frontend deploy
3. Smoke: a creator + production sign the same deal → `fullyExecuted: true`; edit a term → stale flag

## Liquidity note

Per `docs/deal-servicing-roadmap-2026-06-27.md` §5, P5.0 is the **no-payment slice** and is safe pre-liquidity. The money slices (P5.1 Connect onboarding, P5.2 option payment + take-rate) remain **gated** on the §5 liquidity trigger and are **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)