### PR TITLE
chore(lint): scope no-misused-promises to exclude JSX attributes (C1c)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -110,7 +110,7 @@ export default [
 
       // Keep promise safety in tests
       '@typescript-eslint/no-floating-promises': 'error',
-      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/no-misused-promises': ['error', { checksVoidReturn: { attributes: false } }],
       '@typescript-eslint/await-thenable': 'error',
       '@typescript-eslint/prefer-as-const': 'error',
     },
@@ -155,7 +155,7 @@ export default [
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/require-await': 'error',
       '@typescript-eslint/await-thenable': 'error',
-      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/no-misused-promises': ['error', { checksVoidReturn: { attributes: false } }],
       '@typescript-eslint/prefer-as-const': 'error',
     },
     settings: {

--- a/scripts/frontend-lint-gate.mjs
+++ b/scripts/frontend-lint-gate.mjs
@@ -28,7 +28,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 // ── The baseline. Lower it (never raise it) as frontend lint errors are fixed. ──
-const BASELINE = 8283;
+const BASELINE = 7727;
 // 2026-06-27: created at the measured floor (8908 errors / 184 warnings). Top
 // rules: no-unsafe-member-access, no-unsafe-assignment, no-explicit-any,
 // no-unused-vars, no-misused-promises. The gate blocks any NEW error.
@@ -50,6 +50,10 @@ const BASELINE = 8283;
 // promises (React Router v6 navigate returns a Promise) across 53 files. `void` is
 // behavior-preserving — the promise was already floating; you never await navigation
 // in a handler. Start of the promise-handling (C1) hardening workstream.
+// 2026-06-28: lowered 8283 -> 7727 (-556). C1c: narrowed no-misused-promises with
+// checksVoidReturn.attributes:false (eslint.config.js) — async JSX event handlers
+// are idiomatic, safe React (React discards the return). Rule stays ON for timers,
+// callbacks, object handlers (26 genuine cases remain → C1c-residual follow-up).
 
 const LIST = process.argv.includes('--list');
 


### PR DESCRIPTION
Workstream **C1c** ([#384](https://github.com/WizardryPro/pitchey-app/issues/384)) — the async JSX event-handler portion of `no-misused-promises`.

Async JSX handlers (`onClick={async () => …}`) are **idiomatic, safe React** — React discards the handler's return, so a returned promise is harmless by React's contract. The rule's default flagged **~561** of these (noise, not signal).

Sets `checksVoidReturn: { attributes: false }` on both rule sites in `eslint.config.js`.

### Why this is scope-narrowing, not laundering
The rule stays **ON** for the cases that are genuinely bugs: timer callbacks (`setInterval`/`setTimeout` with async fns), object-literal handlers, and `new Promise(async executor)`. **26 genuine cases remain flagged** → fixed per-site in a **C1c-residual** follow-up. (Decision made with the user; the alternative — mechanically wrapping 561 handlers — adds the same zero rejection-handling for a massive noisy diff.)

True per-handler `.catch()` hardening (surfacing failures on money/NDA paths) is tracked separately.

### Result
- **556 lint errors cleared** (8283 → 7727)
- eslint-config-only — **no runtime impact**, `tsc` clean (0 errors)
- baseline ratcheted to **7727**

🤖 Generated with [Claude Code](https://claude.com/claude-code)