### PR TITLE
chore(lint): void floating navigate() promises (C1a)

### DIFF
--- a/frontend/src/components/BackButton.tsx
+++ b/frontend/src/components/BackButton.tsx
@@ -21,7 +21,7 @@ export default function BackButton({
 
   const handleBack = () => {
     if (to) {
-      navigate(to);
+      void navigate(to);
       return;
     }
 
@@ -30,45 +30,45 @@ export default function BackButton({
     
     // If on a login page, go back to portals
     if (path.startsWith('/login/')) {
-      navigate('/login');
+      void navigate('/login');
       return;
     }
     
     // If on portals page, go back to marketplace
     if (path === '/login') {
-      navigate('/');
+      void navigate('/');
       return;
     }
     
     // If on a pitch detail page, try to go back to marketplace
     if (path.startsWith('/pitch/') && !path.includes('/edit') && !path.includes('/analytics')) {
-      navigate('/');
+      void navigate('/');
       return;
     }
     
     // For creator pages, go back to creator dashboard
     if (path.startsWith('/creator/') && path !== '/creator/dashboard') {
-      navigate('/creator/dashboard');
+      void navigate('/creator/dashboard');
       return;
     }
     
     // For investor pages, go back to investor dashboard
     if (path.startsWith('/investor/') && path !== '/investor/dashboard') {
-      navigate('/investor/dashboard');
+      void navigate('/investor/dashboard');
       return;
     }
     
     // For production pages, go back to production dashboard
     if (path.startsWith('/production/') && path !== '/production/dashboard') {
-      navigate('/production/dashboard');
+      void navigate('/production/dashboard');
       return;
     }
     
     // Default fallback - try browser back or go to marketplace
     if (window.history.length > 1) {
-      navigate(-1);
+      void navigate(-1);
     } else {
-      navigate('/');
+      void navigate('/');
     }
   };
 

--- a/frontend/src/components/EnhancedNavigationShadcn.tsx
+++ b/frontend/src/components/EnhancedNavigationShadcn.tsx
@@ -70,7 +70,7 @@ export function EnhancedNavigationShadcn({
   }, [userType]);
 
   const handleNavigation = (path: string) => {
-    navigate(path);
+    void navigate(path);
     setMobileMenuOpen(false); // Close mobile menu after navigation
   };
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -23,7 +23,7 @@ export default function Layout({ children }: LayoutProps) {
 
   const handleLogout = () => {
     logout();
-    navigate('/login');
+    void navigate('/login');
   };
 
 

--- a/frontend/src/components/Onboarding/InvestorOnboarding.tsx
+++ b/frontend/src/components/Onboarding/InvestorOnboarding.tsx
@@ -332,7 +332,7 @@ const InvestorProfileStep: React.FC<{
         <Button 
           className="flex-1" 
           onClick={() => {
-            navigate(INVESTOR_ROUTES.settings);
+            void navigate(INVESTOR_ROUTES.settings);
             onComplete();
           }}
         >
@@ -392,7 +392,7 @@ const BrowsePitchesStep: React.FC<{
         <Button 
           className="flex-1" 
           onClick={() => {
-            navigate(INVESTOR_ROUTES.discover);
+            void navigate(INVESTOR_ROUTES.discover);
             onComplete();
           }}
         >
@@ -532,7 +532,7 @@ const PortfolioManagementStep: React.FC<{
         <Button 
           variant="outline" 
           onClick={() => {
-            navigate(INVESTOR_ROUTES.portfolio);
+            void navigate(INVESTOR_ROUTES.portfolio);
             onComplete();
           }}
         >

--- a/frontend/src/components/Onboarding/ProductionOnboarding.tsx
+++ b/frontend/src/components/Onboarding/ProductionOnboarding.tsx
@@ -340,7 +340,7 @@ const CompanySetupStep: React.FC<{
         <Button 
           className="flex-1" 
           onClick={() => {
-            navigate('/production/settings/profile');
+            void navigate('/production/settings/profile');
             onComplete();
           }}
         >
@@ -409,7 +409,7 @@ const SubmissionProcessStep: React.FC<{
         <Button 
           className="flex-1" 
           onClick={() => {
-            navigate(PRODUCTION_ROUTES.activity);
+            void navigate(PRODUCTION_ROUTES.activity);
             onComplete();
           }}
         >
@@ -564,7 +564,7 @@ const PipelineManagementStep: React.FC<{
         <Button 
           variant="outline" 
           onClick={() => {
-            navigate('/production/dashboard');
+            void navigate('/production/dashboard');
             onComplete();
           }}
         >

--- a/frontend/src/components/portfolio/CreatorHeader.tsx
+++ b/frontend/src/components/portfolio/CreatorHeader.tsx
@@ -50,7 +50,7 @@ const CreatorHeader: React.FC<CreatorHeaderProps> = ({ creator, isOwnProfile = f
   };
 
   const handleEditProfile = () => {
-    navigate('/profile');
+    void navigate('/profile');
   };
   return (
     <div className="bg-white rounded-2xl shadow-xl p-8 mb-8">

--- a/frontend/src/components/portfolio/ProfileHeader.tsx
+++ b/frontend/src/components/portfolio/ProfileHeader.tsx
@@ -55,7 +55,7 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({ profile, isOwnProfile = f
   };
 
   const handleEditProfile = () => {
-    navigate('/profile');
+    void navigate('/profile');
   };
 
   // Get display text based on user type

--- a/frontend/src/features/browse/components/FollowButton.tsx
+++ b/frontend/src/features/browse/components/FollowButton.tsx
@@ -71,7 +71,7 @@ const FollowButton: React.FC<FollowButtonProps> = ({
 
   const handleFollow = useCallback(async () => {
     if (!isAuthenticated) {
-      navigate('/login');
+      void navigate('/login');
       return;
     }
 

--- a/frontend/src/features/browse/components/Search/SavedSearches.tsx
+++ b/frontend/src/features/browse/components/Search/SavedSearches.tsx
@@ -62,7 +62,7 @@ export const SavedSearches: React.FC<SavedSearchesProps> = ({
     if (search.search_query) params.set('mandate', search.search_query);
     if (genres.length) params.set('genres', genres.join(','));
     if (fmt.length) params.set('formats', fmt.join(','));
-    navigate(`/opportunities?${params.toString()}`);
+    void navigate(`/opportunities?${params.toString()}`);
   };
 
   useEffect(() => {

--- a/frontend/src/features/deals/components/Investment/InvestmentHistory.tsx
+++ b/frontend/src/features/deals/components/Investment/InvestmentHistory.tsx
@@ -101,7 +101,7 @@ export default function InvestmentHistory({
     if (onInvestmentClick) {
       onInvestmentClick(investment);
     } else {
-      navigate(`/investment/${investment.id}`);
+      void navigate(`/investment/${investment.id}`);
     }
   };
 

--- a/frontend/src/features/notifications/components/NotificationBellSafe.tsx
+++ b/frontend/src/features/notifications/components/NotificationBellSafe.tsx
@@ -43,7 +43,7 @@ function NotificationBellSafe({
   const handleBellClick = () => {
     try {
       setIsAnimating(true);
-      navigate('/notifications');
+      void navigate('/notifications');
       setTimeout(() => setIsAnimating(false), 300);
     } catch (error) {
       console.warn('NotificationBell: Navigation error:', error);

--- a/frontend/src/pages/AcceptInvitePage.tsx
+++ b/frontend/src/pages/AcceptInvitePage.tsx
@@ -26,7 +26,7 @@ export default function AcceptInvitePage() {
 
     if (!isAuthenticated) {
       const redirect = `/collaborate/accept?token=${encodeURIComponent(token)}`;
-      navigate(`/register?redirect=${encodeURIComponent(redirect)}`, { replace: true });
+      void navigate(`/register?redirect=${encodeURIComponent(redirect)}`, { replace: true });
       return;
     }
 

--- a/frontend/src/pages/AdvancedSearch.tsx
+++ b/frontend/src/pages/AdvancedSearch.tsx
@@ -234,11 +234,11 @@ export default function AdvancedSearch() {
 
   const handleResultClick = (result: SearchResult) => {
     if (result.type === 'pitch') {
-      navigate(`/pitch/${result.id}`);
+      void navigate(`/pitch/${result.id}`);
     } else if (result.type === 'creator') {
-      navigate(`/creator/${result.id}`);
+      void navigate(`/creator/${result.id}`);
     } else if (result.type === 'production') {
-      navigate(`/production/company/${result.id}`);
+      void navigate(`/production/company/${result.id}`);
     }
   };
 

--- a/frontend/src/pages/Billing.tsx
+++ b/frontend/src/pages/Billing.tsx
@@ -157,7 +157,7 @@ export default function Billing() {
                     onClick={() => {
                       const params = new URLSearchParams(searchParams);
                       params.set('tab', tab.id);
-                      navigate(`?${params.toString()}`, { replace: true });
+                      void navigate(`?${params.toString()}`, { replace: true });
                     }}
                     className={`flex items-center gap-2 py-4 border-b-2 font-medium text-sm transition-colors whitespace-nowrap shrink-0 ${
                       activeTab === tab.id

--- a/frontend/src/pages/ComparePage.tsx
+++ b/frontend/src/pages/ComparePage.tsx
@@ -355,7 +355,7 @@ export default function ComparePage() {
   const inPortalPath = (isAuthenticated && ['creator', 'investor', 'production'].includes(portalSeg)) ? `/${portalSeg}/compare` : null;
   useEffect(() => {
     if (!isInsidePortal && inPortalPath) {
-      navigate(`${inPortalPath}${location.search}`, { replace: true });
+      void navigate(`${inPortalPath}${location.search}`, { replace: true });
     }
   }, [isInsidePortal, inPortalPath, location.search, navigate]);
 

--- a/frontend/src/pages/Contact.tsx
+++ b/frontend/src/pages/Contact.tsx
@@ -42,7 +42,7 @@ export default function Contact() {
       }
       setSubmitted(true);
       setTimeout(() => {
-        navigate('/');
+        void navigate('/');
       }, 3000);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to send message. Please try again.');

--- a/frontend/src/pages/CreatePitch.tsx
+++ b/frontend/src/pages/CreatePitch.tsx
@@ -528,7 +528,7 @@ export default function CreatePitch() {
         }
 
         // PHASE 4: Navigate only after everything completes
-        navigate(isProduction ? '/production/pitches' : '/creator/pitches');
+        void navigate(isProduction ? '/production/pitches' : '/creator/pitches');
       } catch (err: any) {
         console.error('Error creating pitch:', err);
         const errorMessage = err.message || ERROR_MESSAGES?.UNEXPECTED_ERROR || 'An unexpected error occurred';

--- a/frontend/src/pages/CreatorProfile.tsx
+++ b/frontend/src/pages/CreatorProfile.tsx
@@ -199,7 +199,7 @@ const CreatorProfile = () => {
   };
 
   const handleContactCreator = () => {
-    navigate(`/messages?recipient=${creator?.id}`);
+    void navigate(`/messages?recipient=${creator?.id}`);
   };
 
   const handleShareProfile = () => {

--- a/frontend/src/pages/EmailOTPLogin.tsx
+++ b/frontend/src/pages/EmailOTPLogin.tsx
@@ -86,7 +86,7 @@ export default function EmailOTPLogin() {
       sessionManager.updateCache(user);
       setUser(user);
       toast.success('Signed in successfully');
-      navigate(resolvePostLoginRedirect(rawFrom, `/${getPortalPath(user.userType)}/dashboard`), { replace: true });
+      void navigate(resolvePostLoginRedirect(rawFrom, `/${getPortalPath(user.userType)}/dashboard`), { replace: true });
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
       setError(e.message);

--- a/frontend/src/pages/Following.tsx
+++ b/frontend/src/pages/Following.tsx
@@ -776,7 +776,7 @@ const Following: React.FC = () => {
             <div className="flex items-center gap-4">
               <button 
                 onClick={() => {
-                  navigate(userType ? `/${getPortalPath(userType)}/dashboard` : '/');
+                  void navigate(userType ? `/${getPortalPath(userType)}/dashboard` : '/');
                 }}
                 className="p-2 hover:bg-gray-100 rounded-lg transition"
               >

--- a/frontend/src/pages/Homepage.tsx
+++ b/frontend/src/pages/Homepage.tsx
@@ -38,18 +38,18 @@ export default function Homepage() {
   // signed-out visitors go to portal select to sign in/up.
   const handleCreatePitch = () => {
     if (!isAuthenticated) {
-      navigate('/login');
+      void navigate('/login');
       return;
     }
     switch (userType) {
       case 'creator':
-        navigate('/creator/pitch/new');
+        void navigate('/creator/pitch/new');
         break;
       case 'production':
-        navigate('/production/pitch/new');
+        void navigate('/production/pitch/new');
         break;
       default:
-        navigate(getDashboardRoute(userType));
+        void navigate(getDashboardRoute(userType));
     }
   };
 
@@ -172,7 +172,7 @@ export default function Homepage() {
             onSubmit={(e) => {
               e.preventDefault();
               if (searchQuery.trim()) {
-                navigate(`/marketplace?search=${encodeURIComponent(searchQuery.trim())}`);
+                void navigate(`/marketplace?search=${encodeURIComponent(searchQuery.trim())}`);
               }
             }}
             className="max-w-xl mx-auto mb-8 flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.06] backdrop-blur p-1.5 transition focus-within:border-white/35 focus-within:bg-white/[0.09]"

--- a/frontend/src/pages/InvestorBrowse.tsx
+++ b/frontend/src/pages/InvestorBrowse.tsx
@@ -274,11 +274,11 @@ export default function InvestorBrowse() {
   const handleScheduleMeeting = (pitch: Pitch) => {
     const recipientId = pitch.creator?.id || (pitch as any).user_id || '';
     if (!recipientId) return;
-    navigate(`/investor/messages?recipient=${recipientId}&subject=${encodeURIComponent(pitch.title)}`);
+    void navigate(`/investor/messages?recipient=${recipientId}&subject=${encodeURIComponent(pitch.title)}`);
   };
 
   const handleMakeOffer = (pitch: Pitch) => {
-    navigate(`/investor/invest/${pitch.id}`);
+    void navigate(`/investor/invest/${pitch.id}`);
   };
 
   if (currentTabState.loading && currentTabState.pitches.length === 0) {

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -187,7 +187,7 @@ export default function Login() {
                     key={portal.id}
                     onClick={() => {
                       if (portal.route) {
-                        navigate(portal.route, isSafeReturnPath(rawFrom) ? { state: { from: rawFrom } } : undefined);
+                        void navigate(portal.route, isSafeReturnPath(rawFrom) ? { state: { from: rawFrom } } : undefined);
                       } else {
                         setSelectedPortal(portal.id as 'creator' | 'investor' | 'production');
                       }

--- a/frontend/src/pages/MFAChallengePage.tsx
+++ b/frontend/src/pages/MFAChallengePage.tsx
@@ -27,7 +27,7 @@ export default function MFAChallengePage() {
 
   useEffect(() => {
     if (!challengeId) {
-      navigate('/login/' + getPortalPath(userType), { replace: true });
+      void navigate('/login/' + getPortalPath(userType), { replace: true });
     }
     inputRef.current?.focus();
   }, [challengeId, navigate, userType]);
@@ -63,7 +63,7 @@ export default function MFAChallengePage() {
 
       toast.success('Verified successfully');
       const dest = resolvePostLoginRedirect(fromParam, `/${getPortalPath(user.userType)}/dashboard`);
-      navigate(dest, { replace: true });
+      void navigate(dest, { replace: true });
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
       setError(e.message || 'Verification failed');

--- a/frontend/src/pages/MarketplaceEnhanced.tsx
+++ b/frontend/src/pages/MarketplaceEnhanced.tsx
@@ -209,7 +209,7 @@ export default function MarketplaceEnhanced() {
   const shouldRedirectIntoPortal = !isInsidePortal && isAuthenticated && inPortalBrowsePath !== '/marketplace';
   useEffect(() => {
     if (shouldRedirectIntoPortal) {
-      navigate(`${inPortalBrowsePath}${location.search}`, { replace: true });
+      void navigate(`${inPortalBrowsePath}${location.search}`, { replace: true });
     }
   }, [shouldRedirectIntoPortal, inPortalBrowsePath, location.search, navigate]);
 

--- a/frontend/src/pages/NotificationCenter.tsx
+++ b/frontend/src/pages/NotificationCenter.tsx
@@ -436,7 +436,7 @@ export default function NotificationCenter() {
                             <div className="flex space-x-2 mt-3">
                               <button
                                 onClick={() => {
-                                  navigate('/creator/ndas');
+                                  void navigate('/creator/ndas');
                                   handleMarkAsRead(notification.id);
                                 }}
                                 className="px-3 py-1 text-xs bg-green-600 text-white rounded hover:bg-green-700 transition-colors"
@@ -445,7 +445,7 @@ export default function NotificationCenter() {
                               </button>
                               <button
                                 onClick={() => {
-                                  navigate('/creator/ndas');
+                                  void navigate('/creator/ndas');
                                   handleMarkAsRead(notification.id);
                                 }}
                                 className="px-3 py-1 text-xs bg-red-600 text-white rounded hover:bg-red-700 transition-colors"
@@ -454,7 +454,7 @@ export default function NotificationCenter() {
                               </button>
                               <button
                                 onClick={() => {
-                                  navigate('/creator/ndas');
+                                  void navigate('/creator/ndas');
                                   handleMarkAsRead(notification.id);
                                 }}
                                 className="px-3 py-1 text-xs bg-gray-200 text-gray-700 rounded hover:bg-gray-300 transition-colors"
@@ -469,7 +469,7 @@ export default function NotificationCenter() {
                             <div className="flex space-x-2 mt-3">
                               <button
                                 onClick={() => {
-                                  navigate('/investor/all-investments');
+                                  void navigate('/investor/all-investments');
                                   handleMarkAsRead(notification.id);
                                 }}
                                 className="px-3 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"

--- a/frontend/src/pages/OpportunitiesBoard.tsx
+++ b/frontend/src/pages/OpportunitiesBoard.tsx
@@ -561,7 +561,7 @@ export default function OpportunitiesBoard() {
   const inPortalPath = ['creator', 'investor', 'production'].includes(portalSeg) ? `/${portalSeg}/opportunities` : null;
   useEffect(() => {
     if (!isInsidePortal && inPortalPath) {
-      navigate(`${inPortalPath}${location.search}`, { replace: true });
+      void navigate(`${inPortalPath}${location.search}`, { replace: true });
     }
   }, [isInsidePortal, inPortalPath, location.search, navigate]);
 
@@ -590,7 +590,7 @@ export default function OpportunitiesBoard() {
       setShowPost(true);
     }
     // strip the consumed params either way (canPost or not)
-    navigate(location.pathname, { replace: true });
+    void navigate(location.pathname, { replace: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isInsidePortal, inPortalPath, location.search, canPost]);
   const [loading, setLoading] = useState(true);

--- a/frontend/src/pages/PitchEdit.tsx
+++ b/frontend/src/pages/PitchEdit.tsx
@@ -493,7 +493,7 @@ export default function PitchEdit() {
       } else {
         toast.success('Changes saved');
       }
-      navigate(pitchesListPath);
+      void navigate(pitchesListPath);
     } catch (error) {
       console.error('Error updating pitch:', error);
       toast.error(error instanceof Error ? error.message : 'Failed to update pitch');

--- a/frontend/src/pages/ProductionDashboard.tsx
+++ b/frontend/src/pages/ProductionDashboard.tsx
@@ -144,7 +144,7 @@ function ProductionDashboard() {
   // Handle logout
   const handleLogout = async () => {
     await logout();
-    navigate('/');
+    void navigate('/');
   };
 
   // NDA Template Upload State
@@ -175,7 +175,7 @@ function ProductionDashboard() {
   // Redirect to login if not authenticated after session check
   useEffect(() => {
     if (sessionChecked && !isAuthenticated) {
-      navigate('/login/production');
+      void navigate('/login/production');
     }
   }, [sessionChecked, isAuthenticated, navigate]);
 

--- a/frontend/src/pages/ProductionPitchCreate.tsx
+++ b/frontend/src/pages/ProductionPitchCreate.tsx
@@ -455,7 +455,7 @@ export default function ProductionPitchCreate() {
       setCurrentDraft(null);
       
       // Navigate to dashboard
-      navigate('/production/dashboard');
+      void navigate('/production/dashboard');
     } catch (error) {
       console.error('Error creating pitch:', error);
       alert('Failed to create pitch. Please try again.');

--- a/frontend/src/pages/ResetPassword.tsx
+++ b/frontend/src/pages/ResetPassword.tsx
@@ -77,7 +77,7 @@ export default function ResetPassword() {
       setSuccess(true);
       // Redirect to login after 3 seconds
       setTimeout(() => {
-        navigate('/login');
+        void navigate('/login');
       }, 3000);
     } catch (error: any) {
       setError(error.response?.data?.error || 'Failed to reset password. The link may be expired.');

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -210,7 +210,7 @@ export default function Settings() {
       if (response.ok) {
         toast.success('Your account has been deleted.');
         logout();
-        navigate('/');
+        void navigate('/');
       } else {
         const data = await response.json().catch(() => ({} as { error?: string }));
         toast.error(data?.error || 'Failed to delete account. Please try again.');

--- a/frontend/src/pages/UserPortfolio.tsx
+++ b/frontend/src/pages/UserPortfolio.tsx
@@ -148,7 +148,7 @@ const UserPortfolio: React.FC = () => {
   };
 
   const handleGoBack = () => {
-    navigate(-1);
+    void navigate(-1);
   };
 
   const handleBackToDashboard = () => {
@@ -156,13 +156,13 @@ const UserPortfolio: React.FC = () => {
     // Navigate to appropriate dashboard based on user type
     switch (userType) {
       case 'production':
-        navigate('/production/dashboard');
+        void navigate('/production/dashboard');
         break;
       case 'investor':
-        navigate('/investor/dashboard');
+        void navigate('/investor/dashboard');
         break;
       default:
-        navigate('/creator/dashboard');
+        void navigate('/creator/dashboard');
     }
   };
 

--- a/frontend/src/pages/VerifyEmail.tsx
+++ b/frontend/src/pages/VerifyEmail.tsx
@@ -35,7 +35,7 @@ export default function VerifyEmail() {
       setVerified(true);
       // Redirect to login after 3 seconds
       setTimeout(() => {
-        navigate('/login');
+        void navigate('/login');
       }, 3000);
     } catch (error: any) {
       setError(error.response?.data?.error || 'Failed to verify email. The link may be expired.');
@@ -53,7 +53,7 @@ export default function VerifyEmail() {
       const email = localStorage.getItem('pendingVerificationEmail');
       if (!email) {
         setError('Please log in to resend verification email');
-        navigate('/login');
+        void navigate('/login');
         return;
       }
       

--- a/frontend/src/portals/creator/pages/CreatorPitchView.tsx
+++ b/frontend/src/portals/creator/pages/CreatorPitchView.tsx
@@ -206,7 +206,7 @@ const CreatorPitchView: React.FC = () => {
   };
 
   const handleEdit = () => {
-    navigate(`/creator/pitches/${id}/edit`);
+    void navigate(`/creator/pitches/${id}/edit`);
   };
 
   // Respond to a producer's pitch-scoped collaboration proposal. On accept, the
@@ -236,7 +236,7 @@ const CreatorPitchView: React.FC = () => {
     if (window.confirm('Are you sure you want to delete this pitch? This action cannot be undone.')) {
       try {
         await pitchAPI.delete(parseInt(id!));
-        navigate('/creator/pitches');
+        void navigate('/creator/pitches');
       } catch (error) {
         console.error('Failed to delete pitch:', error);
       }

--- a/frontend/src/portals/creator/pages/CreatorPitchesPublished.tsx
+++ b/frontend/src/portals/creator/pages/CreatorPitchesPublished.tsx
@@ -353,7 +353,7 @@ export default function CreatorPitchesPublished() {
                     <button
                       onClick={(e) => {
                         e.stopPropagation();
-                        navigate(`/creator/pitch/${pitch.id}/edit`);
+                        void navigate(`/creator/pitch/${pitch.id}/edit`);
                       }}
                       className="flex-1 flex items-center justify-center gap-2 px-3 py-2 bg-purple-50 text-purple-600 rounded-lg hover:bg-purple-100 transition"
                     >
@@ -363,7 +363,7 @@ export default function CreatorPitchesPublished() {
                     <button
                       onClick={(e) => {
                         e.stopPropagation();
-                        navigate(`/creator/pitch/${pitch.id}/analytics`);
+                        void navigate(`/creator/pitch/${pitch.id}/analytics`);
                       }}
                       className="flex-1 flex items-center justify-center gap-2 px-3 py-2 bg-blue-50 text-blue-600 rounded-lg hover:bg-blue-100 transition"
                     >

--- a/frontend/src/portals/creator/pages/CreatorSlates.tsx
+++ b/frontend/src/portals/creator/pages/CreatorSlates.tsx
@@ -44,7 +44,7 @@ export default function CreatorSlates() {
       setNewDescription('');
       setShowCreate(false);
       toast.success(`Slate "${slate.title}" created`);
-      navigate(`/creator/slates/${slate.id}`);
+      void navigate(`/creator/slates/${slate.id}`);
     } else {
       toast.error('Couldn\'t create the slate. Please try again.');
     }

--- a/frontend/src/portals/investor/pages/InvestorPitchView.tsx
+++ b/frontend/src/portals/investor/pages/InvestorPitchView.tsx
@@ -221,7 +221,7 @@ const InvestorPitchView: React.FC = () => {
 
   const handleContactCreator = () => {
     if (!pitch?.userId) return;
-    navigate(`/investor/messages?recipient=${pitch.userId}&pitch=${id}`);
+    void navigate(`/investor/messages?recipient=${pitch.userId}&pitch=${id}`);
   };
 
   const [ndaRequesting, setNdaRequesting] = useState(false);

--- a/frontend/src/portals/investor/pages/InvestorWallet.tsx
+++ b/frontend/src/portals/investor/pages/InvestorWallet.tsx
@@ -283,7 +283,7 @@ const InvestorWallet = () => {
       wsRef.current.close();
     }
     logout();
-    navigate('/');
+    void navigate('/');
   };
 
   const handleDeposit = () => {

--- a/frontend/src/portals/investor/pages/NDARequests.tsx
+++ b/frontend/src/portals/investor/pages/NDARequests.tsx
@@ -80,7 +80,7 @@ export default function NDARequests() {
   // Redirect to login if not authenticated
   useEffect(() => {
     if (sessionChecked && !isAuthenticated) {
-      navigate('/login/investor');
+      void navigate('/login/investor');
     }
   }, [sessionChecked, isAuthenticated, navigate]);
 
@@ -155,7 +155,7 @@ export default function NDARequests() {
   // View NDA — navigate to pitch detail
   const handleViewNDA = (request: NDARequest) => {
     const targetId = request.pitchId || request.id;
-    navigate(`/investor/pitch/${targetId}`);
+    void navigate(`/investor/pitch/${targetId}`);
   };
 
   // Download NDA document
@@ -212,7 +212,7 @@ export default function NDARequests() {
   // Access protected content — navigate to pitch
   const handleAccessContent = (request: NDARequest) => {
     const targetId = request.pitchId || request.id;
-    navigate(`/investor/pitch/${targetId}`);
+    void navigate(`/investor/pitch/${targetId}`);
   };
 
   const filteredRequests = ndaRequests

--- a/frontend/src/portals/investor/pages/PendingDeals.tsx
+++ b/frontend/src/portals/investor/pages/PendingDeals.tsx
@@ -230,7 +230,7 @@ const PendingDeals = () => {
   const handleLogout = async () => {
     try {
       await logout();
-      navigate('/login/investor');
+      void navigate('/login/investor');
     } catch (error) {
       console.error('Logout failed:', error);
     }

--- a/frontend/src/portals/investor/pages/PerformanceTracking.tsx
+++ b/frontend/src/portals/investor/pages/PerformanceTracking.tsx
@@ -205,7 +205,7 @@ const PerformanceTracking = () => {
   const handleLogout = async () => {
     try {
       await logout();
-      navigate('/login/investor');
+      void navigate('/login/investor');
     } catch (error) {
       console.error('Logout failed:', error);
     }

--- a/frontend/src/portals/investor/pages/ROIAnalysis.tsx
+++ b/frontend/src/portals/investor/pages/ROIAnalysis.tsx
@@ -124,7 +124,7 @@ const ROIAnalysis = () => {
   const handleLogout = async () => {
     try {
       await logout();
-      navigate('/login/investor');
+      void navigate('/login/investor');
     } catch (error) {
       console.error('Logout failed:', error);
     }

--- a/frontend/src/portals/investor/pages/TaxDocuments.tsx
+++ b/frontend/src/portals/investor/pages/TaxDocuments.tsx
@@ -46,7 +46,7 @@ const TaxDocuments = () => {
   const handleLogout = async () => {
     try {
       await logout();
-      navigate('/login/investor');
+      void navigate('/login/investor');
     } catch (error) {
       console.error('Logout failed:', error);
     }

--- a/frontend/src/portals/production/pages/ProductionPitchView.tsx
+++ b/frontend/src/portals/production/pages/ProductionPitchView.tsx
@@ -414,7 +414,7 @@ const ProductionPitchView: React.FC = () => {
   };
 
   const handleContactCreator = () => {
-    navigate(`/production/messages?recipient=${pitch?.userId}&pitch=${id}`);
+    void navigate(`/production/messages?recipient=${pitch?.userId}&pitch=${id}`);
   };
 
   // Propose a pitch-scoped collaboration to the creator. On accept (their side)

--- a/frontend/src/portals/production/pages/ProductionSaved.tsx
+++ b/frontend/src/portals/production/pages/ProductionSaved.tsx
@@ -365,7 +365,7 @@ export default function ProductionSaved() {
                         size="sm"
                         onClick={(e) => {
                           e.stopPropagation();
-                          navigate(`/production/messages?pitch=${pitch.id}`);
+                          void navigate(`/production/messages?pitch=${pitch.id}`);
                         }}
                       >
                         <MessageSquare className="w-4 h-4" />
@@ -375,7 +375,7 @@ export default function ProductionSaved() {
                         size="sm"
                         onClick={(e) => {
                           e.stopPropagation();
-                          navigate(`/production/pitch/${pitch.id}`);
+                          void navigate(`/production/pitch/${pitch.id}`);
                         }}
                       >
                         <MoreVertical className="w-4 h-4" />

--- a/frontend/src/portals/production/pages/ProductionSubmissionsAccepted.tsx
+++ b/frontend/src/portals/production/pages/ProductionSubmissionsAccepted.tsx
@@ -109,11 +109,11 @@ export default function ProductionSubmissionsAccepted() {
   const genres = ['all', ...new Set(submissions.map(s => s.genre))];
 
   const handleViewProject = (submissionId: string) => {
-    navigate(`/production/projects/${submissionId}`);
+    void navigate(`/production/projects/${submissionId}`);
   };
 
   const handleManageProduction = (submissionId: string) => {
-    navigate(`/production/projects/${submissionId}`);
+    void navigate(`/production/projects/${submissionId}`);
   };
 
   const handleViewContract = (submissionId: string) => {

--- a/frontend/src/portals/production/pages/ProductionSubmissionsRejected.tsx
+++ b/frontend/src/portals/production/pages/ProductionSubmissionsRejected.tsx
@@ -136,7 +136,7 @@ export default function ProductionSubmissionsRejected() {
   };
 
   const handleSendFeedback = (submission: Submission) => {
-    navigate(`/production/messages?to=${encodeURIComponent(submission.creatorEmail)}&subject=${encodeURIComponent('Feedback: ' + submission.title)}&body=${encodeURIComponent('Thank you for your submission. We wanted to provide feedback on your pitch.')}`);
+    void navigate(`/production/messages?to=${encodeURIComponent(submission.creatorEmail)}&subject=${encodeURIComponent('Feedback: ' + submission.title)}&body=${encodeURIComponent('Thank you for your submission. We wanted to provide feedback on your pitch.')}`);
   };
 
   const getRejectionCategoryColor = (category: string) => {

--- a/frontend/src/portals/watcher/pages/WatcherDashboard.tsx
+++ b/frontend/src/portals/watcher/pages/WatcherDashboard.tsx
@@ -97,7 +97,7 @@ export default function WatcherDashboard() {
 
   useEffect(() => {
     if (!isAuthenticated) {
-      navigate('/login/watcher');
+      void navigate('/login/watcher');
       return;
     }
     fetchDashboardData();

--- a/frontend/src/portals/watcher/pages/WatcherLibrary.tsx
+++ b/frontend/src/portals/watcher/pages/WatcherLibrary.tsx
@@ -101,7 +101,7 @@ export default function WatcherLibrary() {
 
   useEffect(() => {
     if (!isAuthenticated) {
-      navigate('/login/watcher');
+      void navigate('/login/watcher');
       return;
     }
     void fetchLibrary();

--- a/frontend/src/shared/components/layout/BreadcrumbNav.tsx
+++ b/frontend/src/shared/components/layout/BreadcrumbNav.tsx
@@ -59,7 +59,7 @@ export function BreadcrumbNav({ items, showBackButton = true }: BreadcrumbNavPro
 
   const handleBack = () => {
     const portal = location.pathname.split('/')[1];
-    navigate(`/${portal}/dashboard`);
+    void navigate(`/${portal}/dashboard`);
   };
 
   return (

--- a/frontend/src/shared/components/layout/MinimalHeader.tsx
+++ b/frontend/src/shared/components/layout/MinimalHeader.tsx
@@ -74,7 +74,7 @@ export function MinimalHeader({ onMenuToggle, isSidebarOpen = true, userType }: 
 
   const handleLogout = async () => {
     await logout();
-    navigate('/');
+    void navigate('/');
   };
 
   // Portal theme — single source of truth for color accents. See usePortalTheme.

--- a/frontend/src/shared/components/layout/PortalTopNav.tsx
+++ b/frontend/src/shared/components/layout/PortalTopNav.tsx
@@ -96,7 +96,7 @@ export default function PortalTopNav() {
 
   const handleLogout = async () => {
     await logout();
-    navigate('/');
+    void navigate('/');
   };
 
   return (

--- a/scripts/frontend-lint-gate.mjs
+++ b/scripts/frontend-lint-gate.mjs
@@ -28,7 +28,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 // ── The baseline. Lower it (never raise it) as frontend lint errors are fixed. ──
-const BASELINE = 8371;
+const BASELINE = 8283;
 // 2026-06-27: created at the measured floor (8908 errors / 184 warnings). Top
 // rules: no-unsafe-member-access, no-unsafe-assignment, no-explicit-any,
 // no-unused-vars, no-misused-promises. The gate blocks any NEW error.
@@ -46,6 +46,10 @@ const BASELINE = 8371;
 // investment.service (Raw* shapes + response generics; fixed investmentDate Date→
 // string drift), pitch.service (added missing RawPitchData fields + raw response
 // arrays). Same input-typing/loose-return pattern; zero cascade, full suite green.
+// 2026-06-28: lowered 8371 -> 8283 (-88). C1a: voided bare `navigate(...)` floating
+// promises (React Router v6 navigate returns a Promise) across 53 files. `void` is
+// behavior-preserving — the promise was already floating; you never await navigation
+// in a handler. Start of the promise-handling (C1) hardening workstream.
 
 const LIST = process.argv.includes('--list');
 


### PR DESCRIPTION
First slice of the **promise-handling workstream (C1)** — the hardening pass over `no-floating-promises` / `no-misused-promises` ([#384](https://github.com/WizardryPro/pitchey-app/issues/384)).

React Router v6's `navigate()` returns a `Promise`, so bare `navigate(...)` statements trip `no-floating-promises`. Marked the **88 bare-statement cases across 53 files** with the `void` operator (applied precisely via eslint's own line numbers, only to `^\s*navigate(...);$` statements — never assignments/returns/awaits).

**`void` is behavior-preserving** — the promise was already floating (unawaited), and navigation is never awaited inside a click/effect handler. `void` just makes the fire-and-forget intent explicit and satisfies the rule. (The ~14 multi-line / non-statement `navigate` forms are left for a follow-up slice.)

### Result
- **88 lint errors cleared** (8371 → 8283)
- app `tsc` clean (0 errors), **full frontend suite green (5211 tests)**
- baseline ratcheted to **8283**

🤖 Generated with [Claude Code](https://claude.com/claude-code)