### PR TITLE
chore(lint): void bare floating promises (C1b-1)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -332,7 +332,7 @@ function App() {
         setConfigLoaded(true);
       }
     };
-    loadConfig();
+    void loadConfig();
   }, []);
 
   // Initialize app with proper session verification

--- a/frontend/src/components/CollaborationTimeline.tsx
+++ b/frontend/src/components/CollaborationTimeline.tsx
@@ -40,7 +40,7 @@ export default function CollaborationTimeline({ collaborationId }: Collaboration
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetchTimeline();
+    void fetchTimeline();
   }, [collaborationId]);
 
   async function fetchTimeline() {

--- a/frontend/src/components/Dashboard/NotificationWidgetSafe.tsx
+++ b/frontend/src/components/Dashboard/NotificationWidgetSafe.tsx
@@ -57,7 +57,7 @@ function NotificationWidgetSafe({
       }
     };
 
-    loadNotifications();
+    void loadNotifications();
   }, [maxNotifications]);
 
   const markAsRead = async (notificationId: string) => {
@@ -206,7 +206,7 @@ function NotificationWidgetSafe({
                           onClick={() => {
                             try {
                               action.action();
-                              markAsRead(notification.id);
+                              void markAsRead(notification.id);
                             } catch (err) {
                               console.warn('Notification action error:', err);
                             }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -22,7 +22,7 @@ export default function Layout({ children }: LayoutProps) {
   useRealTimeNotifications();
 
   const handleLogout = () => {
-    logout();
+    void logout();
     void navigate('/login');
   };
 

--- a/frontend/src/components/Legal/DocumentComparisonTool.tsx
+++ b/frontend/src/components/Legal/DocumentComparisonTool.tsx
@@ -106,7 +106,7 @@ const DocumentComparisonTool: React.FC = () => {
 
   // Load available documents
   useEffect(() => {
-    loadDocuments();
+    void loadDocuments();
   }, []);
 
   const loadDocuments = useCallback(async () => {

--- a/frontend/src/components/Legal/LegalDocumentDashboard.tsx
+++ b/frontend/src/components/Legal/LegalDocumentDashboard.tsx
@@ -42,7 +42,7 @@ const LegalDocumentDashboard: React.FC = () => {
   const ITEMS_PER_PAGE = 10;
 
   useEffect(() => {
-    loadDocuments();
+    void loadDocuments();
   }, [currentPage, statusFilter, typeFilter, complianceFilter, jurisdictionFilter]);
 
   const loadDocuments = useCallback(async () => {

--- a/frontend/src/components/Legal/LegalDocumentWizard.tsx
+++ b/frontend/src/components/Legal/LegalDocumentWizard.tsx
@@ -123,8 +123,8 @@ const LegalDocumentWizard: React.FC = () => {
 
   // Load initial data
   useEffect(() => {
-    loadTemplates();
-    loadJurisdictions();
+    void loadTemplates();
+    void loadJurisdictions();
   }, []);
 
   const loadTemplates = useCallback(async () => {

--- a/frontend/src/components/Legal/LegalLibrary.tsx
+++ b/frontend/src/components/Legal/LegalLibrary.tsx
@@ -143,8 +143,8 @@ const LegalLibrary: React.FC = () => {
 
   // Load documents
   useEffect(() => {
-    loadDocuments();
-    loadFilterOptions();
+    void loadDocuments();
+    void loadFilterOptions();
   }, [filters, settings.sortBy, settings.sortOrder, currentPage, settings.itemsPerPage]);
 
   // Filter documents locally

--- a/frontend/src/components/Legal/TemplateEditor.tsx
+++ b/frontend/src/components/Legal/TemplateEditor.tsx
@@ -150,7 +150,7 @@ const TemplateEditor: React.FC = () => {
 
   // Load initial data
   useEffect(() => {
-    loadJurisdictions();
+    void loadJurisdictions();
   }, []);
 
   const loadJurisdictions = useCallback(async () => {

--- a/frontend/src/components/feedback/FeedbackSection.tsx
+++ b/frontend/src/components/feedback/FeedbackSection.tsx
@@ -90,7 +90,7 @@ export default function FeedbackSection({ pitchId, isOwner, isAuthenticated, use
   const handleSubmitted = () => {
     setShowForm(false);
     setRefreshKey((k) => k + 1);
-    loadData();
+    void loadData();
   };
 
   const handleQuickRate = async (rating: number) => {
@@ -105,7 +105,7 @@ export default function FeedbackSection({ pitchId, isOwner, isAuthenticated, use
       success('Rating saved', `You rated this pitch ${rating} star${rating === 1 ? '' : 's'}.`);
       // Refresh myFeedback so the structured form seeds with this rating instead of
       // opening with empty stars and forcing the user to pick it again.
-      loadData();
+      void loadData();
     } else {
       error('Couldn\'t save your rating', 'Please try again.');
     }
@@ -118,7 +118,7 @@ export default function FeedbackSection({ pitchId, isOwner, isAuthenticated, use
     setCommentSubmitting(false);
     if (ok) {
       setCommentText('');
-      loadComments();
+      void loadComments();
       success(
         isAnonymous ? 'Comment posted anonymously' : 'Comment posted',
         isAnonymous ? 'Your name is hidden from other viewers.' : undefined,

--- a/frontend/src/components/portfolio/ShareLinksModal.tsx
+++ b/frontend/src/components/portfolio/ShareLinksModal.tsx
@@ -26,7 +26,7 @@ export default function ShareLinksModal({ onClose }: ShareLinksModalProps) {
   const getShareUrl = (token: string) => `${window.location.origin}/portfolio/s/${token}`;
 
   useEffect(() => {
-    fetchLinks();
+    void fetchLinks();
   }, []);
 
   async function fetchLinks() {
@@ -80,7 +80,7 @@ export default function ShareLinksModal({ onClose }: ShareLinksModalProps) {
   }
 
   function handleCopy(link: ShareLink) {
-    navigator.clipboard.writeText(getShareUrl(link.token));
+    void navigator.clipboard.writeText(getShareUrl(link.token));
     setCopiedId(link.id);
     setTimeout(() => setCopiedId(null), 2000);
   }

--- a/frontend/src/features/analytics/components/Analytics/EnhancedInvestorAnalytics.tsx
+++ b/frontend/src/features/analytics/components/Analytics/EnhancedInvestorAnalytics.tsx
@@ -236,7 +236,7 @@ export const EnhancedInvestorAnalytics: React.FC<InvestorAnalyticsProps> = ({
   };
 
   useEffect(() => {
-    fetchAnalyticsData();
+    void fetchAnalyticsData();
 
     // Set up auto-refresh every 5 minutes if enabled
     let interval: NodeJS.Timeout;

--- a/frontend/src/features/analytics/components/Analytics/EnhancedProductionAnalytics.tsx
+++ b/frontend/src/features/analytics/components/Analytics/EnhancedProductionAnalytics.tsx
@@ -73,7 +73,7 @@ export const EnhancedProductionAnalytics: React.FC<PitchEvaluationProps> = (prop
   }, [timeRange]);
 
   useEffect(() => {
-    fetchChartData();
+    void fetchChartData();
     let interval: NodeJS.Timeout;
     if (autoRefresh) {
       interval = setInterval(fetchChartData, 5 * 60 * 1000);

--- a/frontend/src/features/billing/components/PaymentHistory.tsx
+++ b/frontend/src/features/billing/components/PaymentHistory.tsx
@@ -133,7 +133,7 @@ export default function PaymentHistory({ payments: initialPayments, onRefresh }:
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
-    applyFilters();
+    void applyFilters();
   };
 
   const exportPayments = async () => {

--- a/frontend/src/features/browse/components/BrowseTabsFixed.tsx
+++ b/frontend/src/features/browse/components/BrowseTabsFixed.tsx
@@ -236,7 +236,7 @@ const BrowseTabsFixed: React.FC = () => {
       const delay = currentTabState.fetchedWithSearch !== searchTerm ? 500 : 0;
 
       const timeoutId = setTimeout(() => {
-        fetchTabPitches(activeTab, true, searchTerm, selectedGenre);
+        void fetchTabPitches(activeTab, true, searchTerm, selectedGenre);
       }, delay);
 
       return () => clearTimeout(timeoutId);
@@ -253,7 +253,7 @@ const BrowseTabsFixed: React.FC = () => {
 
   // Load more pitches for current tab
   const loadMore = () => {
-    fetchTabPitches(activeTab, false, searchTerm, selectedGenre);
+    void fetchTabPitches(activeTab, false, searchTerm, selectedGenre);
   };
 
   const currentTabState = tabStates[activeTab];

--- a/frontend/src/features/browse/components/FollowButton.tsx
+++ b/frontend/src/features/browse/components/FollowButton.tsx
@@ -66,7 +66,7 @@ const FollowButton: React.FC<FollowButtonProps> = ({
   }, [creatorId, pitchId, isAuthenticated]);
 
   useEffect(() => {
-    checkFollowStatus();
+    void checkFollowStatus();
   }, [checkFollowStatus]);
 
   const handleFollow = useCallback(async () => {

--- a/frontend/src/features/browse/components/SavedFilters.tsx
+++ b/frontend/src/features/browse/components/SavedFilters.tsx
@@ -55,7 +55,7 @@ export default function SavedFilters({
 
   useEffect(() => {
     if (user) {
-      loadSavedFilters();
+      void loadSavedFilters();
     }
   }, [user]);
 

--- a/frontend/src/features/browse/components/Search/AdvancedSearchModal.tsx
+++ b/frontend/src/features/browse/components/Search/AdvancedSearchModal.tsx
@@ -153,7 +153,7 @@ export const AdvancedSearchModal: React.FC<AdvancedSearchProps> = ({
   useEffect(() => {
     if (filters.query) {
       const timeoutId = setTimeout(() => {
-        fetchSuggestions(filters.query);
+        void fetchSuggestions(filters.query);
       }, 300);
       return () => clearTimeout(timeoutId);
     }

--- a/frontend/src/features/browse/components/Search/SearchBar.tsx
+++ b/frontend/src/features/browse/components/Search/SearchBar.tsx
@@ -61,7 +61,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
     };
 
     if (showHistory) {
-      loadSearchHistory();
+      void loadSearchHistory();
     }
   }, [showHistory]);
 
@@ -98,7 +98,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
       }
 
       debounceRef.current = setTimeout(() => {
-        fetchSuggestions(newValue);
+        void fetchSuggestions(newValue);
       }, 300);
     }
   };
@@ -107,7 +107,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
   const handleFocus = () => {
     setIsOpen(true);
     if (value.length >= 2 && showSuggestions) {
-      fetchSuggestions(value);
+      void fetchSuggestions(value);
     }
   };
 

--- a/frontend/src/features/browse/hooks/__tests__/useSearch.test.ts
+++ b/frontend/src/features/browse/hooks/__tests__/useSearch.test.ts
@@ -114,7 +114,7 @@ describe('useSearch', () => {
       const { result } = renderHook(() => useSearch());
 
       act(() => {
-        result.current.search('space');
+        void result.current.search('space');
       });
 
       expect(result.current.loading).toBe(true);

--- a/frontend/src/features/browse/hooks/useSearch.ts
+++ b/frontend/src/features/browse/hooks/useSearch.ts
@@ -72,7 +72,7 @@ export const useSearch = (options: UseSearchOptions = {}) => {
     }
 
     debounceRef.current = setTimeout(() => {
-      search(query);
+      void search(query);
     }, debounceMs);
   }, [search, debounceMs]);
 

--- a/frontend/src/features/deals/components/Investment/InvestmentAnalytics.tsx
+++ b/frontend/src/features/deals/components/Investment/InvestmentAnalytics.tsx
@@ -58,7 +58,7 @@ export default function InvestmentAnalytics({ userType, className = '' }: Invest
   }, [userType]);
 
   useEffect(() => {
-    fetchAnalytics();
+    void fetchAnalytics();
   }, [fetchAnalytics]);
 
   const formatCurrency = useCallback((amount: number) => {

--- a/frontend/src/features/deals/components/Investment/TransactionHistory.tsx
+++ b/frontend/src/features/deals/components/Investment/TransactionHistory.tsx
@@ -109,7 +109,7 @@ export default function TransactionHistory({
   }, [currentPage, filterType, filterStatus, sortBy, sortOrder, searchTerm, pageSize]);
 
   useEffect(() => {
-    fetchTransactions();
+    void fetchTransactions();
   }, [fetchTransactions]);
 
   const formatCurrency = useCallback((amount: number) => {

--- a/frontend/src/features/ndas/components/NDA/ComprehensiveNDAManagement.tsx
+++ b/frontend/src/features/ndas/components/NDA/ComprehensiveNDAManagement.tsx
@@ -98,7 +98,7 @@ export default function ComprehensiveNDAManagement({
   useEffect(() => {
     // Only fetch NDA data if we have a valid userId AND user is authenticated
     if (isAuthenticated && userId && userId > 0) {
-      fetchAllNDAData();
+      void fetchAllNDAData();
     } else {
       // Clear data if not authenticated
       setIncomingNDAs([]);

--- a/frontend/src/features/ndas/components/NDA/EnhancedNDARequest.tsx
+++ b/frontend/src/features/ndas/components/NDA/EnhancedNDARequest.tsx
@@ -250,7 +250,7 @@ By clicking "Submit NDA Request" below, you are providing your electronic signat
               <button
                 onClick={() => {
                   setShowNDAPreview(false);
-                  handleSubmit();
+                  void handleSubmit();
                 }}
                 disabled={loading}
                 className="px-6 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 font-medium disabled:bg-gray-300"

--- a/frontend/src/features/ndas/components/NDA/NDADashboard.tsx
+++ b/frontend/src/features/ndas/components/NDA/NDADashboard.tsx
@@ -88,7 +88,7 @@ function NDAAnalyticsPanel() {
         setAnalyticsLoading(false);
       }
     };
-    loadAnalytics();
+    void loadAnalytics();
   }, [timeframe]);
 
   if (analyticsLoading) {
@@ -170,7 +170,7 @@ export default function NDADashboard({ userId, userRole }: NDADashboardProps) {
   const { success, error } = useToast();
 
   useEffect(() => {
-    loadDashboardData();
+    void loadDashboardData();
   }, [userId, timeframe, refreshKey]);
 
   const loadDashboardData = async () => {

--- a/frontend/src/features/ndas/components/NDA/NDADashboardIntegration.tsx
+++ b/frontend/src/features/ndas/components/NDA/NDADashboardIntegration.tsx
@@ -51,7 +51,7 @@ export default function NDADashboardIntegration({
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetchNDADashboardData();
+    void fetchNDADashboardData();
   }, [userType]);
 
   const fetchNDADashboardData = async () => {
@@ -514,7 +514,7 @@ export function NDAStatsWidget({ userType }: { userType: 'creator' | 'investor' 
       }
     };
 
-    fetchStats();
+    void fetchStats();
   }, []);
 
   return (

--- a/frontend/src/features/ndas/components/NDA/NDANotificationCenter.tsx
+++ b/frontend/src/features/ndas/components/NDA/NDANotificationCenter.tsx
@@ -222,7 +222,7 @@ export default function NDANotificationCenter({
   }, [userId, error]);
 
   useEffect(() => {
-    loadNotifications();
+    void loadNotifications();
 
     // Refresh every 30 seconds
     const interval = setInterval(loadNotifications, 30000);
@@ -296,7 +296,7 @@ export default function NDANotificationCenter({
   const handleNotificationClick = (notification: NDANotification) => {
     // Mark as read if not already read
     if (!notification.isRead) {
-      handleMarkAsRead([notification.id]);
+      void handleMarkAsRead([notification.id]);
     }
 
     // Handle notification-specific actions
@@ -311,9 +311,9 @@ export default function NDANotificationCenter({
     const selectedNotifications = Array.from(selectedIds);
 
     if (action === 'read') {
-      handleMarkAsRead(selectedNotifications);
+      void handleMarkAsRead(selectedNotifications);
     } else {
-      handleDelete(selectedNotifications);
+      void handleDelete(selectedNotifications);
     }
 
     setSelectedIds(new Set());
@@ -549,7 +549,7 @@ export default function NDANotificationCenter({
                           <button
                             onClick={(e) => {
                               e.stopPropagation();
-                              handleDelete([notification.id]);
+                              void handleDelete([notification.id]);
                             }}
                             className="p-1 text-gray-400 hover:text-red-600"
                             title="Delete"

--- a/frontend/src/features/ndas/components/NDA/NDARequestPanel.tsx
+++ b/frontend/src/features/ndas/components/NDA/NDARequestPanel.tsx
@@ -85,8 +85,8 @@ export default function NDARequestPanel({
   const { success, error } = useToast();
 
   useEffect(() => {
-    checkNDAStatus();
-    loadTemplates();
+    void checkNDAStatus();
+    void loadTemplates();
   }, [pitchId, userId]);
 
   const checkNDAStatus = async () => {

--- a/frontend/src/features/ndas/components/NDAManagement.tsx
+++ b/frontend/src/features/ndas/components/NDAManagement.tsx
@@ -47,7 +47,7 @@ const NDAManagement: React.FC<NDAManagementProps> = ({ userType, userId }) => {
   const [filter, setFilter] = useState<'all' | 'pending' | 'approved' | 'rejected' | 'expired'>('all');
 
   useEffect(() => {
-    fetchNDARequests();
+    void fetchNDARequests();
   }, [activeTab, filter]);
 
   const fetchNDARequests = async () => {
@@ -100,7 +100,7 @@ const NDAManagement: React.FC<NDAManagementProps> = ({ userType, userId }) => {
         alert(message);
         
         // Refresh requests
-        fetchNDARequests();
+        void fetchNDARequests();
         
         // Close modal
         setApprovalModal(false);

--- a/frontend/src/features/ndas/components/NDANotifications.tsx
+++ b/frontend/src/features/ndas/components/NDANotifications.tsx
@@ -50,7 +50,7 @@ export default function NDANotifications({ className = '', compact = false }: ND
   const { isConnected } = useWebSocket({
     onMessage: useCallback((message: any) => {
       if (message.type === 'nda_request' || message.type === 'nda_update') {
-        fetchNDANotifications();
+        void fetchNDANotifications();
         info('New NDA notification received');
       }
     }, [])
@@ -58,7 +58,7 @@ export default function NDANotifications({ className = '', compact = false }: ND
 
   useEffect(() => {
     if (user?.userType === 'creator') {
-      fetchNDANotifications();
+      void fetchNDANotifications();
     }
   }, [user]);
 
@@ -383,7 +383,7 @@ export function NDANotificationPanel({ className = '' }: { className?: string })
 
   useEffect(() => {
     if (user?.userType === 'creator') {
-      fetchRequests();
+      void fetchRequests();
     }
   }, [user]);
 

--- a/frontend/src/features/ndas/components/NDAStatus.tsx
+++ b/frontend/src/features/ndas/components/NDAStatus.tsx
@@ -43,7 +43,7 @@ export default function NDAStatus({
 
   useEffect(() => {
     if (user && user.id !== creatorId) {
-      fetchNDAStatus();
+      void fetchNDAStatus();
     } else {
       setLoading(false);
     }

--- a/frontend/src/features/ndas/components/NDAUploadSection.tsx
+++ b/frontend/src/features/ndas/components/NDAUploadSection.tsx
@@ -129,7 +129,7 @@ export default function NDAUploadSection({
         isCustom: false,
         ndaType: 'template'
       });
-      loadTemplates();
+      void loadTemplates();
     } else {
       // Custom NDA - prepare for file upload
       onChange({
@@ -208,7 +208,7 @@ export default function NDAUploadSection({
   const handleFileInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
-      handleFileSelect(file);
+      void handleFileSelect(file);
     }
     // Reset input
     e.target.value = '';
@@ -222,7 +222,7 @@ export default function NDAUploadSection({
 
     const file = e.dataTransfer.files[0];
     if (file) {
-      handleFileSelect(file);
+      void handleFileSelect(file);
     }
   }, [disabled, handleFileSelect]);
 

--- a/frontend/src/features/notifications/components/NotificationBellSafe.tsx
+++ b/frontend/src/features/notifications/components/NotificationBellSafe.tsx
@@ -33,7 +33,7 @@ function NotificationBellSafe({
       }
     };
 
-    loadUnreadCount();
+    void loadUnreadCount();
 
     // Poll every 60 seconds for new notifications
     const interval = setInterval(loadUnreadCount, 60000);

--- a/frontend/src/features/notifications/components/NotificationDropdown.tsx
+++ b/frontend/src/features/notifications/components/NotificationDropdown.tsx
@@ -175,14 +175,14 @@ export function NotificationDropdown({ className = '' }: NotificationDropdownPro
   // Load notifications on mount and when user becomes authenticated
   useEffect(() => {
     if (isAuthenticated) {
-      loadNotifications();
+      void loadNotifications();
     }
   }, [isAuthenticated]);
 
   // Reload notifications when dropdown opens
   useEffect(() => {
     if (isOpen && isAuthenticated) {
-      loadNotifications();
+      void loadNotifications();
     }
   }, [isOpen, isAuthenticated]);
 

--- a/frontend/src/features/notifications/components/NotificationPreferences.tsx
+++ b/frontend/src/features/notifications/components/NotificationPreferences.tsx
@@ -373,7 +373,7 @@ export default function NotificationPreferences() {
 
   // Load preferences from API
   useEffect(() => {
-    loadPreferences();
+    void loadPreferences();
   }, []);
 
   const loadPreferences = async () => {

--- a/frontend/src/features/notifications/components/Notifications/NotificationCenter.tsx
+++ b/frontend/src/features/notifications/components/Notifications/NotificationCenter.tsx
@@ -135,7 +135,7 @@ export const NotificationCenter: React.FC<NotificationCenterProps> = ({
 
   // Load notifications on mount and filter change
   useEffect(() => {
-    loadNotifications(true);
+    void loadNotifications(true);
   }, [filter]);
 
   // Real-time notifications via WebSocket

--- a/frontend/src/features/notifications/components/Notifications/NotificationPreferences.tsx
+++ b/frontend/src/features/notifications/components/Notifications/NotificationPreferences.tsx
@@ -159,8 +159,8 @@ export const NotificationPreferences: React.FC<NotificationPreferencesProps> = (
 
   // Load preferences on mount
   useEffect(() => {
-    loadPreferences();
-    checkPushPermission();
+    void loadPreferences();
+    void checkPushPermission();
   }, []);
 
   const loadPreferences = async () => {
@@ -448,7 +448,7 @@ export const NotificationPreferences: React.FC<NotificationPreferencesProps> = (
                         checked={preferences.pushEnabled && pushSubscriptionStatus === 'granted'}
                         onChange={(e) => {
                           if (e.target.checked && pushSubscriptionStatus !== 'granted') {
-                            requestPushPermission();
+                            void requestPushPermission();
                           } else {
                             updateGlobalSetting('pushEnabled', e.target.checked);
                           }

--- a/frontend/src/features/notifications/components/Notifications/PushSubscriptionManager.tsx
+++ b/frontend/src/features/notifications/components/Notifications/PushSubscriptionManager.tsx
@@ -56,8 +56,8 @@ export const PushSubscriptionManager: React.FC<PushSubscriptionManagerProps> = (
   useEffect(() => {
     if (isPushSupported) {
       checkPermissionStatus();
-      loadSubscriptions();
-      checkCurrentSubscription();
+      void loadSubscriptions();
+      void checkCurrentSubscription();
     }
   }, []);
 
@@ -228,7 +228,7 @@ export const PushSubscriptionManager: React.FC<PushSubscriptionManagerProps> = (
       }
 
       // Reload subscriptions
-      loadSubscriptions();
+      void loadSubscriptions();
       toast.success('Push notifications disabled');
 
     } catch (error) {

--- a/frontend/src/features/notifications/hooks/useWebSocket.ts
+++ b/frontend/src/features/notifications/hooks/useWebSocket.ts
@@ -215,7 +215,7 @@ export function useMessaging() {
 
           // Show read receipt notification (silent)
           if (message.readByName) {
-            notificationService.notifyMessageRead(message.messageId, message.readByName);
+            void notificationService.notifyMessageRead(message.messageId, message.readByName);
           }
           break;
 
@@ -243,7 +243,7 @@ export function useMessaging() {
           
           // Show user online notification (silent)
           if (message.username) {
-            notificationService.notifyUserOnline(message.username);
+            void notificationService.notifyUserOnline(message.username);
           }
           break;
 

--- a/frontend/src/features/notifications/hooks/useWebSocketAdvanced.ts
+++ b/frontend/src/features/notifications/hooks/useWebSocketAdvanced.ts
@@ -339,7 +339,7 @@ export function useWebSocketAdvanced(options: UseWebSocketAdvancedOptions = {}) 
               console.warn('Heartbeat timeout - connection appears dead');
               disconnect();
               if (reconnectionConfig.enabled) {
-                connect();
+                void connect();
               }
             }
           }, heartbeatConfig.timeout);
@@ -1054,7 +1054,7 @@ export function useWebSocketAdvanced(options: UseWebSocketAdvancedOptions = {}) 
               },
             });
             opts.onReconnect(attempt);
-            connect();
+            void connect();
           }, delay);
         } else if (isAuthFailure) {
           // Authentication failed - don't retry, provide clear feedback
@@ -1184,7 +1184,7 @@ export function useWebSocketAdvanced(options: UseWebSocketAdvancedOptions = {}) 
       
       // Try to reconnect if not already connecting
       if (!connectionStatus.connecting && !connectionStatus.reconnecting) {
-        connect();
+        void connect();
       }
       
       return false;
@@ -1213,7 +1213,7 @@ export function useWebSocketAdvanced(options: UseWebSocketAdvancedOptions = {}) 
       const delay = isDev ? 100 : 0;
       
       const timer = setTimeout(() => {
-        connect();
+        void connect();
       }, delay);
       
       return () => {
@@ -1266,7 +1266,7 @@ export function useWebSocketAdvanced(options: UseWebSocketAdvancedOptions = {}) 
     const interval = setInterval(() => {
       const circuitState = checkCircuitBreakerState();
       if (circuitState === 'half-open' && !connectionStatus.connected && !connectionStatus.connecting) {
-        connect();
+        void connect();
       }
     }, 30000); // Check every 30 seconds
     
@@ -1313,7 +1313,7 @@ export function useWebSocketAdvanced(options: UseWebSocketAdvancedOptions = {}) 
         disconnect();
       }
       reconnectAttemptRef.current = 0; // Reset attempt counter
-      connect();
+      void connect();
     }, [connect, disconnect]),
     
     // Configuration access

--- a/frontend/src/features/notifications/services/notification.service.ts
+++ b/frontend/src/features/notifications/services/notification.service.ts
@@ -24,7 +24,7 @@ export class NotificationService {
   private sounds: { [key: string]: HTMLAudioElement } = {};
 
   constructor() {
-    this.initializePermission();
+    void this.initializePermission();
     this.loadSounds();
   }
 

--- a/frontend/src/features/pitches/components/CharacterManagement/CharacterManagement.tsx
+++ b/frontend/src/features/pitches/components/CharacterManagement/CharacterManagement.tsx
@@ -344,7 +344,7 @@ export const CharacterManagement: React.FC<CharacterManagementProps> = ({
     e.preventDefault();
     
     if (draggedItem !== null && draggedItem !== dropIndex) {
-      handleMoveCharacter(draggedItem, dropIndex);
+      void handleMoveCharacter(draggedItem, dropIndex);
     }
     
     setDraggedItem(null);

--- a/frontend/src/features/pitches/components/PitchValidation/ValidationDashboard.tsx
+++ b/frontend/src/features/pitches/components/PitchValidation/ValidationDashboard.tsx
@@ -45,7 +45,7 @@ export const ValidationDashboard: React.FC<ValidationDashboardProps> = ({
   const [activeTab, setActiveTab] = useState<'overview' | 'categories' | 'trends' | 'recommendations' | 'comparisons'>('overview');
 
   useEffect(() => {
-    fetchDashboardData();
+    void fetchDashboardData();
   }, [pitchId]);
 
   const fetchDashboardData = async () => {

--- a/frontend/src/features/uploads/components/FileUpload/ChunkedFileUpload.tsx
+++ b/frontend/src/features/uploads/components/FileUpload/ChunkedFileUpload.tsx
@@ -218,7 +218,7 @@ const ChunkedFileUpload: React.FC<ChunkedFileUploadProps> = ({
 
       // Start uploads
       pendingStates.forEach(fileState => {
-        startFileUpload(fileState);
+        void startFileUpload(fileState);
       });
     }
   }, [files, maxFiles, disabled, validateFile, onFilesSelected]);
@@ -343,7 +343,7 @@ const ChunkedFileUpload: React.FC<ChunkedFileUploadProps> = ({
     fileState.result = null;
     
     setFiles(prev => prev.map(f => f.sessionId === fileState.sessionId ? { ...fileState } : f));
-    startFileUpload(fileState);
+    void startFileUpload(fileState);
   }, [startFileUpload]);
 
   // Remove file from list

--- a/frontend/src/features/uploads/components/FileUpload/FileUpload.tsx
+++ b/frontend/src/features/uploads/components/FileUpload/FileUpload.tsx
@@ -362,7 +362,7 @@ export default function FileUpload({
   const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFiles = e.target.files;
     if (selectedFiles && selectedFiles.length > 0) {
-      processFiles(selectedFiles);
+      void processFiles(selectedFiles);
     }
     // Reset input value
     if (fileInputRef.current) {
@@ -394,7 +394,7 @@ export default function FileUpload({
 
     const droppedFiles = e.dataTransfer.files;
     if (droppedFiles && droppedFiles.length > 0) {
-      processFiles(droppedFiles);
+      void processFiles(droppedFiles);
     }
   }, [disabled, enableDragDrop, processFiles]);
 
@@ -526,7 +526,7 @@ export default function FileUpload({
       
       if (file && file.uploadStatus === 'idle') {
         setUploadQueue(prev => prev.slice(1));
-        uploadFile(file);
+        void uploadFile(file);
       }
     }
   }, [uploadQueue, activeUploads.size, maxConcurrentUploads, files, uploadFile, enableConcurrentUploads]);
@@ -677,12 +677,12 @@ export default function FileUpload({
                       .forEach((file, index) => {
                         if (enableConcurrentUploads) {
                           if (activeUploads.size + index < maxConcurrentUploads) {
-                            uploadFile(file);
+                            void uploadFile(file);
                           } else {
                             setUploadQueue(prev => [...prev, file.id]);
                           }
                         } else {
-                          uploadFile(file);
+                          void uploadFile(file);
                         }
                       });
                   }}

--- a/frontend/src/features/uploads/components/FileUpload/MultipleFileUpload.tsx
+++ b/frontend/src/features/uploads/components/FileUpload/MultipleFileUpload.tsx
@@ -433,7 +433,7 @@ export default function MultipleFileUpload({
   const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFiles = e.target.files;
     if (selectedFiles && selectedFiles.length > 0) {
-      processFiles(selectedFiles);
+      void processFiles(selectedFiles);
     }
     // Reset input
     e.target.value = '';
@@ -448,7 +448,7 @@ export default function MultipleFileUpload({
 
     const droppedFiles = e.dataTransfer.files;
     if (droppedFiles && droppedFiles.length > 0) {
-      processFiles(droppedFiles);
+      void processFiles(droppedFiles);
     }
   }, [disabled, processFiles]);
 

--- a/frontend/src/features/uploads/services/chunked-upload.service.ts
+++ b/frontend/src/features/uploads/services/chunked-upload.service.ts
@@ -189,7 +189,7 @@ class ChunkedUploadService {
     this.emit('queue:added', { sessionId, position: this.uploadQueue.length - 1 });
 
     // Process queue if we have capacity
-    this.processQueue();
+    void this.processQueue();
 
     return sessionId;
   }

--- a/frontend/src/lib/better-auth-client.tsx
+++ b/frontend/src/lib/better-auth-client.tsx
@@ -274,7 +274,7 @@ export function withBetterAuth<T extends object>(
         }
       };
 
-      checkAuth();
+      void checkAuth();
     }, []);
 
     if (isLoading) {

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -95,7 +95,7 @@ const About: React.FC = () => {
       }
     };
     
-    loadContent();
+    void loadContent();
   }, []);
   
   // Show loading state

--- a/frontend/src/pages/AcceptInvitePage.tsx
+++ b/frontend/src/pages/AcceptInvitePage.tsx
@@ -30,7 +30,7 @@ export default function AcceptInvitePage() {
       return;
     }
 
-    acceptInvitation();
+    void acceptInvitation();
   }, [token, isAuthenticated]);
 
   const acceptInvitation = async () => {

--- a/frontend/src/pages/AdminLogin.tsx
+++ b/frontend/src/pages/AdminLogin.tsx
@@ -34,7 +34,7 @@ export default function AdminLogin() {
       // Verify the user is actually an admin
       const user = useBetterAuthStore.getState().user;
       if (user?.userType !== 'admin') {
-        useBetterAuthStore.getState().logout();
+        void useBetterAuthStore.getState().logout();
         setAuthError('Access denied. This portal is restricted to administrators.');
         resetTurnstile();
         return;

--- a/frontend/src/pages/AdvancedSearch.tsx
+++ b/frontend/src/pages/AdvancedSearch.tsx
@@ -115,7 +115,7 @@ export default function AdvancedSearch() {
   // Debounced search — runs on any filter change, including initial load
   useEffect(() => {
     const timeoutId = setTimeout(() => {
-      performSearch();
+      void performSearch();
     }, 300);
 
     return () => clearTimeout(timeoutId);

--- a/frontend/src/pages/Billing.tsx
+++ b/frontend/src/pages/Billing.tsx
@@ -49,7 +49,7 @@ export default function Billing() {
   const userType = (user?.userType || 'creator') as 'creator' | 'investor' | 'production' | 'watcher' | 'viewer';
 
   useEffect(() => {
-    fetchBillingData();
+    void fetchBillingData();
   }, []);
 
   useEffect(() => {

--- a/frontend/src/pages/BrowseGenres.tsx
+++ b/frontend/src/pages/BrowseGenres.tsx
@@ -78,7 +78,7 @@ export default function BrowseGenres() {
         console.error('Failed to load configuration:', error);
       }
     };
-    loadConfig();
+    void loadConfig();
   }, []);
 
   // Fetch genre statistics
@@ -206,12 +206,12 @@ export default function BrowseGenres() {
 
   // Fetch data on mount and when dependencies change
   useEffect(() => {
-    fetchGenreStats();
+    void fetchGenreStats();
   }, [fetchGenreStats]);
 
   useEffect(() => {
     if (selectedGenre) {
-      fetchGenrePitches();
+      void fetchGenrePitches();
     } else {
       setLoading(false);
       setPitches([]);

--- a/frontend/src/pages/BrowseTopRated.tsx
+++ b/frontend/src/pages/BrowseTopRated.tsx
@@ -105,7 +105,7 @@ export default function BrowseTopRated() {
         console.error('Failed to load configuration:', error);
       }
     };
-    loadConfig();
+    void loadConfig();
   }, []);
 
   // Fetch rating statistics
@@ -252,11 +252,11 @@ export default function BrowseTopRated() {
 
   // Fetch data on mount and when dependencies change
   useEffect(() => {
-    fetchRatingStats();
+    void fetchRatingStats();
   }, [fetchRatingStats]);
 
   useEffect(() => {
-    fetchTopRatedPitches();
+    void fetchTopRatedPitches();
   }, [fetchTopRatedPitches]);
 
   // Reset page when filters change

--- a/frontend/src/pages/CreatePitch.tsx
+++ b/frontend/src/pages/CreatePitch.tsx
@@ -221,16 +221,16 @@ export default function CreatePitch() {
         // Already using sync fallback values
       }
     };
-    loadConfig();
+    void loadConfig();
   }, []);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
-    handleFieldChange(name as keyof PitchFormData)(value);
+    void handleFieldChange(name as keyof PitchFormData)(value);
   };
   
   const handleBlur = (fieldName: string) => {
-    handleFieldBlur(fieldName as keyof PitchFormData)();
+    void handleFieldBlur(fieldName as keyof PitchFormData)();
   };
 
   const handleFormatCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -243,7 +243,7 @@ export default function CreatePitch() {
     });
     
     // Validate the category field
-    handleFieldChange('formatCategory')(category);
+    void handleFieldChange('formatCategory')(category);
   };
 
   const handleFormatSubtypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -254,7 +254,7 @@ export default function CreatePitch() {
     });
     
     // Validate the subtype field
-    handleFieldChange('formatSubtype')(subtype);
+    void handleFieldChange('formatSubtype')(subtype);
   };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>, fileType: 'image' | 'video') => {

--- a/frontend/src/pages/CreatorPortfolio.tsx
+++ b/frontend/src/pages/CreatorPortfolio.tsx
@@ -83,7 +83,7 @@ export default function CreatorPortfolio() {
       }
     };
 
-    fetchPortfolio();
+    void fetchPortfolio();
   }, [effectiveCreatorId, creatorId]);
 
   if (!effectiveCreatorId) {

--- a/frontend/src/pages/CreatorProfile.tsx
+++ b/frontend/src/pages/CreatorProfile.tsx
@@ -67,8 +67,8 @@ const CreatorProfile = () => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetchCreatorData();
-    fetchCreatorPitches();
+    void fetchCreatorData();
+    void fetchCreatorPitches();
   }, [creatorId]);
 
   const fetchCreatorData = async () => {
@@ -203,7 +203,7 @@ const CreatorProfile = () => {
   };
 
   const handleShareProfile = () => {
-    navigator.clipboard.writeText(window.location.href);
+    void navigator.clipboard.writeText(window.location.href);
   };
 
   if (loading) {

--- a/frontend/src/pages/EmailOTPLogin.tsx
+++ b/frontend/src/pages/EmailOTPLogin.tsx
@@ -99,7 +99,7 @@ export default function EmailOTPLogin() {
     const digits = value.replace(/\D/g, '').slice(0, 6);
     setCode(digits);
     if (digits.length === 6) {
-      handleVerifyCode(digits);
+      void handleVerifyCode(digits);
     }
   };
 

--- a/frontend/src/pages/Following.tsx
+++ b/frontend/src/pages/Following.tsx
@@ -156,7 +156,7 @@ const Following: React.FC = () => {
   const userType = user?.userType;
 
   useEffect(() => {
-    fetchFollowingData();
+    void fetchFollowingData();
   }, [activeTab, timeframe]);
 
   const fetchFollowingData = async () => {

--- a/frontend/src/pages/Homepage.tsx
+++ b/frontend/src/pages/Homepage.tsx
@@ -56,7 +56,7 @@ export default function Homepage() {
   useEffect(() => {
     // Add delay to prevent rate limiting on initial page load
     const timer = setTimeout(() => {
-      fetchPitches();
+      void fetchPitches();
     }, 1500); // Stagger after auth and notification delays
 
     return () => clearTimeout(timer);

--- a/frontend/src/pages/InvestorBrowse.tsx
+++ b/frontend/src/pages/InvestorBrowse.tsx
@@ -85,7 +85,7 @@ export default function InvestorBrowse() {
         console.error('Error loading config:', error);
       }
     };
-    loadConfig();
+    void loadConfig();
   }, []);
 
   const fetchPitches = useCallback(async (tab: InvestorTabType) => {
@@ -177,7 +177,7 @@ export default function InvestorBrowse() {
 
   // Fetch when tab or filters change
   useEffect(() => {
-    fetchPitches(activeTab);
+    void fetchPitches(activeTab);
   }, [activeTab, filters, fetchPitches]);
 
   // Derive filtered + sorted pitches from current tab's data using debounced search

--- a/frontend/src/pages/MFAChallengePage.tsx
+++ b/frontend/src/pages/MFAChallengePage.tsx
@@ -76,7 +76,7 @@ export default function MFAChallengePage() {
     const digits = value.replace(/\D/g, '').slice(0, 6);
     setCode(digits);
     if (digits.length === 6) {
-      handleSubmit(digits);
+      void handleSubmit(digits);
     }
   };
 

--- a/frontend/src/pages/MarketplaceEnhanced.tsx
+++ b/frontend/src/pages/MarketplaceEnhanced.tsx
@@ -452,7 +452,7 @@ export default function MarketplaceEnhanced() {
 
   useEffect(() => {
     if (isSearchMode) {
-      performServerSearch();
+      void performServerSearch();
     } else {
       setSearchResults([]);
     }

--- a/frontend/src/pages/Messages.tsx
+++ b/frontend/src/pages/Messages.tsx
@@ -264,7 +264,7 @@ export default function Messages() {
       // Clear params to prevent re-triggering
       setSearchParams({}, { replace: true });
     };
-    initConversation();
+    void initConversation();
   }, [searchParams, setSearchParams, joinConversation, hookMarkConversationAsRead, fetchConversationMessages]);
 
   // Sync with hook conversations and messages (only when hook has real data)
@@ -477,7 +477,7 @@ export default function Messages() {
       setSuggestedMessage('');
     } else if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
-      sendMessage();
+      void sendMessage();
     }
   }, [sendMessage, suggestedMessage, newMessage]);
 
@@ -1041,7 +1041,7 @@ export default function Messages() {
                                         className="w-full p-2 border rounded text-gray-900 text-sm"
                                         onKeyDown={(e) => {
                                           if (e.key === 'Enter' && e.ctrlKey) {
-                                            handleEditMessage(message.id, e.currentTarget.value);
+                                            void handleEditMessage(message.id, e.currentTarget.value);
                                           }
                                           if (e.key === 'Escape') {
                                             setEditingMessage(null);
@@ -1053,7 +1053,7 @@ export default function Messages() {
                                         <button
                                           onClick={() => {
                                             const textarea = document.querySelector('textarea') as HTMLTextAreaElement | null;
-                                            if (textarea) handleEditMessage(message.id, textarea.value);
+                                            if (textarea) void handleEditMessage(message.id, textarea.value);
                                           }}
                                           className="text-xs bg-purple-600 text-white px-2 py-1 rounded"
                                         >

--- a/frontend/src/pages/MyCollaborations.tsx
+++ b/frontend/src/pages/MyCollaborations.tsx
@@ -33,7 +33,7 @@ export default function MyCollaborations() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    loadCollaborations();
+    void loadCollaborations();
   }, []);
 
   const loadCollaborations = async () => {

--- a/frontend/src/pages/NotificationCenter.tsx
+++ b/frontend/src/pages/NotificationCenter.tsx
@@ -33,8 +33,8 @@ export default function NotificationCenter() {
 
   // Load notifications and preferences
   useEffect(() => {
-    loadNotifications();
-    loadPreferences();
+    void loadNotifications();
+    void loadPreferences();
   }, []);
 
   const loadNotifications = async () => {
@@ -299,7 +299,7 @@ export default function NotificationCenter() {
                         checked={value}
                         onChange={(e) => {
                           const newPrefs = { ...preferences, [key]: e.target.checked };
-                          handlePreferencesUpdate(newPrefs);
+                          void handlePreferencesUpdate(newPrefs);
                         }}
                         className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
                       />
@@ -412,7 +412,7 @@ export default function NotificationCenter() {
                                   key={index}
                                   onClick={() => {
                                     action.action();
-                                    handleMarkAsRead(notification.id);
+                                    void handleMarkAsRead(notification.id);
                                   }}
                                   className={`px-3 py-1 text-xs rounded transition-colors ${
                                     (action.type as string) === 'primary'
@@ -437,7 +437,7 @@ export default function NotificationCenter() {
                               <button
                                 onClick={() => {
                                   void navigate('/creator/ndas');
-                                  handleMarkAsRead(notification.id);
+                                  void handleMarkAsRead(notification.id);
                                 }}
                                 className="px-3 py-1 text-xs bg-green-600 text-white rounded hover:bg-green-700 transition-colors"
                               >
@@ -446,7 +446,7 @@ export default function NotificationCenter() {
                               <button
                                 onClick={() => {
                                   void navigate('/creator/ndas');
-                                  handleMarkAsRead(notification.id);
+                                  void handleMarkAsRead(notification.id);
                                 }}
                                 className="px-3 py-1 text-xs bg-red-600 text-white rounded hover:bg-red-700 transition-colors"
                               >
@@ -455,7 +455,7 @@ export default function NotificationCenter() {
                               <button
                                 onClick={() => {
                                   void navigate('/creator/ndas');
-                                  handleMarkAsRead(notification.id);
+                                  void handleMarkAsRead(notification.id);
                                 }}
                                 className="px-3 py-1 text-xs bg-gray-200 text-gray-700 rounded hover:bg-gray-300 transition-colors"
                               >
@@ -470,7 +470,7 @@ export default function NotificationCenter() {
                               <button
                                 onClick={() => {
                                   void navigate('/investor/all-investments');
-                                  handleMarkAsRead(notification.id);
+                                  void handleMarkAsRead(notification.id);
                                 }}
                                 className="px-3 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
                               >

--- a/frontend/src/pages/OpportunitiesBoard.tsx
+++ b/frontend/src/pages/OpportunitiesBoard.tsx
@@ -642,7 +642,7 @@ export default function OpportunitiesBoard() {
     const nextStatus = call.status === 'open' ? 'closed' : 'open';
     try {
       await callsService.update(call.id, { status: nextStatus });
-      load();
+      void load();
       toast.success(nextStatus === 'open' ? 'Call reopened' : 'Call closed to new submissions');
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Couldn\'t update the call. Please try again.');

--- a/frontend/src/pages/PitchAnalytics.tsx
+++ b/frontend/src/pages/PitchAnalytics.tsx
@@ -19,7 +19,7 @@ export default function PitchAnalytics() {
 
   useEffect(() => {
     if (id) {
-      fetchAnalytics(parseInt(id));
+      void fetchAnalytics(parseInt(id));
     }
   }, [id, timeRange]);
 

--- a/frontend/src/pages/PitchDetail.tsx
+++ b/frontend/src/pages/PitchDetail.tsx
@@ -104,7 +104,7 @@ export default function PitchDetail() {
   
   useEffect(() => {
     if (id) {
-      fetchPitch(parseInt(id));
+      void fetchPitch(parseInt(id));
     }
   }, [id, isAuthenticated]);
 
@@ -243,7 +243,7 @@ export default function PitchDetail() {
   const handleLike = async () => {
     if (!pitch) return;
     if (!isAuthenticated) {
-      goToLogin();
+      void goToLogin();
       return;
     }
     const next = !isLiked;
@@ -298,7 +298,7 @@ export default function PitchDetail() {
     if (id) {
       // Add a small delay to ensure the backend has processed the NDA
       setTimeout(() => {
-        fetchPitch(parseInt(id));
+        void fetchPitch(parseInt(id));
       }, 500);
     }
   };
@@ -388,7 +388,7 @@ export default function PitchDetail() {
                 if (id) {
                   setError(null);
                   setLoading(true);
-                  fetchPitch(parseInt(id));
+                  void fetchPitch(parseInt(id));
                 }
               }}
               className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition"

--- a/frontend/src/pages/PitchEdit.tsx
+++ b/frontend/src/pages/PitchEdit.tsx
@@ -156,7 +156,7 @@ export default function PitchEdit() {
 
   useEffect(() => {
     if (id) {
-      fetchPitch(parseInt(id));
+      void fetchPitch(parseInt(id));
     }
   }, [id]);
 

--- a/frontend/src/pages/ProductionAnalyticsPage.tsx
+++ b/frontend/src/pages/ProductionAnalyticsPage.tsx
@@ -34,7 +34,7 @@ export default function ProductionAnalyticsPage() {
         // Keep defaults
       }
     };
-    load();
+    void load();
   }, []);
 
   const tabs = [

--- a/frontend/src/pages/ProductionDashboard.tsx
+++ b/frontend/src/pages/ProductionDashboard.tsx
@@ -169,7 +169,7 @@ function ProductionDashboard() {
         setSessionChecked(true);
       }
     };
-    validateSession();
+    void validateSession();
   }, [checkSession]);
 
   // Redirect to login if not authenticated after session check
@@ -709,7 +709,7 @@ function ProductionDashboard() {
 
   const handleRetrySection = useCallback((section: string) => {
     trackEvent('dashboard.retry', { section });
-    fetchData();
+    void fetchData();
   }, [fetchData, trackEvent]);
 
   // NDA Template Upload Handlers
@@ -743,7 +743,7 @@ function ProductionDashboard() {
     setNdaTemplates(prev => [...prev, template]);
     
     // Automatically start upload
-    uploadNDATemplate(template, file);
+    void uploadNDATemplate(template, file);
   };
 
   const uploadNDATemplate = async (template: NDATemplate, file: File) => {
@@ -1472,7 +1472,7 @@ function ProductionDashboard() {
                             <button
                               onClick={(e) => {
                                 e.stopPropagation();
-                                handleSavePitch(pitch.id);
+                                void handleSavePitch(pitch.id);
                               }}
                               className={`flex items-center gap-1 px-3 py-1 rounded-lg transition-colors ${
                                 savedPitches?.includes(pitch.id) 
@@ -1509,7 +1509,7 @@ function ProductionDashboard() {
                                 <button
                                   onClick={(e) => {
                                     e.stopPropagation();
-                                    handleRequestNDA(pitch.id, pitch.title);
+                                    void handleRequestNDA(pitch.id, pitch.title);
                                   }}
                                   className="flex items-center gap-1 px-3 py-1 bg-purple-100 text-purple-600 rounded-lg hover:bg-purple-200 transition-colors"
                                 >

--- a/frontend/src/pages/ProductionPitchCreate.tsx
+++ b/frontend/src/pages/ProductionPitchCreate.tsx
@@ -111,7 +111,7 @@ export default function ProductionPitchCreate() {
         // Already using sync fallback values
       }
     };
-    loadConfig();
+    void loadConfig();
   }, []);
 
   // Load draft if editing

--- a/frontend/src/pages/PublicPitchView.tsx
+++ b/frontend/src/pages/PublicPitchView.tsx
@@ -237,7 +237,7 @@ export default function PublicPitchView() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-6">
         <button
           onClick={() => {
-            if (window.history.length > 1) navigate(-1);
+            if (window.history.length > 1) void navigate(-1);
             else void navigate('/marketplace');
           }}
           className="inline-flex items-center gap-1.5 text-sm font-medium text-gray-600 transition hover:text-purple-600"

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -57,7 +57,7 @@ export default function SearchPage() {
 
   useEffect(() => {
     if (searchQuery) {
-      performSearch();
+      void performSearch();
     }
   }, [searchQuery, selectedType, selectedGenre, selectedBudget, selectedTimeframe, sortBy]);
 
@@ -135,7 +135,7 @@ export default function SearchPage() {
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     setSearchParams({ q: searchQuery });
-    performSearch();
+    void performSearch();
   };
 
   const getTypeIcon = (type: string) => {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -135,7 +135,7 @@ export default function Settings() {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   useEffect(() => {
-    fetchSettings();
+    void fetchSettings();
   }, []);
 
   const fetchSettings = async () => {
@@ -209,7 +209,7 @@ export default function Settings() {
 
       if (response.ok) {
         toast.success('Your account has been deleted.');
-        logout();
+        void logout();
         void navigate('/');
       } else {
         const data = await response.json().catch(() => ({} as { error?: string }));
@@ -704,7 +704,7 @@ export default function Settings() {
               </button>
               <button
                 onClick={() => {
-                  handleDeleteAccount();
+                  void handleDeleteAccount();
                   setShowDeleteModal(false);
                 }}
                 className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition"

--- a/frontend/src/pages/SharedPortfolio.tsx
+++ b/frontend/src/pages/SharedPortfolio.tsx
@@ -55,7 +55,7 @@ export default function SharedPortfolio() {
 
   useEffect(() => {
     if (!token) return;
-    fetchPortfolio(token);
+    void fetchPortfolio(token);
   }, [token]);
 
   async function fetchPortfolio(t: string) {

--- a/frontend/src/pages/TeamManagement.tsx
+++ b/frontend/src/pages/TeamManagement.tsx
@@ -50,7 +50,7 @@ export default function TeamManagement() {
   }, []);
 
   useEffect(() => {
-    loadData();
+    void loadData();
   }, [loadData]);
 
   const handleRemove = async (collaborator: Collaborator) => {

--- a/frontend/src/pages/UserPortfolio.tsx
+++ b/frontend/src/pages/UserPortfolio.tsx
@@ -144,7 +144,7 @@ const UserPortfolio: React.FC = () => {
   };
 
   const handleRetry = () => {
-    fetchPortfolio();
+    void fetchPortfolio();
   };
 
   const handleGoBack = () => {
@@ -168,7 +168,7 @@ const UserPortfolio: React.FC = () => {
 
   useEffect(() => {
     if (effectiveUserId) {
-      fetchPortfolio();
+      void fetchPortfolio();
     }
   }, [effectiveUserId]);
 

--- a/frontend/src/pages/VerifyEmail.tsx
+++ b/frontend/src/pages/VerifyEmail.tsx
@@ -17,7 +17,7 @@ export default function VerifyEmail() {
 
   useEffect(() => {
     if (token) {
-      verifyEmail();
+      void verifyEmail();
     } else {
       setVerifying(false);
       setError('Invalid verification link');

--- a/frontend/src/pages/settings/NotificationSettings.tsx
+++ b/frontend/src/pages/settings/NotificationSettings.tsx
@@ -93,7 +93,7 @@ export default function NotificationSettings() {
         setInitialLoading(false);
       }
     };
-    loadPreferences();
+    void loadPreferences();
   }, []);
 
   const updatePreference = (categoryId: string, channel: keyof Omit<NotificationPreference, 'id' | 'title' | 'description'>, value: boolean) => {

--- a/frontend/src/pages/settings/PrivacySettings.tsx
+++ b/frontend/src/pages/settings/PrivacySettings.tsx
@@ -85,7 +85,7 @@ export default function PrivacySettings() {
         setInitialLoading(false);
       }
     };
-    loadSettings();
+    void loadSettings();
   }, []);
 
   const updateProfileVisibility = (field: keyof ProfileVisibility, value: boolean) => {
@@ -148,7 +148,7 @@ export default function PrivacySettings() {
     try {
       await UserService.deleteAccount(deleteConfirmText);
       toast.success('Account deletion request submitted');
-      logout();
+      void logout();
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
       toast.error(e.message || 'Failed to delete account');

--- a/frontend/src/pages/team/TeamInvite.tsx
+++ b/frontend/src/pages/team/TeamInvite.tsx
@@ -71,7 +71,7 @@ export default function TeamInvite() {
   const [bulkEmails, setBulkEmails] = useState('');
 
   useEffect(() => {
-    fetchInvitations();
+    void fetchInvitations();
   }, []);
 
   const fetchInvitations = async () => {

--- a/frontend/src/pages/team/TeamMembers.tsx
+++ b/frontend/src/pages/team/TeamMembers.tsx
@@ -67,10 +67,10 @@ export default function TeamMembers() {
 
   useEffect(() => {
     if (teamId) {
-      fetchTeamMembers();
+      void fetchTeamMembers();
     } else {
       // No formal team — load collaborators from projects instead
-      fetchCollaborators();
+      void fetchCollaborators();
     }
   }, [teamId]);
 

--- a/frontend/src/pages/team/TeamOverview.tsx
+++ b/frontend/src/pages/team/TeamOverview.tsx
@@ -65,7 +65,7 @@ export default function TeamOverview() {
 
   useEffect(() => {
     if (teamId) {
-      fetchTeamData();
+      void fetchTeamData();
     } else {
       setLoading(false);
     }

--- a/frontend/src/portals/admin/pages/ContentModeration.tsx
+++ b/frontend/src/portals/admin/pages/ContentModeration.tsx
@@ -51,7 +51,7 @@ const ContentModeration: React.FC = () => {
   ];
 
   useEffect(() => {
-    loadPitches();
+    void loadPitches();
   }, [filters]);
 
   const loadPitches = async () => {

--- a/frontend/src/portals/admin/pages/SystemSettings.tsx
+++ b/frontend/src/portals/admin/pages/SystemSettings.tsx
@@ -58,7 +58,7 @@ const SystemSettings: React.FC = () => {
   const [activeTab, setActiveTab] = useState('general');
 
   useEffect(() => {
-    loadSettings();
+    void loadSettings();
   }, []);
 
   const loadSettings = async () => {

--- a/frontend/src/portals/admin/pages/Transactions.tsx
+++ b/frontend/src/portals/admin/pages/Transactions.tsx
@@ -54,7 +54,7 @@ const Transactions: React.FC = () => {
   const [actionLoading, setActionLoading] = useState<string | null>(null);
 
   useEffect(() => {
-    loadTransactions();
+    void loadTransactions();
   }, [filters]);
 
   const loadTransactions = async () => {

--- a/frontend/src/portals/admin/pages/UserManagement.tsx
+++ b/frontend/src/portals/admin/pages/UserManagement.tsx
@@ -38,7 +38,7 @@ const UserManagement: React.FC = () => {
   const [actionLoading, setActionLoading] = useState<string | null>(null);
 
   useEffect(() => {
-    loadUsers();
+    void loadUsers();
   }, [filters]);
 
   const loadUsers = async () => {

--- a/frontend/src/portals/creator/pages/CreatorActivity.tsx
+++ b/frontend/src/portals/creator/pages/CreatorActivity.tsx
@@ -122,14 +122,14 @@ export default function CreatorActivity() {
 
   // Load activities from API on mount
   useEffect(() => {
-    loadActivities();
-    loadStats();
+    void loadActivities();
+    void loadStats();
   }, [loadActivities]);
 
   // Auto-poll every 30 seconds
   useEffect(() => {
     const interval = setInterval(() => {
-      loadActivities(true);
+      void loadActivities(true);
     }, 30000);
     return () => clearInterval(interval);
   }, [loadActivities]);

--- a/frontend/src/portals/creator/pages/CreatorCollaborations.tsx
+++ b/frontend/src/portals/creator/pages/CreatorCollaborations.tsx
@@ -71,7 +71,7 @@ export default function CreatorCollaborations() {
   });
 
   useEffect(() => {
-    loadCollaborations();
+    void loadCollaborations();
   }, []);
 
   useEffect(() => {

--- a/frontend/src/portals/creator/pages/CreatorFundingSettings.tsx
+++ b/frontend/src/portals/creator/pages/CreatorFundingSettings.tsx
@@ -74,7 +74,7 @@ export default function CreatorFundingSettings() {
   }, []);
 
   useEffect(() => {
-    loadFundingData();
+    void loadFundingData();
   }, [loadFundingData]);
 
   const handleSave = async () => {

--- a/frontend/src/portals/creator/pages/CreatorInvestors.tsx
+++ b/frontend/src/portals/creator/pages/CreatorInvestors.tsx
@@ -75,7 +75,7 @@ export default function CreatorInvestors() {
   }, []);
 
   useEffect(() => {
-    loadInvestors();
+    void loadInvestors();
   }, [loadInvestors]);
 
   const filteredInvestors = investors.filter(inv => {

--- a/frontend/src/portals/creator/pages/CreatorPitchView.tsx
+++ b/frontend/src/portals/creator/pages/CreatorPitchView.tsx
@@ -130,7 +130,7 @@ const CreatorPitchView: React.FC = () => {
 
   useEffect(() => {
     if (id) {
-      fetchPitchData();
+      void fetchPitchData();
       checkOwnership();
     }
   }, [id]);

--- a/frontend/src/portals/creator/pages/CreatorPitchesDrafts.tsx
+++ b/frontend/src/portals/creator/pages/CreatorPitchesDrafts.tsx
@@ -108,7 +108,7 @@ export default function CreatorPitchesDrafts() {
   const [selectedDrafts, setSelectedDrafts] = useState<string[]>([]);
 
   useEffect(() => {
-    loadDrafts();
+    void loadDrafts();
   }, []);
 
   const filteredDrafts = useMemo(() => {

--- a/frontend/src/portals/creator/pages/CreatorPitchesPublished.tsx
+++ b/frontend/src/portals/creator/pages/CreatorPitchesPublished.tsx
@@ -76,7 +76,7 @@ export default function CreatorPitchesPublished() {
   const [sortBy, setSortBy] = useState<string>('recent');
 
   useEffect(() => {
-    loadPublishedPitches();
+    void loadPublishedPitches();
   }, []);
 
   const loadPublishedPitches = async () => {
@@ -373,7 +373,7 @@ export default function CreatorPitchesPublished() {
                     <button
                       onClick={(e) => {
                         e.stopPropagation();
-                        navigator.clipboard.writeText(`${window.location.origin}/pitch/${pitch.id}`);
+                        void navigator.clipboard.writeText(`${window.location.origin}/pitch/${pitch.id}`);
                       }}
                       className="p-2 bg-gray-50 text-gray-600 rounded-lg hover:bg-gray-100 transition"
                     >

--- a/frontend/src/portals/creator/pages/CreatorSlateDetail.tsx
+++ b/frontend/src/portals/creator/pages/CreatorSlateDetail.tsx
@@ -50,7 +50,7 @@ export default function CreatorSlateDetailPage() {
 
   useEffect(() => {
     if (!slateId) return;
-    loadSlate();
+    void loadSlate();
   }, [slateId]);
 
   const loadSlate = async () => {

--- a/frontend/src/portals/creator/pages/CreatorSlates.tsx
+++ b/frontend/src/portals/creator/pages/CreatorSlates.tsx
@@ -21,7 +21,7 @@ export default function CreatorSlates() {
   const [menuOpen, setMenuOpen] = useState<number | null>(null);
 
   useEffect(() => {
-    loadSlates();
+    void loadSlates();
   }, []);
 
   const loadSlates = async () => {

--- a/frontend/src/portals/creator/pages/CreatorStats.tsx
+++ b/frontend/src/portals/creator/pages/CreatorStats.tsx
@@ -147,7 +147,7 @@ export default function CreatorStats() {
   }, []);
 
   useEffect(() => {
-    loadStats();
+    void loadStats();
   }, [loadStats]);
 
   // Chart configurations

--- a/frontend/src/portals/creator/pages/CreatorTeamInvite.tsx
+++ b/frontend/src/portals/creator/pages/CreatorTeamInvite.tsx
@@ -114,7 +114,7 @@ export default function CreatorTeamInvite() {
   ];
 
   useEffect(() => {
-    loadData();
+    void loadData();
   }, []);
 
   const loadData = async () => {
@@ -262,7 +262,7 @@ export default function CreatorTeamInvite() {
   };
 
   const handleCopyLink = () => {
-    navigator.clipboard.writeText(linkForm.generatedLink);
+    void navigator.clipboard.writeText(linkForm.generatedLink);
     // Show copied confirmation
   };
 

--- a/frontend/src/portals/creator/pages/CreatorTeamMembers.tsx
+++ b/frontend/src/portals/creator/pages/CreatorTeamMembers.tsx
@@ -53,7 +53,7 @@ export default function CreatorTeamMembers() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    loadTeamMembers();
+    void loadTeamMembers();
   }, []);
 
   useEffect(() => {

--- a/frontend/src/portals/creator/pages/CreatorTeamRoles.tsx
+++ b/frontend/src/portals/creator/pages/CreatorTeamRoles.tsx
@@ -56,7 +56,7 @@ export default function CreatorTeamRoles() {
   });
 
   useEffect(() => {
-    loadData();
+    void loadData();
   }, []);
 
   // Helper to get role icon based on role name

--- a/frontend/src/portals/investor/pages/AllInvestments.tsx
+++ b/frontend/src/portals/investor/pages/AllInvestments.tsx
@@ -59,7 +59,7 @@ const AllInvestments = () => {
   const [viewMode, setViewMode] = useState<'grid' | 'table'>('table');
 
   useEffect(() => {
-    loadInvestments();
+    void loadInvestments();
   }, []);
 
   useEffect(() => {

--- a/frontend/src/portals/investor/pages/BudgetAllocation.tsx
+++ b/frontend/src/portals/investor/pages/BudgetAllocation.tsx
@@ -20,7 +20,7 @@ const BudgetAllocation = () => {
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
-    loadBudgetAllocations();
+    void loadBudgetAllocations();
   }, []);
 
   const loadBudgetAllocations = async () => {

--- a/frontend/src/portals/investor/pages/CompletedProjects.tsx
+++ b/frontend/src/portals/investor/pages/CompletedProjects.tsx
@@ -39,7 +39,7 @@ const CompletedProjects = () => {
   const [sortBy, setSortBy] = useState<'recent' | 'roi' | 'returns'>('recent');
 
   useEffect(() => {
-    loadCompletedProjects();
+    void loadCompletedProjects();
   }, []);
 
   const loadCompletedProjects = async () => {

--- a/frontend/src/portals/investor/pages/FinancialOverview.tsx
+++ b/frontend/src/portals/investor/pages/FinancialOverview.tsx
@@ -33,7 +33,7 @@ const FinancialOverview = () => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetchFinancialData();
+    void fetchFinancialData();
   }, []);
 
   const fetchFinancialData = async () => {

--- a/frontend/src/portals/investor/pages/InvestorActivity.tsx
+++ b/frontend/src/portals/investor/pages/InvestorActivity.tsx
@@ -64,7 +64,7 @@ export default function InvestorActivity() {
 
   // Load activity feed from API
   useEffect(() => {
-    loadActivityFeed();
+    void loadActivityFeed();
   }, []);
 
   // Apply filters when activities or filters change

--- a/frontend/src/portals/investor/pages/InvestorAnalytics.tsx
+++ b/frontend/src/portals/investor/pages/InvestorAnalytics.tsx
@@ -195,7 +195,7 @@ export default function InvestorAnalytics() {
   }, [timeRange, filterType]);
 
   useEffect(() => {
-    loadAnalyticsData();
+    void loadAnalyticsData();
   }, [loadAnalyticsData]);
 
   // Chart data for Recharts

--- a/frontend/src/portals/investor/pages/InvestorCoInvestors.tsx
+++ b/frontend/src/portals/investor/pages/InvestorCoInvestors.tsx
@@ -45,7 +45,7 @@ export default function InvestorCoInvestors() {
   const [filteredInvestors, setFilteredInvestors] = useState<CoInvestor[]>([]);
 
   useEffect(() => {
-    loadCoInvestors();
+    void loadCoInvestors();
   }, []);
 
   useEffect(() => {

--- a/frontend/src/portals/investor/pages/InvestorCreators.tsx
+++ b/frontend/src/portals/investor/pages/InvestorCreators.tsx
@@ -58,7 +58,7 @@ export default function InvestorCreators() {
   const [filteredCreators, setFilteredCreators] = useState<Creator[]>([]);
 
   useEffect(() => {
-    loadCreators();
+    void loadCreators();
   }, []);
 
   useEffect(() => {

--- a/frontend/src/portals/investor/pages/InvestorNetwork.tsx
+++ b/frontend/src/portals/investor/pages/InvestorNetwork.tsx
@@ -41,7 +41,7 @@ export default function InvestorNetwork() {
   const [filteredMembers, setFilteredMembers] = useState<NetworkMember[]>([]);
 
   useEffect(() => {
-    loadNetworkData();
+    void loadNetworkData();
   }, []);
 
   useEffect(() => {

--- a/frontend/src/portals/investor/pages/InvestorPerformance.tsx
+++ b/frontend/src/portals/investor/pages/InvestorPerformance.tsx
@@ -39,7 +39,7 @@ export default function InvestorPerformance() {
   const [allocations, setAllocations] = useState<PortfolioAllocation[]>([]);
 
   useEffect(() => {
-    loadPerformanceData();
+    void loadPerformanceData();
   }, [timeRange]);
 
   const loadPerformanceData = async () => {

--- a/frontend/src/portals/investor/pages/InvestorPitchView.tsx
+++ b/frontend/src/portals/investor/pages/InvestorPitchView.tsx
@@ -167,9 +167,9 @@ const InvestorPitchView: React.FC = () => {
 
   useEffect(() => {
     if (id) {
-      fetchPitchData();
-      fetchInvestmentDetail();
-      loadLocalData();
+      void fetchPitchData();
+      void fetchInvestmentDetail();
+      void loadLocalData();
     }
   }, [id, fetchPitchData, fetchInvestmentDetail]);
 
@@ -263,7 +263,7 @@ const InvestorPitchView: React.FC = () => {
       setShowInterestModal(false);
       setInterestForm({ amount: '', level: 'medium', message: '' });
       // Refresh detail to update hasExpressedInterest
-      fetchInvestmentDetail();
+      void fetchInvestmentDetail();
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
       setActionError(e.message);

--- a/frontend/src/portals/investor/pages/InvestorPortfolio.tsx
+++ b/frontend/src/portals/investor/pages/InvestorPortfolio.tsx
@@ -55,7 +55,7 @@ export default function InvestorPortfolio() {
   });
 
   useEffect(() => {
-    loadPortfolioData();
+    void loadPortfolioData();
   }, []);
 
   const loadPortfolioData = async () => {

--- a/frontend/src/portals/investor/pages/InvestorProductionCompanies.tsx
+++ b/frontend/src/portals/investor/pages/InvestorProductionCompanies.tsx
@@ -56,7 +56,7 @@ export default function InvestorProductionCompanies() {
   const [filteredCompanies, setFilteredCompanies] = useState<ProductionCompany[]>([]);
 
   useEffect(() => {
-    loadProductionCompanies();
+    void loadProductionCompanies();
   }, []);
 
   useEffect(() => {

--- a/frontend/src/portals/investor/pages/InvestorReports.tsx
+++ b/frontend/src/portals/investor/pages/InvestorReports.tsx
@@ -40,7 +40,7 @@ const InvestorReports = () => {
         setLoading(false);
       }
     };
-    fetchReports();
+    void fetchReports();
   }, []);
 
   const filteredReports = reports.filter(report => {

--- a/frontend/src/portals/investor/pages/InvestorStats.tsx
+++ b/frontend/src/portals/investor/pages/InvestorStats.tsx
@@ -181,7 +181,7 @@ export default function InvestorStats() {
   }, [timeRange]);
 
   useEffect(() => {
-    loadStats();
+    void loadStats();
   }, [loadStats]);
 
   // Chart data — populated from API, empty by default

--- a/frontend/src/portals/investor/pages/InvestorWallet.tsx
+++ b/frontend/src/portals/investor/pages/InvestorWallet.tsx
@@ -53,9 +53,9 @@ const InvestorWallet = () => {
 
   // Initialize real-time updates and fetch data
   useEffect(() => {
-    loadWalletData();
+    void loadWalletData();
     setupWebSocketConnection();
-    loadNotificationPreferences();
+    void loadNotificationPreferences();
     
     return () => {
       if (wsRef.current) {
@@ -282,7 +282,7 @@ const InvestorWallet = () => {
     if (wsRef.current) {
       wsRef.current.close();
     }
-    logout();
+    void logout();
     void navigate('/');
   };
 

--- a/frontend/src/portals/investor/pages/InvestorWatchlist.tsx
+++ b/frontend/src/portals/investor/pages/InvestorWatchlist.tsx
@@ -61,7 +61,7 @@ export default function InvestorWatchlist() {
   });
 
   useEffect(() => {
-    loadWatchlist();
+    void loadWatchlist();
   }, []);
 
   useEffect(() => {
@@ -300,7 +300,7 @@ export default function InvestorWatchlist() {
             <button
               onClick={() => {
                 setLoading(true);
-                loadWatchlist();
+                void loadWatchlist();
               }}
               className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50"
             >
@@ -327,7 +327,7 @@ export default function InvestorWatchlist() {
                 onClick={() => {
                   setLoading(true);
                   setError(null);
-                  loadWatchlist();
+                  void loadWatchlist();
                 }}
                 className="inline-flex items-center gap-2 px-3 py-1.5 border border-red-300 rounded-md text-sm text-red-700 hover:bg-red-100"
               >

--- a/frontend/src/portals/investor/pages/MarketTrends.tsx
+++ b/frontend/src/portals/investor/pages/MarketTrends.tsx
@@ -16,7 +16,7 @@ const MarketTrends = () => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    loadMarketTrends();
+    void loadMarketTrends();
   }, []);
 
   const loadMarketTrends = async () => {

--- a/frontend/src/portals/investor/pages/NDARequests.tsx
+++ b/frontend/src/portals/investor/pages/NDARequests.tsx
@@ -74,7 +74,7 @@ export default function NDARequests() {
         setSessionChecked(true);
       }
     };
-    validateSession();
+    void validateSession();
   }, [checkSession]);
 
   // Redirect to login if not authenticated
@@ -122,7 +122,7 @@ export default function NDARequests() {
   // Fetch data when session is confirmed
   useEffect(() => {
     if (sessionChecked && isAuthenticated) {
-      fetchNDARequests();
+      void fetchNDARequests();
     }
   }, [sessionChecked, isAuthenticated, fetchNDARequests]);
 

--- a/frontend/src/portals/investor/pages/PendingDeals.tsx
+++ b/frontend/src/portals/investor/pages/PendingDeals.tsx
@@ -65,7 +65,7 @@ const PendingDeals = () => {
   const [searchQuery, setSearchQuery] = useState('');
 
   useEffect(() => {
-    loadPendingDeals();
+    void loadPendingDeals();
   }, []);
 
   useEffect(() => {

--- a/frontend/src/portals/investor/pages/PerformanceTracking.tsx
+++ b/frontend/src/portals/investor/pages/PerformanceTracking.tsx
@@ -50,7 +50,7 @@ const PerformanceTracking = () => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    loadPerformanceData();
+    void loadPerformanceData();
   }, [timeRange]);
 
   const loadPerformanceData = async () => {

--- a/frontend/src/portals/investor/pages/ROIAnalysis.tsx
+++ b/frontend/src/portals/investor/pages/ROIAnalysis.tsx
@@ -35,7 +35,7 @@ const ROIAnalysis = () => {
   const [categoryMetrics, setCategoryMetrics] = useState<ROIMetric[]>([]);
 
   useEffect(() => {
-    loadROIData();
+    void loadROIData();
   }, [timeRange]);
 
   const [error, setError] = useState<string | null>(null);

--- a/frontend/src/portals/investor/pages/RiskAssessment.tsx
+++ b/frontend/src/portals/investor/pages/RiskAssessment.tsx
@@ -15,7 +15,7 @@ const RiskAssessment = () => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    loadRiskAssessment();
+    void loadRiskAssessment();
   }, []);
 
   const loadRiskAssessment = async () => {

--- a/frontend/src/portals/investor/pages/TaxDocuments.tsx
+++ b/frontend/src/portals/investor/pages/TaxDocuments.tsx
@@ -19,7 +19,7 @@ const TaxDocuments = () => {
   const [documents, setDocuments] = useState<any[]>([]);
 
   useEffect(() => {
-    loadTaxDocuments();
+    void loadTaxDocuments();
   }, [year]);
 
   const loadTaxDocuments = async () => {

--- a/frontend/src/portals/investor/pages/TransactionHistory.tsx
+++ b/frontend/src/portals/investor/pages/TransactionHistory.tsx
@@ -38,8 +38,8 @@ const TransactionHistory = () => {
   const [dateRange, setDateRange] = useState<{ start?: string; end?: string }>({});
 
   useEffect(() => {
-    fetchTransactions();
-    fetchStats();
+    void fetchTransactions();
+    void fetchStats();
   }, [page, filterType, searchQuery, dateRange]);
 
   const fetchTransactions = async () => {

--- a/frontend/src/portals/production/pages/ProductionAnalytics.tsx
+++ b/frontend/src/portals/production/pages/ProductionAnalytics.tsx
@@ -59,7 +59,7 @@ export default function ProductionAnalytics() {
 
   // Load analytics data from API
   useEffect(() => {
-    loadAnalyticsData();
+    void loadAnalyticsData();
   }, [timeRange]);
 
   const loadAnalyticsData = async () => {

--- a/frontend/src/portals/production/pages/ProductionCollaborations.tsx
+++ b/frontend/src/portals/production/pages/ProductionCollaborations.tsx
@@ -76,7 +76,7 @@ export default function ProductionCollaborations() {
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
 
   useEffect(() => {
-    fetchCollaborations();
+    void fetchCollaborations();
   }, []);
 
   const fetchCollaborations = async () => {
@@ -539,7 +539,7 @@ export default function ProductionCollaborations() {
                   });
                   toast.success('Collaboration created');
                   setShowCreateModal(false);
-                  fetchCollaborations();
+                  void fetchCollaborations();
                 } catch (err) {
                   const error = err instanceof Error ? err : new Error(String(err));
                   toast.error(error.message);

--- a/frontend/src/portals/production/pages/ProductionPitchView.tsx
+++ b/frontend/src/portals/production/pages/ProductionPitchView.tsx
@@ -229,8 +229,8 @@ const ProductionPitchView: React.FC = () => {
 
   useEffect(() => {
     if (id) {
-      fetchPitchData();
-      loadProductionData();
+      void fetchPitchData();
+      void loadProductionData();
     }
   }, [id]);
 
@@ -1444,7 +1444,7 @@ const ProductionPitchView: React.FC = () => {
                 className="hidden"
                 onChange={(e) => {
                   const file = e.target.files?.[0];
-                  if (file) handleAutoFill(file);
+                  if (file) void handleAutoFill(file);
                 }}
               />
               <button

--- a/frontend/src/portals/production/pages/ProductionSaved.tsx
+++ b/frontend/src/portals/production/pages/ProductionSaved.tsx
@@ -71,7 +71,7 @@ export default function ProductionSaved() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetchSavedPitches();
+    void fetchSavedPitches();
   }, [filterGenre, sortBy]);
 
   const fetchSavedPitches = async () => {
@@ -295,7 +295,7 @@ export default function ProductionSaved() {
                       className="bg-white/90 hover:bg-white"
                       onClick={(e) => {
                         e.stopPropagation();
-                        handleRemoveSaved(pitch.id);
+                        void handleRemoveSaved(pitch.id);
                       }}
                     >
                       <BookmarkCheck className="w-4 h-4 text-purple-600" />

--- a/frontend/src/portals/production/pages/ProductionSettingsNotifications.tsx
+++ b/frontend/src/portals/production/pages/ProductionSettingsNotifications.tsx
@@ -118,7 +118,7 @@ export default function ProductionSettingsNotifications() {
         // Use defaults if preferences endpoint fails
       }
     };
-    loadPreferences();
+    void loadPreferences();
   }, []);
 
   const handleToggle = (category: keyof NotificationSettings, setting: string) => {

--- a/frontend/src/portals/production/pages/ProductionSettingsSecurity.tsx
+++ b/frontend/src/portals/production/pages/ProductionSettingsSecurity.tsx
@@ -166,7 +166,7 @@ export default function ProductionSettingsSecurity() {
   }, []);
 
   useEffect(() => {
-    fetchMFAStatus();
+    void fetchMFAStatus();
   }, [fetchMFAStatus]);
 
   const revokeSession = (_sessionId: string) => {

--- a/frontend/src/portals/production/pages/ProductionStats.tsx
+++ b/frontend/src/portals/production/pages/ProductionStats.tsx
@@ -36,7 +36,7 @@ export default function ProductionStats() {
 
   // Load stats data from API
   useEffect(() => {
-    loadStatsData();
+    void loadStatsData();
   }, [timeRange]);
 
   const loadStatsData = async () => {

--- a/frontend/src/portals/production/pages/ProductionSubmissionsAccepted.tsx
+++ b/frontend/src/portals/production/pages/ProductionSubmissionsAccepted.tsx
@@ -71,7 +71,7 @@ export default function ProductionSubmissionsAccepted() {
       }
     };
 
-    fetchAcceptedSubmissions();
+    void fetchAcceptedSubmissions();
   }, []);
 
   const filteredSubmissions = submissions.filter(submission => {

--- a/frontend/src/portals/production/pages/ProductionSubmissionsArchive.tsx
+++ b/frontend/src/portals/production/pages/ProductionSubmissionsArchive.tsx
@@ -66,7 +66,7 @@ export default function ProductionSubmissionsArchive() {
       }
     };
 
-    fetchArchivedSubmissions();
+    void fetchArchivedSubmissions();
   }, []);
 
   const filteredSubmissions = submissions.filter(submission => {
@@ -126,11 +126,11 @@ export default function ProductionSubmissionsArchive() {
   };
 
   const handleRestore = (submissionId: string) => {
-    updateStatus(submissionId, 'reviewing');
+    void updateStatus(submissionId, 'reviewing');
   };
 
   const handlePermanentDelete = (submissionId: string) => {
-    updateStatus(submissionId, 'archived');
+    void updateStatus(submissionId, 'archived');
   };
 
   const handleExport = (submission: ArchivedSubmission) => {

--- a/frontend/src/portals/production/pages/ProductionSubmissionsNew.tsx
+++ b/frontend/src/portals/production/pages/ProductionSubmissionsNew.tsx
@@ -59,7 +59,7 @@ export default function ProductionSubmissionsNew() {
       }
     };
 
-    fetchNewSubmissions();
+    void fetchNewSubmissions();
   }, []);
 
   const filteredSubmissions = submissions.filter(submission => {
@@ -112,15 +112,15 @@ export default function ProductionSubmissionsNew() {
   };
 
   const handleStartReview = (submissionId: string) => {
-    updateStatus(submissionId, 'reviewing');
+    void updateStatus(submissionId, 'reviewing');
   };
 
   const handleQuickApprove = (submissionId: string) => {
-    updateStatus(submissionId, 'accepted');
+    void updateStatus(submissionId, 'accepted');
   };
 
   const handleReject = (submissionId: string) => {
-    updateStatus(submissionId, 'rejected');
+    void updateStatus(submissionId, 'rejected');
   };
 
   const getPriorityColor = (priority: string | undefined) => {

--- a/frontend/src/portals/production/pages/ProductionSubmissionsRejected.tsx
+++ b/frontend/src/portals/production/pages/ProductionSubmissionsRejected.tsx
@@ -64,7 +64,7 @@ export default function ProductionSubmissionsRejected() {
       }
     };
 
-    fetchRejectedSubmissions();
+    void fetchRejectedSubmissions();
   }, []);
 
   const filteredSubmissions = submissions.filter(submission => {
@@ -124,15 +124,15 @@ export default function ProductionSubmissionsRejected() {
   };
 
   const handleReconsider = (submissionId: string) => {
-    updateStatus(submissionId, 'reviewing');
+    void updateStatus(submissionId, 'reviewing');
   };
 
   const handleArchive = (submissionId: string) => {
-    updateStatus(submissionId, 'archived');
+    void updateStatus(submissionId, 'archived');
   };
 
   const handleDelete = (submissionId: string) => {
-    updateStatus(submissionId, 'archived');
+    void updateStatus(submissionId, 'archived');
   };
 
   const handleSendFeedback = (submission: Submission) => {

--- a/frontend/src/portals/production/pages/ProductionSubmissionsReview.tsx
+++ b/frontend/src/portals/production/pages/ProductionSubmissionsReview.tsx
@@ -67,7 +67,7 @@ export default function ProductionSubmissionsReview() {
       }
     };
 
-    fetchReviewSubmissions();
+    void fetchReviewSubmissions();
   }, []);
 
   const filteredSubmissions = submissions.filter(submission => {
@@ -125,15 +125,15 @@ export default function ProductionSubmissionsReview() {
   };
 
   const handleApprove = (submissionId: string) => {
-    updateStatus(submissionId, 'accepted');
+    void updateStatus(submissionId, 'accepted');
   };
 
   const handleReject = (submissionId: string) => {
-    updateStatus(submissionId, 'rejected');
+    void updateStatus(submissionId, 'rejected');
   };
 
   const handleShortlist = (submissionId: string) => {
-    updateStatus(submissionId, 'shortlisted');
+    void updateStatus(submissionId, 'shortlisted');
   };
 
   const handleAddNote = (submissionId: string) => {
@@ -144,7 +144,7 @@ export default function ProductionSubmissionsReview() {
 
   const handleSaveNote = () => {
     if (noteModalSubmissionId && noteText.trim()) {
-      updateStatus(noteModalSubmissionId, 'reviewing', noteText.trim());
+      void updateStatus(noteModalSubmissionId, 'reviewing', noteText.trim());
     }
     setNoteModalOpen(false);
     setNoteModalSubmissionId(null);

--- a/frontend/src/portals/production/pages/ProductionSubmissionsShortlisted.tsx
+++ b/frontend/src/portals/production/pages/ProductionSubmissionsShortlisted.tsx
@@ -63,7 +63,7 @@ export default function ProductionSubmissionsShortlisted() {
       }
     };
 
-    fetchShortlistedSubmissions();
+    void fetchShortlistedSubmissions();
   }, []);
 
   const filteredSubmissions = submissions.filter(submission => {
@@ -117,15 +117,15 @@ export default function ProductionSubmissionsShortlisted() {
   };
 
   const handleApprove = (submissionId: string) => {
-    updateStatus(submissionId, 'accepted');
+    void updateStatus(submissionId, 'accepted');
   };
 
   const handleReject = (submissionId: string) => {
-    updateStatus(submissionId, 'rejected');
+    void updateStatus(submissionId, 'rejected');
   };
 
   const handleStartProduction = (submissionId: string) => {
-    updateStatus(submissionId, 'accepted');
+    void updateStatus(submissionId, 'accepted');
   };
 
   const getMarketPotentialColor = (potential: string) => {

--- a/frontend/src/portals/production/pages/TeamRoles.tsx
+++ b/frontend/src/portals/production/pages/TeamRoles.tsx
@@ -90,7 +90,7 @@ export default function TeamRoles() {
 
   useEffect(() => {
     if (teamId) {
-      fetchRolesAndMembers();
+      void fetchRolesAndMembers();
     } else {
       // No team yet — stop loading and show empty state
       setLoading(false);
@@ -208,7 +208,7 @@ export default function TeamRoles() {
       console.error('Failed to save role:', e);
       setError('Failed to save role: ' + e.message);
       // Rollback
-      fetchRolesAndMembers();
+      void fetchRolesAndMembers();
     }
   };
 

--- a/frontend/src/portals/watcher/pages/WatcherDashboard.tsx
+++ b/frontend/src/portals/watcher/pages/WatcherDashboard.tsx
@@ -100,7 +100,7 @@ export default function WatcherDashboard() {
       void navigate('/login/watcher');
       return;
     }
-    fetchDashboardData();
+    void fetchDashboardData();
   }, [isAuthenticated]);
 
   const fetchDashboardData = async () => {

--- a/frontend/src/shared/contexts/NotificationContext.tsx
+++ b/frontend/src/shared/contexts/NotificationContext.tsx
@@ -114,7 +114,7 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({ chil
   useEffect(() => {
     // Single initial fetch with delay to avoid rate limiting on page load
     const timer = setTimeout(() => {
-      fetchNotifications();
+      void fetchNotifications();
     }, 3000);
 
     return () => clearTimeout(timer);

--- a/frontend/src/shared/contexts/PollingContext.tsx
+++ b/frontend/src/shared/contexts/PollingContext.tsx
@@ -125,7 +125,7 @@ export const PollingProvider: React.FC<PollingProviderProps> = ({
     };
 
     // Start immediately
-    poll();
+    void poll();
   }, [performPoll, pollingInterval, enablePolling]);
 
   /**

--- a/frontend/src/shared/contexts/WebSocketContext.tsx
+++ b/frontend/src/shared/contexts/WebSocketContext.tsx
@@ -288,7 +288,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           // Small delay to let browser networking stabilize
           setTimeout(() => {
             if (!document.hidden) {
-              connect();
+              void connect();
             }
           }, 500);
         }
@@ -732,7 +732,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
     // Update presence to online when connected
     if (user) {
-      updatePresence('online');
+      void updatePresence('online');
     }
     
     // Subscribe to user-specific channels
@@ -1060,7 +1060,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       // Allow time for cleanup before reconnecting
       setTimeout(() => {
         if (authStabilized && isAuthenticated && !isWebSocketDisabled && config.WEBSOCKET_ENABLED) {
-          connect();
+          void connect();
         }
       }, 1000);
     }
@@ -1068,7 +1068,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     previousUserType.current = currentUserType;
     
     if (authStabilized && isAuthenticated && !isConnected && !isWebSocketDisabled && config.WEBSOCKET_ENABLED) {
-      connect();
+      void connect();
     } else if (!isAuthenticated && isConnected) {
       disconnect();
       // Clear all real-time data when user logs out

--- a/frontend/src/shared/hooks/useCurrentTeam.ts
+++ b/frontend/src/shared/hooks/useCurrentTeam.ts
@@ -37,7 +37,7 @@ export function useCurrentTeam() {
   }, []);
 
   useEffect(() => {
-    fetchTeam();
+    void fetchTeam();
   }, [fetchTeam]);
 
   const createDefaultTeam = useCallback(async (name = 'My Team') => {

--- a/frontend/src/utils/csrf.ts
+++ b/frontend/src/utils/csrf.ts
@@ -182,23 +182,23 @@ export class CSRFTokenManager {
   
   start(): void {
     // Initial check
-    this.checkAndRefreshToken();
+    void this.checkAndRefreshToken();
     
     // Set up periodic refresh
     this.refreshInterval = window.setInterval(() => {
-      this.checkAndRefreshToken();
+      void this.checkAndRefreshToken();
     }, this.REFRESH_INTERVAL);
     
     // Refresh on visibility change
     document.addEventListener('visibilitychange', () => {
       if (!document.hidden) {
-        this.checkAndRefreshToken();
+        void this.checkAndRefreshToken();
       }
     });
     
     // Refresh on online event
     window.addEventListener('online', () => {
-      this.checkAndRefreshToken();
+      void this.checkAndRefreshToken();
     });
   }
   

--- a/frontend/src/utils/fileDownloads.ts
+++ b/frontend/src/utils/fileDownloads.ts
@@ -88,6 +88,6 @@ export async function handleFileDownload(url: string, fileName?: string): Promis
 export function createDownloadClickHandler(url: string, fileName?: string) {
   return (event: React.MouseEvent) => {
     event.preventDefault();
-    handleFileDownload(url, fileName);
+    void handleFileDownload(url, fileName);
   };
 }

--- a/scripts/frontend-lint-gate.mjs
+++ b/scripts/frontend-lint-gate.mjs
@@ -28,7 +28,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 // ── The baseline. Lower it (never raise it) as frontend lint errors are fixed. ──
-const BASELINE = 7727;
+const BASELINE = 7466;
 // 2026-06-27: created at the measured floor (8908 errors / 184 warnings). Top
 // rules: no-unsafe-member-access, no-unsafe-assignment, no-explicit-any,
 // no-unused-vars, no-misused-promises. The gate blocks any NEW error.
@@ -54,6 +54,10 @@ const BASELINE = 7727;
 // checksVoidReturn.attributes:false (eslint.config.js) — async JSX event handlers
 // are idiomatic, safe React (React discards the return). Rule stays ON for timers,
 // callbacks, object handlers (26 genuine cases remain → C1c-residual follow-up).
+// 2026-06-28: lowered 7727 -> 7466 (-261). C1b-1: void-prefixed bare-statement
+// floating promises (load/fetch/other calls) across 150 files, behavior-preserving.
+// ~58 multi-line forms (.then chains, IIFEs, inline effect/handler calls) remain
+// for C1b-2 (.then chains get real .catch()).
 
 const LIST = process.argv.includes('--list');
 


### PR DESCRIPTION
Continues the promise-handling workstream (**C1**, [#384](https://github.com/WizardryPro/pitchey-app/issues/384)). Marked **261 bare-statement floating promises** (load/fetch/other unawaited calls) across **150 files** with the `void` operator.

`void` is behavior-preserving — the promise was already floating; `void` makes the fire-and-forget intent explicit and satisfies `no-floating-promises`. Applied via eslint's own line numbers, only to single-line bare-call statements (`^\s*ident(...);$`), skipping assignments/returns/awaits. Caught and fixed 3 `if (cond) asyncCall();` lines (moved `void` to the inner call, not the `if`).

~58 multi-line forms remain (`.then()` chains → real `.catch()`, IIFEs, inline effect/handler calls) → **C1b-2** follow-up.

### Result
- **261 lint errors cleared** (7727 → 7466)
- app `tsc` clean (0 errors), **full frontend suite green (5211 tests)**
- baseline ratcheted to **7466**

🤖 Generated with [Claude Code](https://claude.com/claude-code)