### PR TITLE
chore(lint): wrap timer/handler misused-promises (C1c-residual-1)

### DIFF
--- a/frontend/src/features/analytics/components/Analytics/EnhancedInvestorAnalytics.tsx
+++ b/frontend/src/features/analytics/components/Analytics/EnhancedInvestorAnalytics.tsx
@@ -241,7 +241,7 @@ export const EnhancedInvestorAnalytics: React.FC<InvestorAnalyticsProps> = ({
     // Set up auto-refresh every 5 minutes if enabled
     let interval: NodeJS.Timeout;
     if (autoRefresh) {
-      interval = setInterval(fetchAnalyticsData, 5 * 60 * 1000);
+      interval = setInterval(() => void fetchAnalyticsData(), 5 * 60 * 1000);
     }
 
     return () => {

--- a/frontend/src/features/analytics/components/Analytics/EnhancedProductionAnalytics.tsx
+++ b/frontend/src/features/analytics/components/Analytics/EnhancedProductionAnalytics.tsx
@@ -76,7 +76,7 @@ export const EnhancedProductionAnalytics: React.FC<PitchEvaluationProps> = (prop
     void fetchChartData();
     let interval: NodeJS.Timeout;
     if (autoRefresh) {
-      interval = setInterval(fetchChartData, 5 * 60 * 1000);
+      interval = setInterval(() => void fetchChartData(), 5 * 60 * 1000);
     }
     return () => { if (interval) clearInterval(interval); };
   }, [timeRange, autoRefresh, fetchChartData]);

--- a/frontend/src/features/ndas/components/NDA/NDADashboard.tsx
+++ b/frontend/src/features/ndas/components/NDA/NDADashboard.tsx
@@ -225,7 +225,7 @@ export default function NDADashboard({ userId, userRole }: NDADashboardProps) {
           title: 'Download Reports',
           description: 'Export NDA data and analytics',
           icon: Download,
-          action: () => handleDownloadReports(),
+          action: () => { void handleDownloadReports(); },
           color: 'bg-purple-600 hover:bg-purple-700'
         }
       );

--- a/frontend/src/features/ndas/components/NDA/NDANotificationCenter.tsx
+++ b/frontend/src/features/ndas/components/NDA/NDANotificationCenter.tsx
@@ -225,7 +225,7 @@ export default function NDANotificationCenter({
     void loadNotifications();
 
     // Refresh every 30 seconds
-    const interval = setInterval(loadNotifications, 30000);
+    const interval = setInterval(() => void loadNotifications(), 30000);
 
     return () => clearInterval(interval);
   }, [loadNotifications]);

--- a/frontend/src/features/notifications/components/NotificationBellSafe.tsx
+++ b/frontend/src/features/notifications/components/NotificationBellSafe.tsx
@@ -36,7 +36,7 @@ function NotificationBellSafe({
     void loadUnreadCount();
 
     // Poll every 60 seconds for new notifications
-    const interval = setInterval(loadUnreadCount, 60000);
+    const interval = setInterval(() => void loadUnreadCount(), 60000);
     return () => clearInterval(interval);
   }, []);
 

--- a/frontend/src/features/pitches/components/PitchValidation/ValidationDashboard.tsx
+++ b/frontend/src/features/pitches/components/PitchValidation/ValidationDashboard.tsx
@@ -73,7 +73,7 @@ export const ValidationDashboard: React.FC<ValidationDashboardProps> = ({
   const handleAnalyzeClick = () => {
     onAnalyzeClick?.();
     // Refresh data after analysis
-    setTimeout(fetchDashboardData, 2000);
+    setTimeout(() => void fetchDashboardData(), 2000);
   };
 
   if (loading) {

--- a/frontend/src/features/uploads/services/chunked-upload.service.ts
+++ b/frontend/src/features/uploads/services/chunked-upload.service.ts
@@ -750,7 +750,7 @@ class ChunkedUploadService {
       .finally(() => {
         this.activeUploads.delete(sessionId);
         // Continue processing queue
-        setTimeout(() => this.processQueue(), 100);
+        setTimeout(() => { void this.processQueue(); }, 100);
       });
 
       this.activeUploads.set(sessionId, uploadPromise);

--- a/frontend/src/portals/creator/pages/CreatorSlateDetail.tsx
+++ b/frontend/src/portals/creator/pages/CreatorSlateDetail.tsx
@@ -181,7 +181,7 @@ export default function CreatorSlateDetailPage() {
   }, [slate]);
 
   useEffect(() => {
-    const timer = setTimeout(() => searchPitches(pitchSearch), 300);
+    const timer = setTimeout(() => { void searchPitches(pitchSearch); }, 300);
     return () => clearTimeout(timer);
   }, [pitchSearch, searchPitches]);
 

--- a/frontend/src/portals/watcher/pages/WatcherLibrary.tsx
+++ b/frontend/src/portals/watcher/pages/WatcherLibrary.tsx
@@ -194,7 +194,7 @@ export default function WatcherLibrary() {
             description="Browse the marketplace and save pitches you want to revisit."
             action={{
               label: 'Browse Marketplace',
-              onClick: () => navigate('/watcher/browse'),
+              onClick: () => { void navigate('/watcher/browse'); },
             }}
           />
         ) : (
@@ -210,7 +210,7 @@ export default function WatcherLibrary() {
             description="Open a pitch and tap Like to add it here."
             action={{
               label: 'Browse Marketplace',
-              onClick: () => navigate('/watcher/browse'),
+              onClick: () => { void navigate('/watcher/browse'); },
             }}
           />
         ) : (
@@ -226,7 +226,7 @@ export default function WatcherLibrary() {
             description="Pitches you view will show up here for easy access."
             action={{
               label: 'Discover Pitches',
-              onClick: () => navigate('/watcher/browse'),
+              onClick: () => { void navigate('/watcher/browse'); },
             }}
           />
         ) : (
@@ -242,7 +242,7 @@ export default function WatcherLibrary() {
             description="Follow creators, investors, and production companies to see their latest activity."
             action={{
               label: 'Discover Creators',
-              onClick: () => navigate('/watcher/browse'),
+              onClick: () => { void navigate('/watcher/browse'); },
             }}
           />
         ) : (

--- a/frontend/src/shared/contexts/PollingContext.tsx
+++ b/frontend/src/shared/contexts/PollingContext.tsx
@@ -120,7 +120,7 @@ export const PollingProvider: React.FC<PollingProviderProps> = ({
 
       // Schedule next poll
       if (isPollingRef.current) {
-        pollTimeoutRef.current = setTimeout(poll, pollingInterval);
+        pollTimeoutRef.current = setTimeout(() => void poll(), pollingInterval);
       }
     };
 
@@ -293,7 +293,7 @@ export const useMessagePolling = (conversationId?: string) => {
     void pollMessages(); // Initial poll
 
     // Set up interval (5 seconds for active conversation)
-    intervalRef.current = setInterval(pollMessages, 5000);
+    intervalRef.current = setInterval(() => void pollMessages(), 5000);
 
     return () => {
       setIsPolling(false);

--- a/frontend/src/shared/contexts/WebSocketContext.tsx
+++ b/frontend/src/shared/contexts/WebSocketContext.tsx
@@ -1121,7 +1121,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     setIsWebSocketDisabled(false);
     localStorage.removeItem('pitchey_websocket_disabled');
     if (isAuthenticated && config.WEBSOCKET_ENABLED) {
-      setTimeout(connect, 1000); // Small delay before reconnecting
+      setTimeout(() => void connect(), 1000); // Small delay before reconnecting
     }
   }, [connect, isAuthenticated]);
 

--- a/scripts/frontend-lint-gate.mjs
+++ b/scripts/frontend-lint-gate.mjs
@@ -28,7 +28,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 // ── The baseline. Lower it (never raise it) as frontend lint errors are fixed. ──
-const BASELINE = 7408;
+const BASELINE = 7393;
 // 2026-06-27: created at the measured floor (8908 errors / 184 warnings). Top
 // rules: no-unsafe-member-access, no-unsafe-assignment, no-explicit-any,
 // no-unused-vars, no-misused-promises. The gate blocks any NEW error.
@@ -60,6 +60,12 @@ const BASELINE = 7408;
 // floating promises — voided .then() chains + IIFEs (prepend), and inserted `void`
 // before inner calls in inline effects/handlers/if-blocks. no-floating-promises is
 // now ZERO across the codebase (all 407 of the rule's hits resolved over C1a/b).
+// 2026-06-28: lowered 7408 -> 7393 (-15). C1c-residual-1: wrapped 15 misused-promises
+// — timers with async fn-refs (setInterval(fn)→setInterval(()=>void fn())) + object/
+// arrow handlers (onClick:()=>nav()→()=>{void nav()}). 11 subtle ones deferred:
+// inline setInterval(async()=>) ×4, new Promise(async executor), WS context-value ×2,
+// test mocks ×4. (Pre-existing flaky CharacterManagement scrollIntoView timer test is
+// unrelated — not in this diff, passes in isolation.)
 
 const LIST = process.argv.includes('--list');
 


### PR DESCRIPTION
Clears **15 of the 26** genuine `no-misused-promises` cases the C1c config change left (the non-JSX-attribute ones the rule correctly still flags) — see [#384](https://github.com/WizardryPro/pitchey-app/issues/384).

- **timers with async fn-ref**: `setInterval(fn)` → `setInterval(() => void fn())` (analytics refresh, notification polling, validation, polling/websocket reconnect)
- **object/arrow handlers**: `onClick: () => nav()` → `() => { void nav() }` (WatcherLibrary nav cards, NDA download action, slate-search debounce, chunked-upload `processQueue`)

All behavior-preserving (the promise was already floating). **11 subtler cases deferred** to a focused follow-up: inline `setInterval(async () => …)` ×4, the `new Promise(async executor)` antipattern, WebSocket context-value fields ×2, test mocks ×4.

### Result
- **15 lint errors cleared** (7408 → 7393), `tsc` clean (0 errors), baseline **7393**

> ⚠️ The full vitest run surfaced a **pre-existing flaky test** (`CharacterManagement` — a `setTimeout(scrollIntoView)` firing after teardown; jsdom has no `scrollIntoView`). It's **not in this diff** and passes 37/37 in isolation. If CI's Frontend Tests flakes on it, re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)