### PR TITLE
feat(reputation): admin manual gold-recompute endpoint + side-effect tests (R13)

### DIFF
--- a/src/handlers/creator-reputation-admin.ts
+++ b/src/handlers/creator-reputation-admin.ts
@@ -1,0 +1,65 @@
+/**
+ * Admin manual-recompute of the platform-earned GOLD creator-reputation tier (R13).
+ *
+ * The promote-only gold recompute (`src/services/creator-reputation.ts`) runs on a
+ * daily cron only — if that cron silently freezes, qualified creators stop being
+ * promoted and nobody notices. This admin-gated endpoint is the operator escape
+ * hatch: trigger the same service on demand and get back what it promoted, with an
+ * audit log naming the triggering admin and the promoted creator ids.
+ *
+ * Mirrors the heat-score recalc precedent: directly registered + excluded from the
+ * AdminEndpointsHandler intercept, admin enforced inside the handler.
+ *   POST /api/admin/reputation/recompute
+ */
+
+import { getDb } from '../db/connection';
+import type { Env } from '../db/connection';
+import { getCorsHeaders } from '../utils/response';
+import { getUserId } from '../utils/auth-extract';
+
+function jsonResponse(data: unknown, origin: string | null, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...getCorsHeaders(origin) },
+  });
+}
+
+export async function recomputeReputationHandler(request: Request, env: Env): Promise<Response> {
+  const origin = request.headers.get('Origin');
+  const sql = getDb(env);
+  const userId = await getUserId(request, env);
+
+  if (!sql || !userId) {
+    return jsonResponse({ success: false, error: 'Authentication required' }, origin, 401);
+  }
+
+  try {
+    // Same admin gate as recalculateHeatScoresHandler.
+    const userResult = await sql`SELECT user_type FROM users WHERE id = ${userId}`;
+    if (userResult.length === 0 || userResult[0].user_type !== 'admin') {
+      return jsonResponse({ success: false, error: 'Admin access required' }, origin, 403);
+    }
+
+    const { recomputeCreatorReputationTiers } = await import('../services/creator-reputation');
+    const { promoted, promotedIds } = await recomputeCreatorReputationTiers(env);
+
+    // Audit: who triggered it + exactly which creators were promoted.
+    console.log(JSON.stringify({
+      level: 'info',
+      category: 'reputation',
+      action: 'creator_gold_recompute_manual',
+      triggeredBy: userId,
+      promoted,
+      promotedIds,
+    }));
+
+    return jsonResponse({ success: true, promoted, promotedIds }, origin);
+  } catch (err) {
+    // Do NOT swallow — surface as a 500 so a failed recompute is visible, not a
+    // silent "nothing promoted". (The service itself is cron-resilient and logs
+    // its own internal errors; this catch handles auth/db failures here.)
+    const e = err instanceof Error ? err : new Error(String(err));
+    console.error('recomputeReputationHandler error:', e.message);
+    return jsonResponse({ success: false, error: 'Failed to recompute reputation' }, origin, 500);
+  }
+}

--- a/src/services/creator-reputation.ts
+++ b/src/services/creator-reputation.ts
@@ -35,9 +35,9 @@ const MIN_HONORED_NDAS = 3;
 // One mutually-confirmed closed deal is enough — both parties had to confirm it.
 const MIN_HONORED_DEALS = 1;
 
-export async function recomputeCreatorReputationTiers(env: any, _ctx?: any): Promise<{ promoted: number }> {
+export async function recomputeCreatorReputationTiers(env: any, _ctx?: any): Promise<{ promoted: number; promotedIds: number[] }> {
   const url = env?.DATABASE_URL;
-  if (!url) return { promoted: 0 };
+  if (!url) return { promoted: 0, promotedIds: [] };
   const sql = neon(url);
   try {
     const rows = await sql`
@@ -72,16 +72,18 @@ export async function recomputeCreatorReputationTiers(env: any, _ctx?: any): Pro
         )
       RETURNING u.id
     `;
-    const promoted = rows.length;
+    const promotedIds = rows.map((r: any) => Number(r.id));
+    const promoted = promotedIds.length;
     console.log(JSON.stringify({
       level: 'info',
       category: 'reputation',
       action: 'creator_gold_recompute',
       promoted,
+      promotedIds,
     }));
-    return { promoted };
+    return { promoted, promotedIds };
   } catch (err) {
     console.error('recomputeCreatorReputationTiers error:', err instanceof Error ? err.message : String(err));
-    return { promoted: 0 };
+    return { promoted: 0, promotedIds: [] };
   }
 }

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -3886,6 +3886,14 @@ class RouteRegistry {
       return recalculateHeatScoresHandler(req, this.env);
     });
 
+    // Manual gold-reputation recompute — operator escape hatch if the daily cron
+    // freezes. Admin-gated inside the handler; excluded from the adminHandler
+    // intercept below (like heat-scores).
+    this.register('POST', '/api/admin/reputation/recompute', async (req) => {
+      const { recomputeReputationHandler } = await import('./handlers/creator-reputation-admin');
+      return recomputeReputationHandler(req, this.env);
+    });
+
     // Founding-user grant status (migration 082) — admin-only observability
     this.register('GET', '/api/admin/subscription-grants/status', async (req) => {
       const { subscriptionGrantsStatusHandler } = await import('./handlers/subscription-grants');
@@ -4425,6 +4433,7 @@ class RouteRegistry {
         !path.startsWith('/api/admin/verifications') &&
         !path.startsWith('/api/admin/heat-scores') &&
         !path.startsWith('/api/admin/credits') &&
+        !path.startsWith('/api/admin/reputation') &&
         !path.startsWith('/api/admin/subscription-grants')) {
       const corsHeaders = getCorsHeaders(request.headers.get('Origin'));
       const authResult = await this.validateAuth(request);

--- a/test/integration/creator-reputation.test.ts
+++ b/test/integration/creator-reputation.test.ts
@@ -1,0 +1,156 @@
+// Creator GOLD-reputation tier — side-effect + invariant coverage (R13).
+//
+// The platform-earned gold tier (src/services/creator-reputation.ts,
+// recomputeCreatorReputationTiers) is PROMOTE-ONLY and runs on a daily cron with
+// no HTTP trigger and (until R13) no side-effect test. These tests seed the exact
+// qualifying signals, run the real service (and the new admin endpoint), and
+// re-query users.verification_tier to prove the UPDATE actually happened — not
+// just that an HTTP call returned 200.
+//
+// All fixtures use the `r13-…@itest.local` email namespace and are pre-cleaned in
+// beforeAll + torn down in afterAll, so reruns are idempotent on a shared branch.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { neon } from '@neondatabase/serverless';
+import { TestClient, json } from './client';
+import { buildTestEnv, getTestDatabaseUrl } from './env';
+import { recomputeCreatorReputationTiers } from '../../src/services/creator-reputation';
+
+const sql = neon(getTestDatabaseUrl());
+const NS = 'r13-%@itest.local';
+
+async function cleanup() {
+  // Children first (FKs), all scoped to the r13 namespace.
+  await sql`DELETE FROM ndas WHERE signer_id IN (SELECT id FROM users WHERE email LIKE ${NS})`;
+  await sql`DELETE FROM ndas WHERE pitch_id IN (SELECT id FROM pitches WHERE user_id IN (SELECT id FROM users WHERE email LIKE ${NS}))`;
+  await sql`DELETE FROM production_deals WHERE creator_id IN (SELECT id FROM users WHERE email LIKE ${NS})`;
+  await sql`DELETE FROM pitch_provenance WHERE creator_id IN (SELECT id FROM users WHERE email LIKE ${NS})`;
+  await sql`DELETE FROM pitches WHERE user_id IN (SELECT id FROM users WHERE email LIKE ${NS})`;
+  await sql`DELETE FROM users WHERE email LIKE ${NS}`;
+}
+
+async function makeUser(tag: string, userType: string, tier: string | null, password = 'R13testpass'): Promise<number> {
+  const email = `r13-${tag}@itest.local`;
+  // A users trigger requires production accounts to carry a company name.
+  const companyName = userType === 'production' ? `R13 Co ${tag}` : null;
+  const [u] = await sql`
+    INSERT INTO users (email, username, password, password_hash, user_type, verification_tier, company_name)
+    VALUES (${email}, ${'r13_' + tag}, ${password}, ${password}, ${userType}, ${tier}, ${companyName})
+    RETURNING id
+  ` as { id: number }[];
+  return Number(u.id);
+}
+
+async function makePitch(creatorId: number, title: string): Promise<number> {
+  const [p] = await sql`
+    INSERT INTO pitches (user_id, creator_id, title, logline, status)
+    VALUES (${creatorId}, ${creatorId}, ${title}, ${'logline ' + title}, 'published')
+    RETURNING id
+  ` as { id: number }[];
+  return Number(p.id);
+}
+
+async function tierOf(userId: number): Promise<string> {
+  const [r] = await sql`SELECT COALESCE(verification_tier, 'grey') AS tier FROM users WHERE id = ${userId}` as { tier: string }[];
+  return r?.tier ?? 'grey';
+}
+
+// Path A = >=2 sealed pitches + >=3 honored (signed, un-revoked) NDAs from others.
+async function seedPathA(creatorId: number, sealedCount: number, ndaCount: number) {
+  for (let i = 0; i < Math.max(sealedCount, ndaCount, 1); i++) {
+    const pitchId = await makePitch(creatorId, `pa-${creatorId}-${i}`);
+    if (i < sealedCount) {
+      await sql`
+        INSERT INTO pitch_provenance (pitch_id, creator_id, content_hash, algorithm, content_version, sealed_at)
+        VALUES (${pitchId}, ${creatorId}, ${'hash-' + creatorId + '-' + i + '-' + Math.random().toString(36).slice(2)}, 'sha-256', 1, NOW())
+      `;
+    }
+    if (i < ndaCount) {
+      const signerId = await makeUser(`signer-${creatorId}-${i}`, 'investor', null);
+      await sql`
+        INSERT INTO ndas (pitch_id, signer_id, status, nda_type, access_granted, signed_at, created_at, updated_at)
+        VALUES (${pitchId}, ${signerId}, 'signed', 'basic', true, NOW(), NOW(), NOW())
+      `;
+    }
+  }
+}
+
+let cA = 0, cBelow = 0, cDealB = 0, cAlreadyGold = 0, prodUser = 0;
+
+beforeAll(async () => {
+  await cleanup();
+  // T1 — Path A qualifier (grey -> should go gold)
+  cA = await makeUser('c-pathA', 'creator', 'grey');
+  await seedPathA(cA, 2, 3);
+  // T2 — below threshold (1 sealed + 2 NDAs -> stays grey)
+  cBelow = await makeUser('c-below', 'creator', 'grey');
+  await seedPathA(cBelow, 1, 2);
+  // T3 — Path B (one mutually-confirmed closed deal, NO seals/NDAs -> gold)
+  cDealB = await makeUser('c-pathB', 'creator', 'grey');
+  prodUser = await makeUser('prod', 'production', 'silver');
+  const dealPitch = await makePitch(cDealB, 'deal-pitch');
+  await sql`
+    INSERT INTO production_deals (pitch_id, production_company_id, creator_id, deal_type, outcome, outcome_confirmed_by_creator, outcome_confirmed_by_production)
+    VALUES (${dealPitch}, ${prodUser}, ${cDealB}, 'option', 'closed_on_platform', true, true)
+  `;
+  // T4 — already gold creator (promote-only invariant) — also qualifies via Path A
+  cAlreadyGold = await makeUser('c-gold', 'creator', 'gold');
+  await seedPathA(cAlreadyGold, 2, 3);
+});
+
+afterAll(async () => { await cleanup(); });
+
+describe('creator-reputation: gold recompute side-effects', () => {
+  it('T1 Path A: a grey creator with >=2 seals + >=3 honored NDAs is promoted to gold', async () => {
+    expect(await tierOf(cA)).toBe('grey'); // precondition
+    const res = await recomputeCreatorReputationTiers(buildTestEnv());
+    expect(res.promotedIds).toContain(cA);
+    expect(await tierOf(cA)).toBe('gold'); // the SIDE EFFECT, re-queried from the DB
+  });
+
+  it('T2 below threshold: a creator with only 1 seal + 2 NDAs is NOT promoted', async () => {
+    await recomputeCreatorReputationTiers(buildTestEnv());
+    expect(await tierOf(cBelow)).toBe('grey');
+  });
+
+  it('T3 Path B: one mutually-confirmed closed deal alone promotes to gold (no seals/NDAs)', async () => {
+    const res = await recomputeCreatorReputationTiers(buildTestEnv());
+    // cDealB has zero provenance/ndas — only the deal qualifies it.
+    expect(await tierOf(cDealB)).toBe('gold');
+    // sanity: it was promoted by Path B in some run (already gold now → excluded going forward)
+    expect(typeof res.promoted).toBe('number');
+  });
+
+  it('T4 promote-only invariant: an already-gold creator stays gold, is not double-counted, non-creators untouched', async () => {
+    const prodTierBefore = await tierOf(prodUser);
+    const res = await recomputeCreatorReputationTiers(buildTestEnv());
+    expect(await tierOf(cAlreadyGold)).toBe('gold'); // never downgraded
+    expect(res.promotedIds).not.toContain(cAlreadyGold); // excluded by COALESCE(tier,'grey') <> 'gold'
+    expect(await tierOf(prodUser)).toBe(prodTierBefore); // production user never touched
+  });
+});
+
+describe('creator-reputation: admin recompute endpoint', () => {
+  const client = new TestClient();
+  let epId = 0;
+
+  beforeAll(async () => {
+    epId = await makeUser('ep-admin', 'creator', null); // created as creator so portal login matches
+    await client.login('r13-ep-admin@itest.local', 'R13testpass', 'creator');
+  });
+
+  it('T5a non-admin gets 403', async () => {
+    const res = await client.post('/api/admin/reputation/recompute', {});
+    expect(res.status, await res.clone().text().catch(() => '')).toBe(403);
+  });
+
+  it('T5b admin gets 200 with a promoted count', async () => {
+    await sql`UPDATE users SET user_type = 'admin' WHERE id = ${epId}`; // flip after login; handler reads type fresh
+    const res = await client.post('/api/admin/reputation/recompute', {});
+    expect(res.status, await res.clone().text().catch(() => '')).toBe(200);
+    const body = await json(res);
+    expect(body.success).toBe(true);
+    expect(typeof body.promoted).toBe('number');
+    expect(Array.isArray(body.promotedIds)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What
The platform-earned GOLD creator tier (`creator-reputation.ts`) ran on a **daily cron only** — no manual trigger if the cron freezes, and no side-effect test. R13 adds both the operator escape hatch and the regression guard. (This is the moat-native trust tier — if it silently stops promoting, qualified creators just never get gold.)

- **`POST /api/admin/reputation/recompute`** (`handlers/creator-reputation-admin.ts`): admin-gated inside the handler (same gate as heat-scores recalc), added to the `/api/admin/*` intercept exclusion list, calls `recomputeCreatorReputationTiers` and returns `{ promoted, promotedIds }`. Audit-logs the triggering admin + promoted creator ids. Returns 500 on a thrown error (no swallow).
- **`creator-reputation.ts`**: additively returns `promotedIds` (from `RETURNING id`) so the endpoint can audit. The cron caller's `{ promoted }` shape is preserved and the service stays cron-resilient (internal catch unchanged — making it throw would change the daily `Promise.all` batch behavior).
- **`test/integration/creator-reputation.test.ts`** (6 tests).

## Verification gates
- **G1 promote-only invariant (T4):** an already-gold creator is not downgraded and not double-counted (`COALESCE(tier,'grey') <> 'gold'`); a non-creator (production) is never touched.
- **G2 side-effects have teeth:** neutering the gold `UPDATE` (→ no-op) turns **T1 + T3 red** (`expected 'grey' to be 'gold'`) — the tests re-query `users.verification_tier`, not the HTTP status. Reverted; `git diff main -- src/services/creator-reputation.ts` is additive-only (`promotedIds`).
- **G3 audit log:** manual recompute emits `{category:'reputation', action:'creator_gold_recompute_manual', triggeredBy, promotedIds, promoted}`.
- **G4 route live, not orphaned:** both the `register(...)` and the exclusion-list entry present; T5 proves dispatch (non-admin 403, admin 200 — not shadowed by adminHandler).
- **G5:** `catch-swallow-gate.mjs --include-worker --threshold 0` clean; `tsc` no new errors; `build:worker` clean. 6/6 integration tests pass.

## Test coverage
T1 Path A (≥2 seals + ≥3 honored NDAs → gold) · T2 below threshold (stays grey) · T3 Path B (one mutually-confirmed closed deal alone → gold) · T4 promote-only invariant · T5 endpoint auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)