### PR TITLE
chore(lint): type team + collaboration service API boundaries (slice 1)

### DIFF
--- a/frontend/src/services/collaboration.service.ts
+++ b/frontend/src/services/collaboration.service.ts
@@ -51,13 +51,6 @@ export interface Collaboration {
   };
 }
 
-// API Response types
-interface ApiResponse<T> {
-  success: boolean;
-  data?: T;
-  error?: { message: string } | string;
-}
-
 export class CollaborationService {
   /**
    * Get all collaborations for the current user
@@ -78,8 +71,8 @@ export class CollaborationService {
 
       const response = await apiClient.get<{ collaborations: Collaboration[] }>(url);
 
-      if (response.success && (response.data as any)?.collaborations) {
-        return (response.data as any).collaborations;
+      if (response.success && response.data?.collaborations) {
+        return response.data.collaborations;
       }
 
       // If no dedicated endpoint exists, return empty array
@@ -100,8 +93,8 @@ export class CollaborationService {
         `/api/collaborations/${collaborationId}`
       );
 
-      if (response.success && (response.data as any)?.collaboration) {
-        return (response.data as any).collaboration;
+      if (response.success && response.data?.collaboration) {
+        return response.data.collaboration;
       }
 
       return null;
@@ -128,7 +121,7 @@ export class CollaborationService {
       data
     );
 
-    if (!response.success || !(response.data as any)?.collaboration) {
+    if (!response.success || !response.data?.collaboration) {
       throw new Error(
         typeof response.error === 'string'
           ? response.error
@@ -136,7 +129,7 @@ export class CollaborationService {
       );
     }
 
-    return (response.data as any).collaboration;
+    return response.data.collaboration;
   }
 
   /**
@@ -146,7 +139,7 @@ export class CollaborationService {
     collaborationId: string,
     status: Collaboration['status']
   ): Promise<void> {
-    const response = await apiClient.put<ApiResponse<{ message: string }>>(
+    const response = await apiClient.put<{ message: string }>(
       `/api/collaborations/${collaborationId}/status`,
       { status }
     );
@@ -195,7 +188,7 @@ export class CollaborationService {
     collaborationId: string,
     message: string
   ): Promise<void> {
-    const response = await apiClient.post<ApiResponse<{ message: string }>>(
+    const response = await apiClient.post<{ message: string }>(
       `/api/collaborations/${collaborationId}/messages`,
       { content: message }
     );
@@ -220,7 +213,7 @@ export class CollaborationService {
     totalValue: number;
   }> {
     try {
-      const response = await apiClient.get<ApiResponse<{
+      const response = await apiClient.get<{
         stats: {
           total: number;
           active: number;
@@ -228,10 +221,10 @@ export class CollaborationService {
           completed: number;
           totalValue: number;
         };
-      }>>('/api/collaborations/stats');
+      }>('/api/collaborations/stats');
 
-      if (response.success && (response.data as any)?.stats) {
-        return (response.data as any).stats;
+      if (response.success && response.data?.stats) {
+        return response.data.stats;
       }
 
       return {

--- a/frontend/src/services/team.service.ts
+++ b/frontend/src/services/team.service.ts
@@ -74,13 +74,6 @@ export interface TeamRole {
   createdAt: string;
 }
 
-// API Response types
-interface ApiResponse<T> {
-  success: boolean;
-  data?: T;
-  error?: { message: string } | string;
-}
-
 export class TeamService {
   /**
    * Get all teams for the current user
@@ -88,11 +81,11 @@ export class TeamService {
   static async getTeams(): Promise<Team[]> {
     const response = await apiClient.get<{ teams: Team[] }>('/api/teams');
 
-    if (!response.success || !(response.data as any)?.teams) {
+    if (!response.success || !response.data?.teams) {
       throw new Error(typeof response.error === 'string' ? response.error : response.error?.message || 'Failed to fetch teams');
     }
 
-    return (response.data as any).teams;
+    return response.data.teams;
   }
 
   /**
@@ -101,11 +94,11 @@ export class TeamService {
   static async getTeamById(teamId: string): Promise<Team> {
     const response = await apiClient.get<{ team: Team }>(`/api/teams/${teamId}`);
 
-    if (!response.success || !(response.data as any)?.team) {
+    if (!response.success || !response.data?.team) {
       throw new Error(typeof response.error === 'string' ? response.error : response.error?.message || 'Failed to fetch team');
     }
 
-    return (response.data as any).team;
+    return response.data.team;
   }
 
   /**
@@ -114,13 +107,13 @@ export class TeamService {
   static async getTeamMembers(teamId: string): Promise<TeamMember[]> {
     const response = await apiClient.get<{ members: TeamMember[] }>(`/api/teams/${teamId}/members`);
 
-    if (!response.success || !(response.data as any)?.members) {
+    if (!response.success || !response.data?.members) {
       // If no members endpoint, try getting from team details
       const team = await this.getTeamById(teamId);
       return team.members || [];
     }
 
-    return (response.data as any).members;
+    return response.data.members;
   }
 
   /**
@@ -129,11 +122,11 @@ export class TeamService {
   static async createTeam(data: { name: string; description?: string }): Promise<Team> {
     const response = await apiClient.post<{ team: Team }>('/api/teams', data);
 
-    if (!response.success || !(response.data as any)?.team) {
+    if (!response.success || !response.data?.team) {
       throw new Error(typeof response.error === 'string' ? response.error : response.error?.message || 'Failed to create team');
     }
 
-    return (response.data as any).team;
+    return response.data.team;
   }
 
   /**
@@ -142,11 +135,11 @@ export class TeamService {
   static async updateTeam(teamId: string, data: { name?: string; description?: string }): Promise<Team> {
     const response = await apiClient.put<{ team: Team }>(`/api/teams/${teamId}`, data);
 
-    if (!response.success || !(response.data as any)?.team) {
+    if (!response.success || !response.data?.team) {
       throw new Error(typeof response.error === 'string' ? response.error : response.error?.message || 'Failed to update team');
     }
 
-    return (response.data as any).team;
+    return response.data.team;
   }
 
   /**
@@ -166,11 +159,11 @@ export class TeamService {
   static async inviteToTeam(teamId: string, data: { email: string; role?: string; message?: string }): Promise<TeamInvitation> {
     const response = await apiClient.post<{ invitation: TeamInvitation }>(`/api/teams/${teamId}/invite`, data);
 
-    if (!response.success || !(response.data as any)?.invitation) {
+    if (!response.success || !response.data?.invitation) {
       throw new Error(typeof response.error === 'string' ? response.error : response.error?.message || 'Failed to send invitation');
     }
 
-    return (response.data as any).invitation;
+    return response.data.invitation;
   }
 
   /**
@@ -179,11 +172,11 @@ export class TeamService {
   static async getInvitations(): Promise<TeamInvitation[]> {
     const response = await apiClient.get<{ invites: TeamInvitation[] }>('/api/teams/invites');
 
-    if (!response.success || !(response.data as any)?.invites) {
+    if (!response.success || !response.data?.invites) {
       return [];
     }
 
-    return (response.data as any).invites;
+    return response.data.invites;
   }
 
   /**
@@ -236,11 +229,11 @@ export class TeamService {
   static async getTeamRoles(teamId: string): Promise<TeamRole[]> {
     const response = await apiClient.get<{ roles: TeamRole[] }>(`/api/teams/${teamId}/roles`);
 
-    if (!response.success || !(response.data as any)?.roles) {
+    if (!response.success || !response.data?.roles) {
       return [];
     }
 
-    return (response.data as any).roles;
+    return response.data.roles;
   }
 
   /**
@@ -249,11 +242,11 @@ export class TeamService {
   static async resendInvitation(inviteId: string): Promise<TeamInvitation> {
     const response = await apiClient.post<{ invitation: TeamInvitation }>(`/api/teams/invites/${inviteId}/resend`, {});
 
-    if (!response.success || !(response.data as any)?.invitation) {
+    if (!response.success || !response.data?.invitation) {
       throw new Error(typeof response.error === 'string' ? response.error : response.error?.message || 'Failed to resend invitation');
     }
 
-    return (response.data as any).invitation;
+    return response.data.invitation;
   }
 
   /**
@@ -276,11 +269,11 @@ export class TeamService {
 
     const response = await apiClient[method]<{ role: TeamRole }>(url, role);
 
-    if (!response.success || !(response.data as any)?.role) {
+    if (!response.success || !response.data?.role) {
       throw new Error(typeof response.error === 'string' ? response.error : response.error?.message || 'Failed to save role');
     }
 
-    return (response.data as any).role;
+    return response.data.role;
   }
 
   /**

--- a/scripts/frontend-lint-gate.mjs
+++ b/scripts/frontend-lint-gate.mjs
@@ -28,10 +28,14 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 // ── The baseline. Lower it (never raise it) as frontend lint errors are fixed. ──
-const BASELINE = 8908;
+const BASELINE = 8837;
 // 2026-06-27: created at the measured floor (8908 errors / 184 warnings). Top
 // rules: no-unsafe-member-access, no-unsafe-assignment, no-explicit-any,
 // no-unused-vars, no-misused-promises. The gate blocks any NEW error.
+// 2026-06-27: lowered 8908 -> 8837 (-71) after typing the team + collaboration
+// service API boundaries (removed unnecessary `(response.data as any)` casts;
+// fixed a latent double-wrapped `get<ApiResponse<...>>` generic that hid a
+// real stats-access bug). slice 1 of the `any`-complex teardown (src/services).
 
 const LIST = process.argv.includes('--list');
 


### PR DESCRIPTION
First slice of the frontend `any`-complex teardown — the 6810 `no-unsafe-*` /
`no-explicit-any` errors that dominate the 8837-error lint debt. Strategy
(chosen): root-cause at API boundaries, `src/services` first, since the
`no-unsafe-*` errors cascade from `any` at the source.

## What changed
- **team.service.ts** — removed 20 unnecessary `(response.data as any)` casts.
  `apiClient.get<{teams: Team[]}>()` already types `response.data`, so the casts
  were pure noise generating both `no-explicit-any` and the downstream
  `no-unsafe-member-access`. Dropped the now-unused local `ApiResponse`.
- **collaboration.service.ts** — same cast removal, **plus a latent type-bug
  fix**: three call sites double-wrapped the generic (`get<ApiResponse<{stats}>>`),
  which typed `response.data` one level too deep — the `as any` was masking it.
  Unwrapped to `get<{stats}>` so `response.data.stats` is correctly typed.

## Result
- **71 lint errors cleared** (8908 → 8837)
- A real, previously-hidden type bug fixed (the stats access)
- **Zero behavior change** — casts were removing type info, not changing runtime

## Verification
- `tsc -p tsconfig.app.json` → **0 errors**
- **328 service tests pass** (incl. team.service + collaboration.service suites)
- lint-gate baseline ratcheted 8908 → **8837** to lock the win

## Not in this slice (deferred — needs real per-endpoint response types)
`ui-actions` (`post<any>`), `slate` (defensive unwrapped fallback decision),
`user` (`Promise<any>` stat/preference shapes), and the `src/shared` contexts.
Those require deciding real response shapes, not mechanical cast removal — next
slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)