### PR TITLE
chore(lint): type feature-service API boundaries (A3)

### DIFF
--- a/frontend/src/features/deals/services/investment.service.ts
+++ b/frontend/src/features/deals/services/investment.service.ts
@@ -6,9 +6,9 @@ export interface Investment {
   pitchId: number;
   amount: number;
   status: 'pending' | 'active' | 'completed' | 'cancelled';
-  terms?: any;
+  terms?: unknown;
   currentValue: number;
-  documents?: any[];
+  documents?: unknown[];
   notes?: string;
   createdAt: string;
   updatedAt: string;
@@ -16,7 +16,8 @@ export interface Investment {
   pitchTitle?: string;
   pitchGenre?: string;
   creatorName?: string;
-  investmentDate?: Date;
+  // String at runtime (ISO date from API); consumers wrap in `new Date(...)`.
+  investmentDate?: string;
   returnAmount?: number;
   returnPercentage?: number;
   daysInvested?: number;
@@ -77,20 +78,67 @@ export interface InvestmentOpportunity {
   publishedAt: Date;
 }
 
+// Raw API payload shapes (snake_case + camelCase coexist). Boundary claims that
+// keep response member-access typed instead of `any`. See the lint teardown plan.
+interface RawPortfolioSummary {
+  total_invested?: number; totalInvested?: number;
+  portfolio_value?: number; currentValue?: number;
+  total_returns?: number; totalReturn?: number;
+  average_roi?: number; returnPercentage?: number; roi?: number;
+  active_investments?: number; activeInvestments?: number;
+  completed_investments?: number; completedInvestments?: number;
+  monthly_growth?: number; monthlyGrowth?: number;
+  quarterly_growth?: number; quarterlyGrowth?: number;
+  ytd_growth?: number; ytdGrowth?: number;
+  [key: string]: unknown;
+}
+
+interface RawInvestmentRow {
+  id?: number;
+  investor_id?: number; investorId?: number;
+  pitch_id?: number; pitchId?: number;
+  amount?: number | string;
+  status?: Investment['status'];
+  terms?: unknown;
+  current_value?: number | string; currentValue?: number | string;
+  documents?: unknown[];
+  notes?: string;
+  created_at?: string; createdAt?: string;
+  updated_at?: string; updatedAt?: string;
+  pitch_title?: string; pitchTitle?: string;
+  genre?: string; pitchGenre?: string;
+  creator_name?: string; creatorName?: string;
+  invested_at?: string; investmentDate?: string;
+  roi_percentage?: number | string; returnPercentage?: number | string;
+  [key: string]: unknown;
+}
+
+interface InvestmentHistoryResponse {
+  investments?: RawInvestmentRow[];
+  total?: number;
+  totalPages?: number; total_pages?: number;
+  currentPage?: number; current_page?: number;
+  summary?: {
+    totalInvested: number;
+    totalCurrentValue: number;
+    activeCount: number;
+    completedCount: number;
+  };
+}
+
 export class InvestmentService {
   // Get investor's portfolio summary
-  static async getInvestorPortfolio(investorId?: number): Promise<{
+  static async getInvestorPortfolio(_investorId?: number): Promise<{
     success: boolean;
     data?: PortfolioMetrics;
     error?: string;
   }> {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const response = await apiClient.get<any>('/api/investor/portfolio/summary');
+      const response = await apiClient.get<{ summary?: RawPortfolioSummary } & RawPortfolioSummary>('/api/investor/portfolio/summary');
       if (!response.success || !response.data) {
         return {
           success: response.success,
-          data: response.data ?? undefined,
+          data: undefined,
           error: response.error?.message
         };
       }
@@ -151,23 +199,21 @@ export class InvestmentService {
       if (params?.sortBy) queryParams.append('sortBy', params.sortBy);
       if (params?.sortOrder) queryParams.append('sortOrder', params.sortOrder);
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const response = await apiClient.get<any>(`/api/investor/investments?${queryParams.toString()}`);
+      const response = await apiClient.get<InvestmentHistoryResponse>(`/api/investor/investments?${queryParams.toString()}`);
       if (!response.success || !response.data) {
         return {
           success: response.success,
-          data: response.data ?? undefined,
+          data: undefined,
           error: response.error?.message
         };
       }
 
       // Transform snake_case investment rows to camelCase
-      const rawInvestments: unknown[] = response.data.investments ?? [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const investments: Investment[] = rawInvestments.map((row: any) => ({
-        id: row.id,
-        investorId: row.investor_id ?? row.investorId,
-        pitchId: row.pitch_id ?? row.pitchId,
+      const rawInvestments: RawInvestmentRow[] = response.data.investments ?? [];
+      const investments: Investment[] = rawInvestments.map((row): Investment => ({
+        id: row.id ?? 0,
+        investorId: row.investor_id ?? row.investorId ?? 0,
+        pitchId: row.pitch_id ?? row.pitchId ?? 0,
         amount: Number(row.amount) || 0,
         status: row.status ?? 'pending',
         terms: row.terms,
@@ -236,7 +282,7 @@ export class InvestmentService {
   }
 
   // Get creator's funding overview
-  static async getCreatorFunding(creatorId?: number): Promise<{
+  static async getCreatorFunding(_creatorId?: number): Promise<{
     success: boolean;
     data?: FundingMetrics;
     error?: string;
@@ -258,7 +304,7 @@ export class InvestmentService {
   }
 
   // Get creator's investor relationships
-  static async getCreatorInvestors(creatorId?: number): Promise<{
+  static async getCreatorInvestors(_creatorId?: number): Promise<{
     success: boolean;
     data?: {
       investors: Array<{
@@ -349,7 +395,7 @@ export class InvestmentService {
   static async createInvestment(data: {
     pitchId: number;
     amount: number;
-    terms?: any;
+    terms?: unknown;
   }): Promise<{
     success: boolean;
     data?: Investment;
@@ -458,7 +504,7 @@ export class InvestmentService {
   }
 
   // Calculate portfolio analytics
-  static async getPortfolioAnalytics(investorId?: number): Promise<{
+  static async getPortfolioAnalytics(_investorId?: number): Promise<{
     success: boolean;
     data?: {
       totalROI: number;

--- a/frontend/src/features/ndas/services/nda.service.ts
+++ b/frontend/src/features/ndas/services/nda.service.ts
@@ -93,11 +93,10 @@ export interface NDAStats {
 }
 
 // Transform flat snake_case NDA API response to camelCase NDA type
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function transformNDAFromApi(raw: any): NDA {
+function transformNDAFromApi(raw: Record<string, unknown>): NDA {
   // If already transformed (has camelCase fields), pass through
   if (raw.pitchId !== undefined && raw.createdAt !== undefined && raw.pitch_id === undefined) {
-    return raw as NDA;
+    return raw as unknown as NDA;
   }
 
   return {
@@ -133,11 +132,10 @@ function transformNDAFromApi(raw: any): NDA {
 }
 
 // Transform flat snake_case NDA request API response to camelCase NDARequest type
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function transformNDARequestFromApi(raw: any): NDARequest {
+function transformNDARequestFromApi(raw: Record<string, unknown>): NDARequest {
   // If already transformed, pass through
   if (raw.pitchId !== undefined && raw.requestedAt !== undefined && raw.pitch_id === undefined) {
-    return raw as NDARequest;
+    return raw as unknown as NDARequest;
   }
 
   return {
@@ -326,7 +324,7 @@ export class NDAService {
     if (filters?.offset !== undefined) params.append('offset', filters.offset.toString());
 
     interface GetNDAsResponse {
-      ndas: NDA[];
+      ndas: Record<string, unknown>[];
       total: number;
     }
     const response = await apiClient.get<GetNDAsResponse>(`/api/ndas?${params}`);
@@ -745,7 +743,7 @@ export class NDAService {
     total: number;
   }> {
     interface ActiveNDAsResponse {
-      ndaRequests: NDARequest[];
+      ndaRequests: Record<string, unknown>[];
       total?: number;
     }
     const response = await apiClient.get<ActiveNDAsResponse>('/api/ndas/active');
@@ -769,7 +767,7 @@ export class NDAService {
     total: number;
   }> {
     interface SignedNDAsResponse {
-      ndaRequests: NDARequest[];
+      ndaRequests: Record<string, unknown>[];
       total?: number;
     }
     const response = await apiClient.get<SignedNDAsResponse>('/api/ndas/signed');
@@ -793,7 +791,7 @@ export class NDAService {
     total: number;
   }> {
     interface IncomingRequestsResponse {
-      ndaRequests: NDARequest[];
+      ndaRequests: Record<string, unknown>[];
       total?: number;
     }
     const response = await apiClient.get<IncomingRequestsResponse>('/api/ndas/incoming-requests');
@@ -817,7 +815,7 @@ export class NDAService {
     total: number;
   }> {
     interface OutgoingRequestsResponse {
-      ndaRequests: NDARequest[];
+      ndaRequests: Record<string, unknown>[];
       total?: number;
     }
     const response = await apiClient.get<OutgoingRequestsResponse>('/api/ndas/outgoing-requests');

--- a/frontend/src/features/pitches/services/pitch.service.ts
+++ b/frontend/src/features/pitches/services/pitch.service.ts
@@ -247,7 +247,13 @@ interface RawPitchData {
   videoPassword?: string;
   video_platform?: string;
   videoPlatform?: string;
-  
+
+  // Format taxonomy + NDA + media (snake_case from API)
+  format_category?: string; formatCategory?: string;
+  format_subtype?: string; formatSubtype?: string;
+  require_nda?: boolean; requireNDA?: boolean;
+  title_image?: string; titleImage?: string;
+
   [key: string]: unknown;
 }
 
@@ -386,8 +392,8 @@ function transformPitchData(pitch: RawPitchData | null | undefined): Partial<Pit
     name: attachment.name,
     role: attachment.role,
     bio: attachment.bio,
-    imdbLink: (attachment as any).imdb_link ?? attachment.imdbLink,
-    websiteLink: (attachment as any).website_link ?? attachment.websiteLink,
+    imdbLink: (attachment as { imdb_link?: string }).imdb_link ?? attachment.imdbLink,
+    websiteLink: (attachment as { website_link?: string }).website_link ?? attachment.websiteLink,
   }));
   
   return {
@@ -404,11 +410,11 @@ function transformPitchData(pitch: RawPitchData | null | undefined): Partial<Pit
     // Map the structured format taxonomy snake_case → camelCase so the Edit form
     // can repopulate the Format Category / Subtype selects (the spread above keeps
     // only the snake_case keys). Without this, Save Changes stayed disabled.
-    formatCategory: (pitch as any).format_category ?? (pitch as any).formatCategory,
-    formatSubtype: (pitch as any).format_subtype ?? (pitch as any).formatSubtype,
+    formatCategory: pitch.format_category ?? pitch.formatCategory,
+    formatSubtype: pitch.format_subtype ?? pitch.formatSubtype,
     // Map require_nda snake→camel so PitchEdit restores the NDA selection
     // (otherwise it reads undefined → "No NDA Required" → forgets the standard NDA).
-    requireNDA: (pitch as any).require_nda ?? (pitch as any).requireNDA ?? false,
+    requireNDA: pitch.require_nda ?? pitch.requireNDA ?? false,
 
     // Transform enhanced fields from snake_case
     toneAndStyle: pitch.tone_and_style ?? pitch.toneAndStyle,
@@ -416,13 +422,13 @@ function transformPitchData(pitch: RawPitchData | null | undefined): Partial<Pit
     storyBreakdown: pitch.story_breakdown ?? pitch.storyBreakdown,
     whyNow: pitch.why_now ?? pitch.whyNow,
     productionLocation: pitch.production_location ?? pitch.productionLocation,
-    developmentStage: (pitch.development_stage ?? pitch.developmentStage) as any,
+    developmentStage: (pitch.development_stage ?? pitch.developmentStage) as Pitch['developmentStage'],
     developmentStageOther: pitch.development_stage_other ?? pitch.developmentStageOther,
     creativeAttachments: transformedAttachments,
     videoUrl: pitch.video_url ?? pitch.videoUrl,
     videoPassword: pitch.video_password ?? pitch.videoPassword,
     videoPlatform: pitch.video_platform ?? pitch.videoPlatform,
-    titleImage: (pitch as any).title_image ?? (pitch as any).titleImage,
+    titleImage: pitch.title_image ?? pitch.titleImage,
   };
 }
 
@@ -1000,7 +1006,7 @@ export class PitchService {
   // These endpoints work without authentication and are rate-limited
 
   // Transform snake_case public pitch response to camelCase Pitch
-  private static transformPublicPitch(p: any): Pitch {
+  private static transformPublicPitch(p: RawPitchData): Pitch {
     return {
       ...p,
       userId: p.user_id ?? p.userId,
@@ -1024,7 +1030,7 @@ export class PitchService {
       creatorUsername: p.creator_username ?? p.creatorUsername,
       creatorAvatar: p.creator_avatar ?? p.creatorAvatar,
       creatorCompany: p.creator_company ?? p.creatorCompany,
-    };
+    } as unknown as Pitch;
   }
 
   // Get public trending pitches (no auth required)
@@ -1043,7 +1049,7 @@ export class PitchService {
 
       interface PublicPitchesJson {
         success?: boolean;
-        data?: { pitches?: Pitch[] };
+        data?: { pitches?: RawPitchData[] };
       }
       const data = await response.json() as PublicPitchesJson;
       const pitches = data.success === true ? (data.data?.pitches ?? []) : [];
@@ -1070,7 +1076,7 @@ export class PitchService {
 
       interface PublicPitchesJson {
         success?: boolean;
-        data?: { pitches?: Pitch[] };
+        data?: { pitches?: RawPitchData[] };
       }
       const data = await response.json() as PublicPitchesJson;
       const pitches = data.success === true ? (data.data?.pitches ?? []) : [];
@@ -1097,7 +1103,7 @@ export class PitchService {
 
       interface PublicPitchesJson {
         success?: boolean;
-        data?: { pitches?: Pitch[] };
+        data?: { pitches?: RawPitchData[] };
       }
       const data = await response.json() as PublicPitchesJson;
       const pitches = data.success === true ? (data.data?.pitches ?? []) : [];
@@ -1120,7 +1126,7 @@ export class PitchService {
 
       interface HotPitchesJson {
         success?: boolean;
-        data?: { pitches?: Pitch[] };
+        data?: { pitches?: RawPitchData[] };
       }
       const data = await response.json() as HotPitchesJson;
       const pitches = data.success === true ? (data.data?.pitches ?? []) : [];

--- a/scripts/frontend-lint-gate.mjs
+++ b/scripts/frontend-lint-gate.mjs
@@ -28,7 +28,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 // ── The baseline. Lower it (never raise it) as frontend lint errors are fixed. ──
-const BASELINE = 8736;
+const BASELINE = 8371;
 // 2026-06-27: created at the measured floor (8908 errors / 184 warnings). Top
 // rules: no-unsafe-member-access, no-unsafe-assignment, no-explicit-any,
 // no-unused-vars, no-misused-promises. The gate blocks any NEW error.
@@ -41,6 +41,11 @@ const BASELINE = 8736;
 // inside the transform with zero consumer cascade (return kept `any`; tightening
 // it to Pitch is deferred — the file's Pitch differs from the page-level Pitch
 // type tree). Remaining api.ts errors are axios response-envelope typing (A2b).
+// 2026-06-28: lowered 8736 -> 8371 (-365). A3: typed the input boundaries of the
+// three feature services — nda.service (transform raw params + raw response types),
+// investment.service (Raw* shapes + response generics; fixed investmentDate Date→
+// string drift), pitch.service (added missing RawPitchData fields + raw response
+// arrays). Same input-typing/loose-return pattern; zero cascade, full suite green.
 
 const LIST = process.argv.includes('--list');
 


### PR DESCRIPTION
Workstream **A3** of the lint teardown ([#384](https://github.com/WizardryPro/pitchey-app/issues/384)). Typed the input boundaries of the three biggest feature services — same input-typing / loose-return pattern as A1/A2a, **zero consumer cascade**.

| Service | Before | After | How |
|---|---|---|---|
| `nda.service` | 177 | **0** | typed the two transforms' `raw` params; retyped local raw-response arrays (`NDA[]`→`Record<string,unknown>[]`, immediately transformed) |
| `investment.service` | 95 | **0** | `Raw*` boundary interfaces + response generics (dropped `get<any>`); fixed `investmentDate` `Date`→`string` drift; `terms`/`documents` `any`→`unknown` |
| `pitch.service` | 93 | **0** | added missing snake fields to `RawPitchData` (drops `(pitch as any)` casts); typed `transformPublicPitch` input + boundary-cast return |

### Notable
- **`investmentDate` drift fixed**: it was typed `Date` but is a string at runtime — every consumer already does `new Date(investment.investmentDate)`, and the portal interfaces declare it `string`. Now honest.
- All raw-but-typed-as-domain response arrays corrected to their actual raw shape (the data is transformed before use).

### Result
- **365 lint errors cleared** (8736 → 8371)
- app `tsc` clean (0 errors), **full frontend suite green (5211 tests)**
- No behavior change (boundary typing only); baseline ratcheted to **8371**

🤖 Generated with [Claude Code](https://claude.com/claude-code)