### PR TITLE
chore(lint): disable no-undef for TS + ignore non-app files (C3a)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -73,8 +73,13 @@ export default [
       '*.config.js',
       '*.config.ts',
       'vite.config.ts',
+      'vite.config.*.ts',
       'vitest.config.ts',
-      'playwright.config.ts'
+      'playwright.config.ts',
+      // Not part of tsconfig.app.json — separate build surfaces / generated output.
+      // (They produced only "parserOptions.project" parse errors, never real lint.)
+      'functions/**',
+      'worker/**'
     ]
   },
 
@@ -139,6 +144,13 @@ export default [
     plugins: COMMON_PLUGINS,
     rules: {
       ...COMMON_RULES,
+
+      // no-undef is redundant in TypeScript (the compiler already errors on
+      // undefined identifiers) and false-positives on ambient globals like
+      // `React`, `NodeJS`, `process`. Disabling it is the typescript-eslint
+      // recommendation. TS (the worker type-check gate + tsconfig.app.json) is
+      // the real net for undefined references.
+      'no-undef': 'off',
 
       // TypeScript strict rules for production code
       '@typescript-eslint/no-explicit-any': 'error',

--- a/scripts/frontend-lint-gate.mjs
+++ b/scripts/frontend-lint-gate.mjs
@@ -28,7 +28,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 // ── The baseline. Lower it (never raise it) as frontend lint errors are fixed. ──
-const BASELINE = 7393;
+const BASELINE = 7306;
 // 2026-06-27: created at the measured floor (8908 errors / 184 warnings). Top
 // rules: no-unsafe-member-access, no-unsafe-assignment, no-explicit-any,
 // no-unused-vars, no-misused-promises. The gate blocks any NEW error.
@@ -66,6 +66,11 @@ const BASELINE = 7393;
 // inline setInterval(async()=>) ×4, new Promise(async executor), WS context-value ×2,
 // test mocks ×4. (Pre-existing flaky CharacterManagement scrollIntoView timer test is
 // unrelated — not in this diff, passes in isolation.)
+// 2026-06-28: lowered 7393 -> 7306 (-87). C3a (config hygiene): disabled `no-undef`
+// for TS (redundant w/ TS, false-positives React/NodeJS/process — tseslint rec) and
+// ignored functions/**, worker/**, vite.config.*.ts (outside tsconfig.app.json /
+// build artifacts — they only produced parserOptions.project parse errors, never
+// real lint). no-undef + parse errors now 0.
 
 const LIST = process.argv.includes('--list');
 


### PR DESCRIPTION
Two config-hygiene fixes clearing the two largest **C3** small-rule buckets ([#384](https://github.com/WizardryPro/pitchey-app/issues/384)) — both config noise, not bugs:

- **`no-undef` (71)** — all `React` (50) / `NodeJS` (19) / `process` (2) ambient-global false positives. `no-undef` is redundant under TypeScript (the compiler already errors on undefined identifiers); disabling it for TS is the **typescript-eslint recommendation**. Set `'no-undef': 'off'` in the source block.
- **parse errors (16)** — `functions/**`, `worker/**` (wrangler build artifacts), and `vite.config.*.ts` are outside `tsconfig.app.json`, so type-aware lint only emitted `"parserOptions.project"` parse errors there (never real lint). Added to ignores.

### Result
- **87 cleared** (7393 → 7306); `no-undef` + parse errors now **0**
- eslint-config-only — no runtime impact, `tsc` clean (0 errors), baseline **7306**

🤖 Generated with [Claude Code](https://claude.com/claude-code)