### PR TITLE
fix(credits): auto-reverse credit-pack refunds + admin grant/revoke tool (R4)

### DIFF
--- a/src/handlers/admin-credits.ts
+++ b/src/handlers/admin-credits.ts
@@ -1,0 +1,159 @@
+/**
+ * Admin credit adjustments — manual grant / revoke with an audit trail.
+ *
+ * Why this exists: refunds and goodwill adjustments previously required a
+ * hand-written DB edit (the `charge.refunded` webhook only auto-reverses
+ * credit-pack purchases it can link via metadata; everything else routes here).
+ * Both endpoints are admin-gated, validate their body, mutate the canonical
+ * balance in `user_credits`, and write a `credit_transactions` ledger row whose
+ * `metadata` records the acting admin + reason — so every manual change is
+ * auditable without a separate table or migration.
+ *
+ * Registered (and excluded from the AdminEndpointsHandler intercept) in
+ * worker-integrated.ts:
+ *   POST /api/admin/credits/grant   { userId, amount, reason }
+ *   POST /api/admin/credits/revoke  { userId, amount, reason }
+ */
+
+import { z } from 'zod';
+import { getDb } from '../db/connection';
+import type { Env } from '../db/connection';
+import { getCorsHeaders } from '../utils/response';
+import { getUserId } from '../utils/auth-extract';
+
+function jsonResponse(data: unknown, origin: string | null, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...getCorsHeaders(origin) },
+  });
+}
+
+const bodySchema = z.object({
+  userId: z.coerce.number().int().positive(),
+  amount: z.coerce.number().int().positive(),
+  reason: z.string().trim().min(1).max(500),
+});
+
+// Shared core for grant (delta > 0) and revoke (delta < 0). Returns the response.
+async function adjustCredits(
+  request: Request,
+  env: Env,
+  action: 'grant' | 'revoke',
+): Promise<Response> {
+  const origin = request.headers.get('Origin');
+  const sql = getDb(env);
+  const adminId = await getUserId(request, env);
+
+  if (!sql || !adminId) {
+    return jsonResponse({ success: false, error: 'Authentication required' }, origin, 401);
+  }
+
+  // Enforce admin inside the handler — once excluded from the /api/admin/*
+  // intercept, the AdminEndpointsHandler's gate no longer applies.
+  const [me] = await sql`SELECT user_type FROM users WHERE id = ${adminId}`;
+  if (me?.user_type !== 'admin') {
+    return jsonResponse({ success: false, error: 'Admin access required' }, origin, 403);
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse({ success: false, error: 'Invalid JSON body' }, origin, 400);
+  }
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return jsonResponse(
+      { success: false, error: 'Invalid body', issues: parsed.error.issues },
+      origin,
+      400,
+    );
+  }
+  const { userId, amount, reason } = parsed.data;
+
+  try {
+    const [target] = await sql`SELECT id FROM users WHERE id = ${userId}`;
+    if (!target) {
+      return jsonResponse({ success: false, error: 'Target user not found' }, origin, 404);
+    }
+
+    const currentRows = await sql`SELECT balance FROM user_credits WHERE user_id = ${userId}`;
+    const balanceBefore = currentRows.length > 0 ? (currentRows[0].balance || 0) : 0;
+
+    // Clamp so a revoke can never drive the balance below zero; the effective
+    // delta is what actually moved (a grant always moves the full amount).
+    const delta = action === 'grant' ? amount : -Math.min(amount, balanceBefore);
+    const balanceAfter = balanceBefore + delta;
+
+    if (action === 'grant') {
+      await sql`
+        INSERT INTO user_credits (user_id, balance, total_purchased, total_used, last_updated)
+        VALUES (${userId}, ${amount}, ${amount}, 0, NOW())
+        ON CONFLICT (user_id) DO UPDATE SET
+          balance = user_credits.balance + ${amount},
+          total_purchased = user_credits.total_purchased + ${amount},
+          last_updated = NOW()
+      `;
+    } else if (delta !== 0) {
+      await sql`
+        UPDATE user_credits
+        SET balance = ${balanceAfter}, last_updated = NOW()
+        WHERE user_id = ${userId}
+      `;
+    }
+
+    const meta = JSON.stringify({ admin_user_id: adminId, reason, admin_action: action });
+    await sql`
+      INSERT INTO credit_transactions (user_id, type, amount, description, balance_before, balance_after, metadata, created_at)
+      VALUES (
+        ${userId},
+        ${action === 'grant' ? 'bonus' : 'refund'},
+        ${delta},
+        ${`Admin ${action}: ${reason}`},
+        ${balanceBefore},
+        ${balanceAfter},
+        ${meta}::jsonb,
+        NOW()
+      )
+    `;
+
+    console.log(JSON.stringify({
+      level: 'info',
+      category: 'admin_credits',
+      action,
+      admin_user_id: adminId,
+      target_user_id: userId,
+      requested_amount: amount,
+      applied_delta: delta,
+      balance_before: balanceBefore,
+      balance_after: balanceAfter,
+    }));
+
+    return jsonResponse(
+      {
+        success: true,
+        data: {
+          userId,
+          action,
+          requestedAmount: amount,
+          appliedDelta: delta,
+          balanceBefore,
+          balanceAfter,
+        },
+      },
+      origin,
+    );
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error(`adminCredits ${action} error:`, e.message);
+    return jsonResponse({ success: false, error: `Failed to ${action} credits` }, origin, 500);
+  }
+}
+
+export function adminGrantCreditsHandler(request: Request, env: Env): Promise<Response> {
+  return adjustCredits(request, env, 'grant');
+}
+
+export function adminRevokeCreditsHandler(request: Request, env: Env): Promise<Response> {
+  return adjustCredits(request, env, 'revoke');
+}

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -3892,6 +3892,17 @@ class RouteRegistry {
       return subscriptionGrantsStatusHandler(req, this.env);
     });
 
+    // Manual credit grant/revoke with audit trail — admin-only. Used for refunds
+    // the charge.refunded webhook can't auto-link, plus goodwill adjustments.
+    this.register('POST', '/api/admin/credits/grant', async (req) => {
+      const { adminGrantCreditsHandler } = await import('./handlers/admin-credits');
+      return adminGrantCreditsHandler(req, this.env);
+    });
+    this.register('POST', '/api/admin/credits/revoke', async (req) => {
+      const { adminRevokeCreditsHandler } = await import('./handlers/admin-credits');
+      return adminRevokeCreditsHandler(req, this.env);
+    });
+
     // Launch promo-code report (FreeThePitch100 / LifesAPitch50) — admin-only.
     // Reads live from Stripe: redemption counts + who signed up with each code.
     this.register('GET', '/api/admin/promo-codes', async (req) => {
@@ -4407,11 +4418,13 @@ class RouteRegistry {
     //   - verifications     : company verification review
     //   - heat-scores       : heat recalculation trigger
     //   - subscription-grants: founding-grant observability
+    //   - credits           : manual credit grant/revoke with audit
     if (this.adminHandler && path.startsWith('/api/admin/') &&
         !path.startsWith('/api/admin/metrics') && !path.startsWith('/api/admin/health') &&
         !path.startsWith('/api/admin/promo-codes') &&
         !path.startsWith('/api/admin/verifications') &&
         !path.startsWith('/api/admin/heat-scores') &&
+        !path.startsWith('/api/admin/credits') &&
         !path.startsWith('/api/admin/subscription-grants')) {
       const corsHeaders = getCorsHeaders(request.headers.get('Origin'));
       const authResult = await this.validateAuth(request);
@@ -11504,11 +11517,21 @@ pitchey_analytics_datapoints_per_minute 1250
                   last_updated = NOW()
               `;
 
+              // Store Stripe refs in metadata (jsonb) — NOT a stripe_session_id
+              // column, which does not exist on credit_transactions in prod (the
+              // old code referenced it and threw, so credit-pack purchases never
+              // recorded). payment_intent is the key charge.refunded matches on to
+              // auto-reverse this grant; one-shot mode=payment sessions carry it.
+              const purchaseMeta = JSON.stringify({
+                stripe_session_id: session.id,
+                payment_intent: session.payment_intent || null,
+                package: session.metadata.package || 'custom',
+              });
               await sql`
-                INSERT INTO credit_transactions (user_id, type, amount, description, balance_before, balance_after, stripe_session_id, created_at)
+                INSERT INTO credit_transactions (user_id, type, amount, description, balance_before, balance_after, metadata, created_at)
                 VALUES (${userId}, 'purchase', ${credits},
                   ${'Purchased ' + credits + ' credits (' + (session.metadata.package || 'custom') + ')'},
-                  ${currentBalance}, ${currentBalance + credits}, ${session.id}, NOW())
+                  ${currentBalance}, ${currentBalance + credits}, ${purchaseMeta}::jsonb, NOW())
               `;
 
               console.log(JSON.stringify({
@@ -11916,25 +11939,100 @@ pitchey_analytics_datapoints_per_minute 1250
         }
 
         case 'charge.refunded': {
-          // Refunds carry charge.payment_intent, not the checkout session id we
-          // persist on credit_transactions.stripe_session_id, so we cannot
-          // cleanly resolve user_id without an extra Stripe API call plus a
-          // partial-refund proration policy. Log loudly so ops reverses credits
-          // manually via the admin grant tool. Full revocation = follow-up work.
+          // Auto-reverse ONLY credit-pack purchases we can link via the
+          // payment_intent stored in credit_transactions.metadata (see the
+          // checkout.session.completed grant above). Subscription/other refunds
+          // and unlinkable grants fall through to an actionable Slack alert — ops
+          // reverses those with the admin credit tool. amount_refunded is
+          // cumulative, so partial-then-full refunds reconcile correctly and
+          // re-delivery never double-reverses.
           const charge = event.data.object;
-          console.error(JSON.stringify({
-            level: 'error',
-            category: 'stripe_webhook',
-            event_id: event.id,
-            event_type: event.type,
-            action: 'refund_received_manual_action_required',
-            charge_id: charge.id,
-            payment_intent: charge.payment_intent || null,
-            amount_refunded: (charge.amount_refunded || 0) / 100,
-            amount_total: (charge.amount || 0) / 100,
-            currency: charge.currency,
-            customer: charge.customer || null,
-          }));
+          const pi: string | null = charge.payment_intent || null;
+          try {
+            let handled = false;
+            if (pi && sql) {
+              const grantRows = await sql`
+                SELECT id, user_id, amount
+                FROM credit_transactions
+                WHERE type = 'purchase' AND metadata->>'payment_intent' = ${pi}
+                ORDER BY created_at DESC LIMIT 1
+              ` as { id: number; user_id: number; amount: number }[];
+              if (grantRows.length > 0) {
+                const grant = grantRows[0];
+                const granted = grant.amount; // positive credits granted
+                const amountTotal = charge.amount || 0;
+                const amountRefunded = charge.amount_refunded || 0;
+                const targetReverse = amountTotal > 0
+                  ? Math.round(granted * amountRefunded / amountTotal)
+                  : granted;
+                const reversedRows = await sql`
+                  SELECT COALESCE(SUM(-amount), 0)::int AS reversed
+                  FROM credit_transactions
+                  WHERE type = 'refund' AND metadata->>'payment_intent' = ${pi}
+                ` as { reversed: number }[];
+                const alreadyReversed = reversedRows[0]?.reversed || 0;
+                const delta = Math.min(targetReverse, granted) - alreadyReversed;
+                if (delta > 0) {
+                  const balRows = await sql`SELECT balance FROM user_credits WHERE user_id = ${grant.user_id}`;
+                  const balanceBefore = balRows.length > 0 ? (balRows[0].balance || 0) : 0;
+                  const applied = Math.min(delta, balanceBefore); // never below 0
+                  const balanceAfter = balanceBefore - applied;
+                  if (applied > 0) {
+                    await sql`UPDATE user_credits SET balance = ${balanceAfter}, last_updated = NOW() WHERE user_id = ${grant.user_id}`;
+                  }
+                  const refundMeta = JSON.stringify({ payment_intent: pi, charge_id: charge.id, source: 'charge.refunded' });
+                  await sql`
+                    INSERT INTO credit_transactions (user_id, type, amount, description, balance_before, balance_after, metadata, created_at)
+                    VALUES (${grant.user_id}, 'refund', ${-applied},
+                      ${'Refund reversal for charge ' + charge.id},
+                      ${balanceBefore}, ${balanceAfter}, ${refundMeta}::jsonb, NOW())
+                  `;
+                  console.log(JSON.stringify({
+                    level: 'info', category: 'stripe_webhook', event_id: event.id, event_type: event.type,
+                    action: 'refund_reversed', charge_id: charge.id, payment_intent: pi,
+                    user_id: grant.user_id, credits_reversed: applied, balance_after: balanceAfter,
+                  }));
+                } else {
+                  console.log(JSON.stringify({
+                    level: 'info', category: 'stripe_webhook', event_id: event.id, event_type: event.type,
+                    action: 'refund_already_reversed', charge_id: charge.id, payment_intent: pi,
+                  }));
+                }
+                handled = true;
+              }
+            }
+            if (!handled) {
+              // No linkable credit-pack grant (subscription refund, no PI, or a
+              // pre-metadata grant). Page ops to reverse via the admin tool.
+              console.error(JSON.stringify({
+                level: 'error', category: 'stripe_webhook', event_id: event.id, event_type: event.type,
+                action: 'refund_received_manual_action_required', charge_id: charge.id,
+                payment_intent: pi,
+                amount_refunded: (charge.amount_refunded || 0) / 100,
+                amount_total: (charge.amount || 0) / 100,
+                currency: charge.currency, customer: charge.customer || null,
+              }));
+              await postSlackAlert(
+                (this.env as any).SLACK_WEBHOOK_URL,
+                '🚨 Stripe refund needs manual review',
+                `Refund of ${((charge.amount_refunded || 0) / 100).toFixed(2)} ${(charge.currency || '').toUpperCase()} on charge ${charge.id} (customer ${charge.customer || 'unknown'}) could not be auto-linked to a credit-pack grant. Reverse via POST /api/admin/credits/revoke if credits were granted.`,
+              );
+            }
+          } catch (err) {
+            const e = err instanceof Error ? err : new Error(String(err));
+            console.error(JSON.stringify({
+              level: 'error', category: 'stripe_webhook', event_id: event.id, event_type: event.type,
+              action: 'refund_reversal_failed', charge_id: charge.id, payment_intent: pi, error: e.message,
+            }));
+            try { Sentry.captureException(e, { tags: { stripe: 'refund_reversal' } }); } catch { /* Sentry hub not initialized */ }
+            // The outer catch returns 200 (Stripe won't retry), so paging Slack is
+            // the only way ops learns a reversal failed — do not let this be silent.
+            await postSlackAlert(
+              (this.env as any).SLACK_WEBHOOK_URL,
+              '🚨 Stripe refund reversal FAILED',
+              `charge ${charge.id} (PI ${pi}) — automatic credit reversal errored: ${e.message}. Manual action required via the admin credit tool.`,
+            );
+          }
           break;
         }
 


### PR DESCRIPTION
## What
Three linked money-path fixes from the live-code roadmap (R4).

**1. Latent grant bug.** The credit-pack grant in `checkout.session.completed` inserted into `credit_transactions.stripe_session_id` — a column that **does not exist** in prod. No `purchase` row has recorded since `2026-02-08` (pre-Stripe-go-live). Now writes Stripe refs into the existing `metadata` jsonb (`{stripe_session_id, payment_intent}`). **No migration needed.**

**2. `charge.refunded` auto-reversal.** Now reverses credit-pack purchases it can link via `metadata->>'payment_intent'` (the field fix #1 stores). Proportional to `amount_refunded` (cumulative), clamps balance ≥ 0, idempotent on re-delivery (`delta = targetReverse − already_reversed`). Subscription/other/unlinkable refunds fall through to an **actionable Slack alert** → ops uses the admin tool. Reversal errors page Slack (the shared outer catch returns 200, so this is the only non-silent path) — never a swallowed success.

**3. Admin tooling.** `POST /api/admin/credits/grant` + `/revoke` (`handlers/admin-credits.ts`). Zod-validated, admin-enforced **inside** the handler, excluded from the `AdminEndpointsHandler` `/api/admin/*` intercept. Mutates `user_credits.balance` (revoke clamps ≥ 0) and writes a `credit_transactions` audit row (`grant`=`bonus`, `revoke`=`refund`) with `{admin_user_id, reason, admin_action}` in `metadata`.

## Verification gates
- **G1 enum safety:** `purchase/refund/bonus` all insert cleanly — proven on a throwaway Neon branch (no constraint violation). The prod `type` is an ENUM `{purchase,usage,refund,bonus}`; no `grant`.
- **G2 routing:** both routes registered (`worker-integrated.ts`), `credits` added to the admin-intercept exclusion list, admin enforced inside the handler. No shadowing.
- **G3 reversal e2e (Neon branch):** full refund 100→50 credits; refund row `type='refund'` amount −50; **re-delivery delta = 0** (no double-reverse); admin grant (`bonus` +25) and revoke (`refund` −10) rows written with `admin_action` metadata.
- **G4 hygiene:** `catch-swallow-gate.mjs --include-worker --threshold 0` → 0 untagged; `tsc --noEmit` 0 errors; `build:worker` clean.

## Notes
- Auto-reversal is scoped to **credit-packs only** (deliberate — see roadmap decision). Subscription refunds are logged + Slack-paged for manual handling.
- No frontend admin UI — endpoints are ops-ready; UI is an optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)