### PR TITLE
fix(ops): detect Neon compute-quota exhaustion proactively + reactively (R6)

### DIFF
--- a/.github/workflows/simple-health-check.yml
+++ b/.github/workflows/simple-health-check.yml
@@ -3,11 +3,13 @@ name: Simple Health Check
 on:
   workflow_dispatch:
   # 2026-05-02: re-enabled at 1hr cadence after the 2026-04-30 Neon-quota
-  # outage (#65). At every-hour, with smoke at every-2hr, the two cron
-  # cycles align at :00 every 2hrs (smoke + health both fire) and miss-
-  # align at :00 odd hours (only health fires) — sustainable on Free tier.
+  # outage (#65). 2026-06-30 (R6): tightened to every 15 min to cut Neon
+  # compute-quota detection latency (the outage class that hit twice). Burn is
+  # negligible — the per-service probe is one `SELECT NOW()` and the new
+  # quota-headroom step is a Neon control-plane API call (no DB compute). See
+  # docs/neon-quota-keepwarm-decision-2026-06-30.md.
   schedule:
-    - cron: '0 * * * *'  # Every hour
+    - cron: '*/15 * * * *'  # Every 15 min
 
 permissions:
   contents: read
@@ -43,6 +45,49 @@ jobs:
             echo "❌ API is down"
             exit 1
           fi
+
+      # Proactive Neon compute-quota headroom (R6). The worker can't read Neon's
+      # usage API (no NEON_API_KEY worker secret), so the BEFORE-exhaustion signal
+      # lives here: a control-plane call (zero DB compute) that reads cpu_used_sec
+      # vs the quota window. Fails (-> Slack + issue) at >= 85% IF a quota ceiling
+      # is configured via the NEON_COMPUTE_QUOTA_SEC repo variable; otherwise it
+      # logs cpu_used_sec for visibility without failing (no false page on an
+      # unknown ceiling). The worker's reactive `neon_quota` service catches the
+      # already-exhausted state via the per-service check below.
+      - name: Check Neon compute-quota headroom
+        id: neon_quota
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ secrets.NEON_PROJECT_ID }}
+          NEON_COMPUTE_QUOTA_SEC: ${{ vars.NEON_COMPUTE_QUOTA_SEC }}
+        run: |
+          if [ -z "$NEON_API_KEY" ] || [ -z "$NEON_PROJECT_ID" ]; then
+            echo "⚠️ NEON_API_KEY / NEON_PROJECT_ID not set — skipping quota headroom check"
+            exit 0
+          fi
+          BODY="$(curl -fsS --retry 3 --retry-delay 2 --retry-all-errors --max-time 20 \
+            -H "Authorization: Bearer $NEON_API_KEY" \
+            "https://console.neon.tech/api/v2/projects/$NEON_PROJECT_ID")"
+          RESULT="$(echo "$BODY" | python3 -c '
+          import sys, json, os
+          p = (json.load(sys.stdin).get("project") or {})
+          used = p.get("cpu_used_sec")
+          reset = p.get("quota_reset_at")
+          ceiling = os.environ.get("NEON_COMPUTE_QUOTA_SEC")
+          if used is None:
+              print("SKIP cpu_used_sec absent from Neon API response"); sys.exit(0)
+          if ceiling and ceiling.isdigit() and int(ceiling) > 0:
+              pct = used / int(ceiling) * 100
+              tag = "BAD" if pct >= 85 else "OK"
+              print(f"{tag} cpu_used={used}s / {ceiling}s = {pct:.1f}% (resets {reset})")
+          else:
+              print(f"INFO cpu_used={used}s (no NEON_COMPUTE_QUOTA_SEC ceiling set; resets {reset})")
+          ')"
+          echo "$RESULT"
+          case "$RESULT" in
+            BAD*) echo "UNHEALTHY_SERVICES=neon_quota_headroom ($RESULT)" >> "$GITHUB_ENV"; exit 1 ;;
+            *)    exit 0 ;;
+          esac
 
       # Per-service check. `curl -f` above only proves /api/health returns 200 —
       # but it returns 200 even when a dependency is broken (the overall `status`

--- a/docs/neon-quota-keepwarm-decision-2026-06-30.md
+++ b/docs/neon-quota-keepwarm-decision-2026-06-30.md
@@ -1,0 +1,80 @@
+# Neon compute-quota: detection, keep-warm, and plan decision (2026-06-30, R6)
+
+## Context
+
+Neon compute-quota exhaustion is the single highest operational risk for launch.
+When the plan's compute-time quota is spent, Neon returns **HTTP 402 on every
+query**, which cascades into login 503s and a silently-empty marketplace (errors
+swallowed). It has taken prod down twice: **2026-04-30 (#65)** and **2026-06-22**.
+
+This doc records the detection added in R6 and the keep-warm / plan decision.
+
+## Two different 402s — do not conflate
+
+| 402 | Source | Meaning |
+|-----|--------|---------|
+| **Neon compute-quota 402** | Neon query layer | Infra quota exhausted → every query 402s. *This is the outage.* |
+| **App `INSUFFICIENT_FUNDS` 402** | `src/utils/api-response.ts` → credit/payment handlers (`worker-integrated.ts:7198/7353/20769/20976`) | Our own "not enough credits" response. Normal. |
+
+These never share a code path: the app 402 is a `Response` object built in payment
+handlers; the Neon 402 is a thrown `NeonDbError` caught in the `/api/health` DB
+probe. The R6 `neon_quota` classifier only inspects the DB-probe catch, so an app
+402 can never trip it and a Neon 402 is never mistaken for credits.
+
+## Detection added in R6
+
+**Reactive (worker, `handleHealth`):** a new `neon_quota` service in `/api/health`.
+`ok` normally; `exhausted` when the DB probe throws a compute-quota-402 signature
+(`402` / `quota` / `compute time` / `exceeded`). `/api/health` still returns **200
+with a degraded body** so the CI parser can read it. Because the CI per-service
+gate treats anything outside `{connected,active,ok,healthy}` as unhealthy, an
+`exhausted` value automatically fires the existing Slack + GitHub-issue alert — no
+new alert channel.
+
+**Proactive (CI, `simple-health-check.yml`):** the worker has **no `NEON_API_KEY`
+secret** (verified via `wrangler secret list`), so it cannot read Neon's usage API.
+The before-exhaustion signal therefore lives in CI: a control-plane call (zero DB
+compute) reads `project.cpu_used_sec` vs the quota window and fails at **≥ 85%**
+when a ceiling is configured. Cron tightened **hourly → every 15 min** to cut
+detection latency.
+
+### Action required to arm the proactive threshold
+
+The proactive check is **log-only until a ceiling is set**. Set the repo variable
+once the plan's compute-time quota (in seconds) is known:
+
+```
+gh variable set NEON_COMPUTE_QUOTA_SEC --body "<plan compute-seconds per window>"
+```
+
+Until then the step logs `cpu_used_sec` each run for trend visibility but does not
+page (no false alarm on an unknown ceiling). The reactive `exhausted` catch still
+pages the moment a real 402 storm begins.
+
+## Keep-warm burn analysis → verdict: **stays OFF**
+
+`KEEP_WARM_DB` (`wrangler.toml:168 = "false"`) gates `keepDatabaseWarm()`
+(`worker-integrated.ts:22512`), which `SELECT 1`s on the `*/5` cron to close
+Neon's autosuspend cold-start gap.
+
+**Burn math (current period):**
+- Observed: `cpu_used_sec ≈ 132,036` s ≈ **36.7 active compute-hours** this quota
+  window (so Neon *is* autosuspending during idle — it is not pinned on).
+- Keep-warm at `*/5` = **288 pings/day**. A ping every 5 min holds Neon awake
+  ~continuously, i.e. ~**730 compute-hours/month** at the 0.25 CU floor.
+- That is **~20× the current burn** — keep-warm would *accelerate* the exact quota
+  exhaustion it is meant to soften.
+
+**Verdict: UNSAFE on the current plan. `KEEP_WARM_DB` stays `false`** (wrangler.toml
+unchanged). Cold-start 530/1016 races are already handled by the DB retry
+classifier (see `project_neon_coldstart_retry`); that is the cheaper mitigation.
+
+## Plan recommendation
+
+The probe only buys warning time; the real fix is plan capacity. Recommended:
+**upgrade the Neon plan to one whose compute-time allowance comfortably exceeds the
+trailing usage with launch headroom, keeping autosuspend ON** (so idle periods stay
+cheap). Do **not** solve this by pinning compute on / enabling keep-warm. Once the
+new plan's quota is known, set `NEON_COMPUTE_QUOTA_SEC` so the proactive check has
+teeth. This is an owner/billing decision — the code change here makes the outage
+*observable*; the plan change makes it *not happen*.

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -5155,6 +5155,15 @@ class RouteRegistry {
       let dbStatus = 'error';
       let dbTime: string | null = null;
       let dbError: string | null = null;
+      // Neon compute-quota dimension (R6). Single-purpose signal: 'ok' unless the
+      // DB probe fails with a compute-quota-402 signature, in which case
+      // 'exhausted'. This is the INFRA 402 (Neon returns 402 on every query when
+      // the plan's compute-time quota is spent), NOT the app-level 402
+      // INSUFFICIENT_FUNDS — those are Response objects built in the credit/payment
+      // handlers and never surface in this DB catch, so the two can't be conflated.
+      // Proactive (headroom-before-exhaustion) detection lives CI-side: the worker
+      // has no NEON_API_KEY secret and cannot read Neon's usage API.
+      let neonQuotaStatus = 'ok';
 
       if (this.db) {
         try {
@@ -5165,6 +5174,10 @@ class RouteRegistry {
           }
         } catch (err: any) {
           dbError = err.message;
+          const msg = String(err?.message || '').toLowerCase();
+          if (msg.includes('402') || msg.includes('quota') || msg.includes('compute time') || msg.includes('exceeded')) {
+            neonQuotaStatus = 'exhausted';
+          }
           console.error('Database health check failed:', err);
         }
       }
@@ -5211,7 +5224,8 @@ class RouteRegistry {
       }
 
       const allConnected = dbStatus === 'connected' && redisStatus !== 'error'
-        && stripeStatus !== 'unreachable' && stripeStatus !== 'test_key_in_prod';
+        && stripeStatus !== 'unreachable' && stripeStatus !== 'test_key_in_prod'
+        && neonQuotaStatus === 'ok';
 
       return builder.success({
         status: allConnected ? 'ok' : 'degraded',
@@ -5222,6 +5236,9 @@ class RouteRegistry {
             status: dbStatus,
             time: dbTime,
             error: dbError
+          },
+          neon_quota: {
+            status: neonQuotaStatus
           },
           redis: {
             status: redisStatus


### PR DESCRIPTION
## What
Neon compute-quota 402 is the highest operational risk for launch — it has taken prod down twice (#65, 2026-06-22). When the plan's compute quota is spent, Neon 402s **every** query → login 503s + a silently-empty marketplace. There was no probe; detection latency was up to 1h.

**Worker (`handleHealth`)** — new `neon_quota` dimension in `/api/health`. *Reactive*: classifies a compute-quota-402 from the DB probe as `exhausted`. `/api/health` still returns **200** with a degraded body. The CI per-service gate already treats anything outside `{connected,active,ok,healthy}` as unhealthy, so `exhausted` **auto-fires the existing Slack + GitHub-issue alert** — no new channel.

**CI (`simple-health-check.yml`)** — *proactive* headroom check. The worker has no `NEON_API_KEY` secret, so the before-exhaustion signal lives in CI: a control-plane Neon API call (**zero DB compute**) reading `cpu_used_sec` vs the quota window, failing at **≥85%** when `NEON_COMPUTE_QUOTA_SEC` is set (log-only until then — no false page). Cron tightened **hourly → every 15 min**.

**Doc** — `docs/neon-quota-keepwarm-decision-2026-06-30.md`: keep-warm burn math (`*/5` ping ≈ 730 compute-hr/mo vs current ~36.7 hr) → **`KEEP_WARM_DB` stays OFF** (it would accelerate the exhaustion it's meant to prevent). Real fix = Neon plan upgrade (owner decision); the probe buys warning time.

## 402 disambiguation (G1)
The Neon compute-quota 402 (thrown `NeonDbError`, caught in the `/api/health` DB probe) and the app-level `INSUFFICIENT_FUNDS` 402 (a `Response` built in payment handlers at `worker-integrated.ts:7198/7353/20769/20976`) never share a code path. The classifier only inspects the DB-probe catch → an app 402 can't trip `neon_quota`, and a Neon 402 isn't mistaken for credits.

## Verification gates
- **G1** — separate code paths (grep evidence above).
- **G2** — both CI parsers proven on synthetic inputs: `neon_quota=exhausted` → BAD; `cpu_used 90%` of ceiling → BAD; no ceiling → INFO (no page).
- **G3** — burn math + explicit **UNSAFE** verdict in the doc; `KEEP_WARM_DB` left `false`, `wrangler.toml` unchanged.
- **G4** — `/api/health` returns **200** with a structured degraded body when `neon_quota` is `exhausted` (`builder.success` is 200; only the `status` field flips to `degraded`).
- **G5** — `catch-swallow-gate.mjs --include-worker --threshold 0` clean; `tsc` 0 new errors; `build:worker` clean; workflow YAML valid.

## ⚠️ Action to arm the proactive threshold
Set the repo variable once the plan quota (compute-seconds/window) is known:
```
gh variable set NEON_COMPUTE_QUOTA_SEC --body "<plan compute-seconds>"
```
Until then the proactive step is log-only; the reactive `exhausted` catch still pages immediately on a real 402 storm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)