### PR TITLE
chore(lint): type transformPitchData input boundary (A2a)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -29,17 +29,59 @@ api.interceptors.response.use(
   }
 );
 
-function safeParseJsonArray(value: unknown): any[] {
+function safeParseJsonArray(value: unknown): unknown[] {
   if (Array.isArray(value)) return value;
   if (typeof value === 'string') {
-    try { const parsed = JSON.parse(value); return Array.isArray(parsed) ? parsed : []; }
+    try { const parsed: unknown = JSON.parse(value); return Array.isArray(parsed) ? parsed : []; }
     catch { return []; }
   }
   return [];
 }
 
+/**
+ * Raw pitch payload as it arrives from the API — snake_case and camelCase keys
+ * coexist across historical endpoints, so both spellings are declared. The index
+ * signature keeps passthrough fields typed as `unknown` (not `any`) so member
+ * access inside transformPitchData is type-safe. A boundary shape claim, the same
+ * kind the apiClient `<T>` generics make. (Return stays `any` for now — tightening
+ * it to `Pitch` is deferred: this file's `Pitch` differs from the page-level
+ * `Pitch` type tree, so a strict return cascades — that's a B-workstream slice.)
+ */
+interface RawPitch {
+  user_id?: number; userId?: number;
+  creator?: { id?: number; name?: string } | null;
+  view_count?: number; viewCount?: number; views?: number;
+  like_count?: number; likeCount?: number; likes?: number;
+  rating_average?: number | string; ratingAverage?: number | string;
+  pitchey_score_avg?: number | string; pitcheyScoreAvg?: number | string;
+  viewer_score_avg?: number | string; viewerScoreAvg?: number | string;
+  rating_count?: number | string; ratingCount?: number | string;
+  nda_count?: number; ndaCount?: number;
+  created_at?: string; createdAt?: string;
+  updated_at?: string; updatedAt?: string;
+  creator_id?: number; creatorId?: number;
+  creator_name?: string; creatorName?: string;
+  company_name?: string; creatorCompany?: string;
+  short_synopsis?: string; shortSynopsis?: string;
+  long_synopsis?: string; longSynopsis?: string;
+  budget_range?: string; estimated_budget?: number | string; budget?: unknown; estimatedBudget?: number | string;
+  production_timeline?: string; productionTimeline?: string;
+  target_audience?: string; targetAudience?: string;
+  comparable_films?: string; comparableFilms?: string;
+  budget_breakdown?: unknown; budgetBreakdown?: unknown;
+  attached_talent?: string; attachedTalent?: string;
+  financial_projections?: unknown; financialProjections?: unknown;
+  title_image?: string; titleImage?: string;
+  thumbnail_url?: string; thumbnail?: string;
+  pitch_deck_url?: string; pitchDeck?: string;
+  script_url?: string; script?: string;
+  trailer_url?: string; trailer?: string;
+  documents?: unknown; characters?: unknown; themes?: unknown; locations?: unknown;
+  [key: string]: unknown;
+}
+
 // Helper to transform pitch data from snake_case (API) to camelCase (frontend)
-function transformPitchData(pitch: any): any {
+function transformPitchData(pitch: RawPitch | null | undefined): any {
   if (!pitch) return pitch;
   return {
     ...pitch,
@@ -74,7 +116,7 @@ function transformPitchData(pitch: any): any {
     pitchDeck: pitch.pitch_deck_url ?? pitch.pitchDeck,
     script: pitch.script_url ?? pitch.script,
     trailer: pitch.trailer_url ?? pitch.trailer,
-    documents: Array.isArray(pitch.documents) ? pitch.documents : [],
+    documents: Array.isArray(pitch.documents) ? (pitch.documents as unknown[]) : [],
     characters: safeParseJsonArray(pitch.characters),
     themes: safeParseJsonArray(pitch.themes),
     locations: safeParseJsonArray(pitch.locations),

--- a/scripts/frontend-lint-gate.mjs
+++ b/scripts/frontend-lint-gate.mjs
@@ -28,7 +28,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 // ── The baseline. Lower it (never raise it) as frontend lint errors are fixed. ──
-const BASELINE = 8837;
+const BASELINE = 8736;
 // 2026-06-27: created at the measured floor (8908 errors / 184 warnings). Top
 // rules: no-unsafe-member-access, no-unsafe-assignment, no-explicit-any,
 // no-unused-vars, no-misused-promises. The gate blocks any NEW error.
@@ -36,6 +36,11 @@ const BASELINE = 8837;
 // service API boundaries (removed unnecessary `(response.data as any)` casts;
 // fixed a latent double-wrapped `get<ApiResponse<...>>` generic that hid a
 // real stats-access bug). slice 1 of the `any`-complex teardown (src/services).
+// 2026-06-28: lowered 8837 -> 8736 (-101). A2a: typed transformPitchData's input
+// (RawPitch boundary shape) in src/lib/api.ts — cleared the unsafe member-access
+// inside the transform with zero consumer cascade (return kept `any`; tightening
+// it to Pitch is deferred — the file's Pitch differs from the page-level Pitch
+// type tree). Remaining api.ts errors are axios response-envelope typing (A2b).
 
 const LIST = process.argv.includes('--list');
 


### PR DESCRIPTION
Workstream **A2** of the lint teardown ([#384](https://github.com/WizardryPro/pitchey-app/issues/384)), part **a**.

Typed the snake_case→camelCase transform's **input** with a `RawPitch` boundary
interface (both key spellings + `[key: string]: unknown` passthrough), clearing
the unsafe member-access *inside* `transformPitchData`. Also
`safeParseJsonArray(): any[]` → `unknown[]`.

### Why the return type stays `any`
Tightening the return to `Pitch` cascades: this file's local `Pitch` differs from
the **page-level `Pitch` type tree** (multiple parallel type definitions), and the
local `Pitch.likes` is drifted (`any[]`, but read as a numeric count). A strict
return surfaces ~10 consumer errors across 4 pages. That unification is a
**B-workstream** slice, tracked in #384. Remaining api.ts errors are axios
response-envelope typing (**A2b**).

### Result
- **101 lint errors cleared** (8837 → 8736), api.ts 199 → 98
- **Zero consumer cascade** (return contract unchanged)
- app `tsc` clean, **full frontend suite green (5211 tests)**
- gate baseline ratcheted to **8736**

🤖 Generated with [Claude Code](https://claude.com/claude-code)