### PR TITLE
R8: read-only stale-cache fallback for discovery surfaces during DB degradation

### DIFF
--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -175,11 +175,18 @@ class ApiClient {
       
       const response = await fetch(url, fetchOptions);
 
-      // Global degraded signal (R0.1): a 5xx (e.g. the public pitch endpoints now
-      // return 503 on a Neon compute-quota 402 instead of a fake-empty 200) flips the
-      // app-wide banner; any non-5xx response clears it. Self-healing, guarded in-store.
+      // Global degraded signal (R0.1 + R8): a 5xx flips the app-wide banner; a 200
+      // carrying `X-Pitchey-Stale: true` (worker served last-good cached discovery
+      // data because the live DB read failed) flips it with stale-specific copy.
+      // Any healthy non-5xx, non-stale response clears both. Self-healing, guarded.
       if (response) {
-        useServiceStatusStore.getState().setDegraded(response.status >= 500);
+        const isStale = response.headers?.get('X-Pitchey-Stale') === 'true';
+        const is5xx = response.status >= 500;
+        useServiceStatusStore.getState().setStatus(
+          is5xx || isStale,
+          isStale,
+          isStale ? 'stale' : (is5xx ? 'error' : undefined),
+        );
       }
 
       // Add null checking for response

--- a/frontend/src/shared/components/feedback/ServiceDegradedBanner.tsx
+++ b/frontend/src/shared/components/feedback/ServiceDegradedBanner.tsx
@@ -7,6 +7,7 @@ import { useServiceStatusStore } from '../../../store/serviceStatusStore';
 // silently-empty marketplace. Auto-hides on the next successful (non-5xx) response.
 export function ServiceDegradedBanner() {
   const degraded = useServiceStatusStore((s) => s.degraded);
+  const stale = useServiceStatusStore((s) => s.stale);
   if (!degraded) return null;
 
   return (
@@ -17,10 +18,17 @@ export function ServiceDegradedBanner() {
     >
       <div className="max-w-7xl mx-auto px-4 py-2 flex items-center justify-center gap-2 text-center text-sm font-medium">
         <AlertTriangle className="w-4 h-4 shrink-0" aria-hidden />
-        <span>
-          We&rsquo;re having trouble reaching our servers. Some content may be temporarily
-          unavailable &mdash; please try again shortly.
-        </span>
+        {stale ? (
+          <span>
+            Showing recent cached results &mdash; live data is temporarily unavailable.
+            We&rsquo;ll refresh automatically once it&rsquo;s back.
+          </span>
+        ) : (
+          <span>
+            We&rsquo;re having trouble reaching our servers. Some content may be temporarily
+            unavailable &mdash; please try again shortly.
+          </span>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/shared/components/feedback/__tests__/ServiceDegradedBanner.test.tsx
+++ b/frontend/src/shared/components/feedback/__tests__/ServiceDegradedBanner.test.tsx
@@ -5,7 +5,7 @@ import { useServiceStatusStore } from '../../../../store/serviceStatusStore';
 
 describe('ServiceDegradedBanner (R0.1)', () => {
   beforeEach(() => {
-    useServiceStatusStore.setState({ degraded: false });
+    useServiceStatusStore.setState({ degraded: false, stale: false, reason: undefined });
   });
 
   it('renders nothing when the service is healthy', () => {
@@ -13,10 +13,17 @@ describe('ServiceDegradedBanner (R0.1)', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('shows the degraded message when degraded', () => {
-    useServiceStatusStore.setState({ degraded: true });
+  it('shows the generic degraded message on a 5xx degrade', () => {
+    useServiceStatusStore.setState({ degraded: true, stale: false });
     render(<ServiceDegradedBanner />);
     expect(screen.getByRole('status')).toBeInTheDocument();
     expect(screen.getByText(/temporarily\s+unavailable/i)).toBeInTheDocument();
+  });
+
+  it('shows distinct stale copy when serving cached results (R8)', () => {
+    useServiceStatusStore.setState({ degraded: true, stale: true, reason: 'stale' });
+    render(<ServiceDegradedBanner />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByText(/cached results/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/store/__tests__/serviceStatusStore.test.ts
+++ b/frontend/src/store/__tests__/serviceStatusStore.test.ts
@@ -3,11 +3,12 @@ import { useServiceStatusStore } from '../serviceStatusStore';
 
 describe('serviceStatusStore (R0.1 degraded signal)', () => {
   beforeEach(() => {
-    useServiceStatusStore.setState({ degraded: false });
+    useServiceStatusStore.setState({ degraded: false, stale: false, reason: undefined });
   });
 
   it('defaults to not degraded', () => {
     expect(useServiceStatusStore.getState().degraded).toBe(false);
+    expect(useServiceStatusStore.getState().stale).toBe(false);
   });
 
   it('flips to degraded on a 5xx signal', () => {
@@ -26,5 +27,21 @@ describe('serviceStatusStore (R0.1 degraded signal)', () => {
     before.setDegraded(false); // already false
     // Same state object reference proves set() was not called.
     expect(useServiceStatusStore.getState()).toBe(before);
+  });
+
+  it('setStatus flips stale (R8) and marks degraded with a stale reason', () => {
+    useServiceStatusStore.getState().setStatus(true, true, 'stale');
+    const s = useServiceStatusStore.getState();
+    expect(s.degraded).toBe(true);
+    expect(s.stale).toBe(true);
+    expect(s.reason).toBe('stale');
+  });
+
+  it('setDegraded clears any prior stale sub-state', () => {
+    useServiceStatusStore.getState().setStatus(true, true, 'stale');
+    useServiceStatusStore.getState().setDegraded(false);
+    const s = useServiceStatusStore.getState();
+    expect(s.degraded).toBe(false);
+    expect(s.stale).toBe(false);
   });
 });

--- a/frontend/src/store/serviceStatusStore.ts
+++ b/frontend/src/store/serviceStatusStore.ts
@@ -8,15 +8,31 @@ import { create } from 'zustand';
 // subscribes to this so an outage reads as "temporarily unavailable" app-wide rather
 // than rendering as a silently-empty marketplace.
 
+// `stale` (R8) is a distinct degraded sub-state: the request succeeded (HTTP 200)
+// but the worker served last-good CACHED discovery data because the live DB read
+// failed (X-Pitchey-Stale header). The banner shows stale-specific copy so users
+// know the data isn't live — separate from the generic 5xx "can't reach servers".
 interface ServiceStatusState {
   degraded: boolean;
+  stale: boolean;
+  reason?: string;
   setDegraded: (degraded: boolean) => void;
+  setStatus: (degraded: boolean, stale: boolean, reason?: string) => void;
 }
 
 export const useServiceStatusStore = create<ServiceStatusState>((set, get) => ({
   degraded: false,
+  stale: false,
+  reason: undefined,
   // Guard so a 2xx on every request doesn't churn subscribers when nothing changed.
+  setStatus: (degraded: boolean, stale: boolean, reason?: string) => {
+    const s = get();
+    if (s.degraded !== degraded || s.stale !== stale || s.reason !== reason) {
+      set({ degraded, stale, reason });
+    }
+  },
+  // Back-compat: a plain degraded toggle clears any stale sub-state.
   setDegraded: (degraded: boolean) => {
-    if (get().degraded !== degraded) set({ degraded });
+    get().setStatus(degraded, false, degraded ? 'error' : undefined);
   },
 }));

--- a/src/lib/read-fallback-cache.ts
+++ b/src/lib/read-fallback-cache.ts
@@ -1,0 +1,74 @@
+/**
+ * Read-only stale-cache fallback for discovery surfaces (R8).
+ *
+ * When a Neon read fails (compute-quota 402, 5xx, cold-start timeout) the
+ * marketplace/browse/trending endpoints would otherwise return an error and the
+ * marketplace renders silently empty. This helper lets those GET handlers serve
+ * the last-good payload — CLEARLY MARKED STALE — instead, protecting discovery
+ * liquidity during a DB blip. It is READ-ONLY: only successful 2xx GET payloads
+ * are cached, with a short bounded TTL so recovery is never poisoned.
+ *
+ * Uses the REAL Upstash client (`@upstash/redis/cloudflare`) — NOT the no-op stub
+ * in src/lib/redis.ts. Degrades gracefully: if Upstash env vars are absent, every
+ * function is a safe no-op and the wrapped handlers behave exactly as before.
+ */
+
+import { Redis } from '@upstash/redis/cloudflare';
+
+const KEY_PREFIX = 'rofallback:v1'; // bump v1 to invalidate after a payload-shape change
+const DEFAULT_TTL_SECONDS = 300; // 5 min — rides a cold-start/quota blip, short enough not to pin stale
+
+export function getFallbackRedis(env: any): Redis | null {
+  const url = env?.UPSTASH_REDIS_REST_URL;
+  const token = env?.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  try {
+    return new Redis({ url, token });
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error('read-fallback-cache: Redis init failed:', e.message);
+    return null;
+  }
+}
+
+// Stable key: endpoint + sorted querystring so identical queries share a slot and
+// param order doesn't fragment the cache.
+export function cacheKeyFor(endpoint: string, url: URL): string {
+  const params = [...url.searchParams.entries()].sort(([a], [b]) => a.localeCompare(b));
+  const qs = params.map(([k, v]) => `${k}=${v}`).join('&');
+  return `${KEY_PREFIX}:${endpoint}:${qs}`;
+}
+
+// Best-effort write of the last-good payload. Errors are LOGGED, never swallowed
+// silently — a Redis outage must not break the happy path, but it also must not
+// pretend success.
+export async function writeLastGood(
+  env: any,
+  key: string,
+  payloadString: string,
+  ttlSeconds: number = DEFAULT_TTL_SECONDS,
+): Promise<void> {
+  const redis = getFallbackRedis(env);
+  if (!redis) return;
+  try {
+    await redis.set(key, payloadString, { ex: ttlSeconds });
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error('read-fallback-cache: writeLastGood failed:', e.message);
+  }
+}
+
+export async function readLastGood(env: any, key: string): Promise<string | null> {
+  const redis = getFallbackRedis(env);
+  if (!redis) return null;
+  try {
+    const val = await redis.get<string>(key);
+    if (val == null) return null;
+    // Upstash auto-deserializes JSON; normalize back to a string for re-emit.
+    return typeof val === 'string' ? val : JSON.stringify(val);
+  } catch (err) {
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error('read-fallback-cache: readLastGood failed:', e.message);
+    return null;
+  }
+}

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -5870,6 +5870,10 @@ pitchey_analytics_datapoints_per_minute 1250
   }
 
   private async getPitches(request: Request): Promise<Response> {
+    return this.serveWithReadFallback('pitches', request, () => this.getPitchesImpl(request));
+  }
+
+  private async getPitchesImpl(request: Request): Promise<Response> {
     const builder = new ApiResponseBuilder(request);
 
     try {
@@ -9480,6 +9484,10 @@ pitchey_analytics_datapoints_per_minute 1250
   }
 
   private async browsePitches(request: Request): Promise<Response> {
+    return this.serveWithReadFallback('browse', request, () => this.browsePitchesImpl(request));
+  }
+
+  private async browsePitchesImpl(request: Request): Promise<Response> {
     const builder = new ApiResponseBuilder(request);
     const url = new URL(request.url);
     const tab = url.searchParams.get('tab') || 'trending';
@@ -9669,7 +9677,67 @@ pitchey_analytics_datapoints_per_minute 1250
     }
   }
 
+  // R8: serve last-good cached payload (clearly marked stale) when a discovery
+  // read fails (Neon 402/5xx/timeout) instead of an empty marketplace. READ-ONLY:
+  // only 2xx GET payloads are cached, short TTL, never poisons recovery.
+  private async serveWithReadFallback(
+    endpoint: string,
+    request: Request,
+    producer: () => Promise<Response>,
+  ): Promise<Response> {
+    const { cacheKeyFor, writeLastGood, readLastGood } = await import('./lib/read-fallback-cache');
+    const key = cacheKeyFor(endpoint, new URL(request.url));
+    const serveStale = async (): Promise<Response | null> => {
+      const cached = await readLastGood(this.env, key);
+      if (!cached) return null;
+      let bodyObj: any = null;
+      try { bodyObj = JSON.parse(cached); } catch { bodyObj = null; }
+      const body = bodyObj && typeof bodyObj === 'object'
+        ? JSON.stringify({ ...bodyObj, stale: true })
+        : cached;
+      return new Response(body, {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Pitchey-Stale': 'true',
+          ...getCorsHeaders(request.headers.get('Origin')),
+        },
+      });
+    };
+    try {
+      const resp = await producer();
+      if (resp.status >= 200 && resp.status < 300) {
+        const text = await resp.clone().text();
+        // fire-and-forget (writeLastGood self-logs on failure; never throws)
+        void writeLastGood(this.env, key, text, 300);
+        return resp;
+      }
+      // 5xx (incl. a DB error caught internally and returned as a Response) ->
+      // try stale. 4xx is a client error, not degradation -> pass through.
+      if (resp.status >= 500) {
+        const stale = await serveStale();
+        if (stale) {
+          console.warn(JSON.stringify({ level: 'warn', category: 'read_fallback', endpoint, action: 'served_stale', reason: 'producer_5xx', status: resp.status }));
+          return stale;
+        }
+      }
+      return resp;
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      const stale = await serveStale();
+      if (stale) {
+        console.warn(JSON.stringify({ level: 'warn', category: 'read_fallback', endpoint, action: 'served_stale', reason: 'producer_threw', error: e.message }));
+        return stale;
+      }
+      throw e;
+    }
+  }
+
   private async getTrending(request: Request): Promise<Response> {
+    return this.serveWithReadFallback('trending', request, () => this.getTrendingImpl(request));
+  }
+
+  private async getTrendingImpl(request: Request): Promise<Response> {
     const builder = new ApiResponseBuilder(request);
     const url = new URL(request.url);
     const limit = parseInt(url.searchParams.get('limit') || '10');


### PR DESCRIPTION
## What
When a Neon read fails (compute-quota 402 / 5xx / cold-start timeout), the discovery endpoints returned an error and the marketplace rendered **silently empty**. R8 serves last-good cached data — **clearly marked stale** — instead, protecting discovery liquidity during a DB blip (the outage class that hit twice: #65, 2026-06-22). Complements R6 (R6 *detects* the quota outage; R8 *softens* its user-facing blast radius). **READ-ONLY — write paths untouched.**

## Wrapped endpoints (the only 3)
- `getPitches` → `GET /api/pitches`
- `browsePitches` → `GET /api/pitches/browse`, `/api/browse`
- `getTrending` → `GET /api/pitches/trending`, `/api/trending`, `/api/search/trending`

## TTL / key scheme
- Real `@upstash/redis/cloudflare` client (not the no-op stub).
- Key: `rofallback:v1:<endpoint>:<sorted-querystring>` — bump `v1` to invalidate on payload-shape change.
- TTL **300s** — rides a cold-start/quota blip, short enough not to pin stale.
- Only **2xx** payloads cached. On throw/5xx → stale (200 + `X-Pitchey-Stale: true` + `stale:true`). No cache → original error (never fabricate). 4xx passes through.

## Frontend
Extends the R0.1 degraded banner: `serviceStatusStore` gains `stale`+`reason`; `api-client` flips degraded-with-stale on the `X-Pitchey-Stale` header and self-heals on healthy responses; `ServiceDegradedBanner` shows distinct stale copy ("Showing recent cached results…").

## Verification gates
- [x] **G1** — stale never served as fresh: 200 + `X-Pitchey-Stale` header + `stale:true` body + distinct banner copy (logic sim + unit test).
- [x] **G2** — write paths untouched: `serveWithReadFallback` call sites are the 3 GET discovery handlers only; no NDA/credit/payment/POST/PUT/DELETE diff.
- [x] **G3** — no cache poisoning: TTL ≤ 300s, only 2xx cached, post-recovery response is fresh (`stale` absent) and banner clears; `v1` prefix.
- [x] **G4** — graceful when Upstash absent: `getFallbackRedis` → null, handlers behave exactly as today.
- [x] **G5** — no silent swallows: cache helper logs on failure; `catch-swallow-gate.mjs --include-worker --threshold 0` clean.
- [x] **G6** — types + tests: `tsc -p tsconfig.app.json` clean; `serviceStatusStore` (6) + `ServiceDegradedBanner` (3) suites pass; worker build clean.

Manual proof commands (logic sim of `serveWithReadFallback`): happy 2xx caches+fresh; throw→stale(200+header+flag); recovery→fresh; no-cache→rethrow; no-redis→graceful; 4xx→passthrough. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)