### PR TITLE
feat(admin): cross-role NDA-intent graph density metrics on /admin/liquidity (R12)

### DIFF
--- a/frontend/src/portals/admin/pages/AdminLiquidity.tsx
+++ b/frontend/src/portals/admin/pages/AdminLiquidity.tsx
@@ -11,12 +11,27 @@ interface BuyersSignal { currentWeek: number; weeks: { week: string; count: numb
 interface DealsSignal { currentMonth: number; months: { month: string; count: number }[]; threshold: number; pass: boolean }
 interface OffPlatformSignal { rate: number; offPlatform: number; totalCloses: number; meaningfulLeakage: boolean; threshold: number }
 interface ConfirmSignal { rate: number; confirmed: number; withOutcome: number; threshold: number; pass: boolean }
+// R12 — cross-role NDA-intent graph density (the moat asset).
+interface GraphDensity {
+  degraded: boolean;
+  ndaDensity?: {
+    totalSigned: number;
+    pitchesWithNda: number;
+    meanPerEngagedPitch: number;
+    distribution: { one: number; twoToThree: number; fourPlus: number };
+  };
+  crossRole?: { bothSides: number; investorOnly: number; productionOnly: number };
+  intentToDeal?: { ndaEngagedPitches: number; convertedPitches: number; conversionRate: number; linkage: string };
+  supplySignals?: { investorsWithThesis: number; publicTheses: number; collaborationsTotal: number; collaborationsLast30d: number };
+}
+
 interface LiquidityData {
   buyersSigningNdas: BuyersSignal;
   dealsReachingOutcome: DealsSignal;
   offPlatformCloseRate: OffPlatformSignal;
   mutualConfirmRate: ConfirmSignal;
   gate: { open: boolean; thresholdsAreDraft: boolean };
+  graphDensity?: GraphDensity;
 }
 
 const pct = (n: number) => `${Math.round(n * 100)}%`;
@@ -59,6 +74,23 @@ function SignalCard({
         </div>
       )}
       <div className="text-xs text-gray-400 border-t border-gray-100 pt-2">Draft threshold: {threshold}</div>
+    </div>
+  );
+}
+
+// Observational metric card (no gate pill / threshold) — for the graph-density
+// section, which measures the moat rather than gating a decision.
+function MetricCard({ icon: Icon, title, value, sub }: {
+  icon: React.ElementType; title: string; value: string; sub: string;
+}) {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6 flex flex-col gap-3">
+      <div className="flex items-center gap-2 text-gray-500">
+        <Icon className="w-5 h-5" />
+        <span className="text-sm font-medium">{title}</span>
+      </div>
+      <div className="text-3xl font-bold text-gray-900">{value}</div>
+      <div className="text-sm text-gray-500">{sub}</div>
     </div>
   );
 }
@@ -188,6 +220,58 @@ export default function AdminLiquidity() {
         Pitchey introduced somewhere else — exactly the leakage on-platform deal-servicing is designed to capture.
         Source: live <code>ndas</code> + <code>production_deals</code> outcome columns (migration 114). No new schema.
       </p>
+
+      {data.graphDensity && (
+        <div className="space-y-4 pt-4 border-t border-gray-200">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900">Cross-role NDA-intent graph density</h2>
+            <p className="text-sm text-gray-500">The moat is this graph over time + liquidity. Read-only over live tables.</p>
+          </div>
+
+          {data.graphDensity.degraded ? (
+            <div className="bg-amber-50 border border-amber-200 text-amber-800 px-4 py-3 rounded-lg text-sm">
+              Graph metrics unavailable — the database is degraded. (This is a failed read, not zero data.)
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+                <MetricCard
+                  icon={Users}
+                  title="Cross-role pitches (both sides)"
+                  value={String(data.graphDensity.crossRole?.bothSides ?? 0)}
+                  sub={`Investor + production both signed · ${data.graphDensity.crossRole?.investorOnly ?? 0} investor-only · ${data.graphDensity.crossRole?.productionOnly ?? 0} production-only`}
+                />
+                <MetricCard
+                  icon={FileSignature}
+                  title="Honored NDAs / engaged pitch"
+                  value={(data.graphDensity.ndaDensity?.meanPerEngagedPitch ?? 0).toFixed(2)}
+                  sub={`${data.graphDensity.ndaDensity?.totalSigned ?? 0} signed across ${data.graphDensity.ndaDensity?.pitchesWithNda ?? 0} pitches`}
+                />
+                <MetricCard
+                  icon={ArrowUpRight}
+                  title="Intent → deal conversion"
+                  value={pct(data.graphDensity.intentToDeal?.conversionRate ?? 0)}
+                  sub={`${data.graphDensity.intentToDeal?.convertedPitches ?? 0} of ${data.graphDensity.intentToDeal?.ndaEngagedPitches ?? 0} NDA-engaged pitches have a deal`}
+                />
+                <MetricCard
+                  icon={CheckCircle2}
+                  title="Structured supply"
+                  value={String(data.graphDensity.supplySignals?.investorsWithThesis ?? 0)}
+                  sub={`${data.graphDensity.supplySignals?.publicTheses ?? 0} public theses · ${data.graphDensity.supplySignals?.collaborationsTotal ?? 0} collabs (${data.graphDensity.supplySignals?.collaborationsLast30d ?? 0} in 30d)`}
+                />
+              </div>
+              <p className="text-xs text-gray-400">
+                NDAs-per-engaged-pitch distribution: {data.graphDensity.ndaDensity?.distribution.one ?? 0} with 1 ·{' '}
+                {data.graphDensity.ndaDensity?.distribution.twoToThree ?? 0} with 2–3 ·{' '}
+                {data.graphDensity.ndaDensity?.distribution.fourPlus ?? 0} with 4+. The{' '}
+                <strong>both-sides</strong> count is the defensible asset — a pitch where an investor AND a
+                production company both signed an NDA. Source: live <code>ndas</code>, <code>users</code>,{' '}
+                <code>production_deals</code>, <code>investor_thesis</code>, <code>collaborations</code>. No new schema.
+              </p>
+            </>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/worker-modules/admin-endpoints.ts
+++ b/src/worker-modules/admin-endpoints.ts
@@ -1588,6 +1588,9 @@ export class AdminEndpointsHandler {
       offPlatformCloseRate: { rate: 0, offPlatform: 0, totalCloses: 0, meaningfulLeakage: false, threshold: THRESHOLDS.offPlatformRate },
       mutualConfirmRate: { rate: 0, confirmed: 0, withOutcome: 0, threshold: THRESHOLDS.mutualConfirmRate, pass: false },
       gate: { open: false, thresholdsAreDraft: true },
+      // R12: never show misleading zeros for the graph section on a total failure —
+      // degraded:true is distinguishable from a genuinely empty graph.
+      graphDensity: { degraded: true },
     };
 
     try {
@@ -1652,6 +1655,10 @@ export class AdminEndpointsHandler {
       const s3Leak = offRate >= THRESHOLDS.offPlatformRate;
       const s4Pass = confirmRate >= THRESHOLDS.mutualConfirmRate;
 
+      // R12: cross-role NDA-intent graph density (the moat asset). Self-contained
+      // error handling — surfaces degraded:true rather than dragging down the gate.
+      const graphDensity = await this.computeGraphDensity(sql);
+
       return this.bareJson({
         buyersSigningNdas: { currentWeek, weeks, trendNonDecreasing, threshold: THRESHOLDS.buyersPerWeek, pass: s1Pass },
         dealsReachingOutcome: { currentMonth, months, threshold: THRESHOLDS.dealsPerMonth, pass: s2Pass },
@@ -1660,11 +1667,106 @@ export class AdminEndpointsHandler {
         // Advisory verdict: liquidity is real AND deals close AND the leak is worth
         // capturing AND both sides report back. All four together = start P5.0.
         gate: { open: s1Pass && s2Pass && s3Leak && s4Pass, thresholdsAreDraft: true },
+        graphDensity,
       }, corsHeaders);
 
     } catch (error) {
       await this.logger.captureError(error instanceof Error ? error : new Error(String(error)));
       return this.bareJson(empty, corsHeaders);
+    }
+  }
+
+  // R12: cross-role NDA-intent graph density — the moat thesis is this graph over
+  // time + liquidity, but nothing measured it. Read-only over EXISTING tables
+  // (ndas/users/production_deals/investor_thesis/collaborations); zero new schema.
+  // 'signed' = the honored edge (matches the gold-reputation Path-A definition).
+  // Self-contained try/catch: a DB failure (e.g. Neon 402) surfaces degraded:true,
+  // never all-zeros that would read as "no graph".
+  private async computeGraphDensity(
+    sql: (strings: TemplateStringsArray, ...values: any[]) => Promise<any[]>,
+  ): Promise<any> {
+    try {
+      // Per-pitch roll-up: NDA count + which buyer roles signed → density + the
+      // headline cross-role (both investor AND production signer) count.
+      const [d] = await sql`
+        WITH pitch_roles AS (
+          SELECT n.pitch_id,
+            COUNT(*) AS nda_count,
+            BOOL_OR(u.user_type = 'investor') AS has_investor,
+            BOOL_OR(u.user_type = 'production') AS has_production
+          FROM ndas n
+          JOIN users u ON u.id = n.signer_id
+          WHERE n.status = 'signed'
+          GROUP BY n.pitch_id
+        )
+        SELECT
+          COALESCE(SUM(nda_count), 0)::int AS total_signed,
+          COUNT(*)::int AS pitches_with_nda,
+          COUNT(*) FILTER (WHERE has_investor AND has_production)::int AS both_sides,
+          COUNT(*) FILTER (WHERE has_investor AND NOT has_production)::int AS investor_only,
+          COUNT(*) FILTER (WHERE has_production AND NOT has_investor)::int AS production_only,
+          COUNT(*) FILTER (WHERE nda_count = 1)::int AS bucket_1,
+          COUNT(*) FILTER (WHERE nda_count BETWEEN 2 AND 3)::int AS bucket_2_3,
+          COUNT(*) FILTER (WHERE nda_count >= 4)::int AS bucket_4plus
+        FROM pitch_roles
+      `;
+
+      // Intent → deal conversion via the real pitch_id linkage on production_deals.
+      const [c] = await sql`
+        SELECT
+          (SELECT COUNT(DISTINCT pitch_id) FROM ndas WHERE status = 'signed')::int AS nda_engaged_pitches,
+          (SELECT COUNT(DISTINCT pd.pitch_id) FROM production_deals pd
+             WHERE pd.pitch_id IN (SELECT pitch_id FROM ndas WHERE status = 'signed'))::int AS converted_pitches
+      `;
+
+      // Supply / intent leading indicators.
+      const [s] = await sql`
+        SELECT
+          (SELECT COUNT(*) FROM investor_thesis)::int AS investors_with_thesis,
+          (SELECT COUNT(*) FROM investor_thesis WHERE is_public)::int AS public_theses,
+          (SELECT COUNT(*) FROM collaborations)::int AS collaborations_total,
+          (SELECT COUNT(*) FROM collaborations WHERE created_at >= NOW() - INTERVAL '30 days')::int AS collaborations_30d
+      `;
+
+      const dd: any = d || {}, cc: any = c || {}, ss: any = s || {};
+      const totalSigned = Number(dd.total_signed || 0);
+      const pitchesWithNda = Number(dd.pitches_with_nda || 0);
+      const ndaEngaged = Number(cc.nda_engaged_pitches || 0);
+      const converted = Number(cc.converted_pitches || 0);
+
+      return {
+        degraded: false,
+        ndaDensity: {
+          totalSigned,
+          pitchesWithNda,
+          meanPerEngagedPitch: pitchesWithNda > 0 ? totalSigned / pitchesWithNda : 0,
+          distribution: {
+            one: Number(dd.bucket_1 || 0),
+            twoToThree: Number(dd.bucket_2_3 || 0),
+            fourPlus: Number(dd.bucket_4plus || 0),
+          },
+        },
+        crossRole: {
+          bothSides: Number(dd.both_sides || 0), // headline — the defensible asset
+          investorOnly: Number(dd.investor_only || 0),
+          productionOnly: Number(dd.production_only || 0),
+        },
+        intentToDeal: {
+          ndaEngagedPitches: ndaEngaged,
+          convertedPitches: converted,
+          conversionRate: ndaEngaged > 0 ? converted / ndaEngaged : 0,
+          linkage: 'pitch_id',
+        },
+        supplySignals: {
+          investorsWithThesis: Number(ss.investors_with_thesis || 0),
+          publicTheses: Number(ss.public_theses || 0),
+          collaborationsTotal: Number(ss.collaborations_total || 0),
+          collaborationsLast30d: Number(ss.collaborations_30d || 0),
+        },
+      };
+    } catch (error) {
+      await this.logger.captureError(error instanceof Error ? error : new Error(String(error)));
+      return { degraded: true };
     }
   }
 


### PR DESCRIPTION
## What
The moat thesis is the **cross-role NDA-intent graph** over time + liquidity — but nothing measured its density. This adds a read-only `graphDensity` section to the existing `/admin/liquidity` dashboard. **Zero new schema, no migration, no Analytics Engine bindings, no new route** (extends the `AdminEndpointsHandler` `liquidity` branch — the existing gate signals are untouched).

## Metrics (read-only over `ndas`/`users`/`production_deals`/`investor_thesis`/`collaborations`)
- **Cross-role (headline):** pitches where **both** an investor-type AND production-type user signed an NDA — the defensible asset — plus investor-only / production-only counts.
- **NDA density:** total signed, distinct engaged pitches, mean-per-engaged-pitch, 1 / 2–3 / 4+ distribution.
- **Intent→deal conversion:** NDA-engaged pitches that have a `production_deals` row (via the confirmed `production_deals.pitch_id` linkage).
- **Supply signals:** investors with a thesis, public theses, total + last-30d collaborations.

`'signed'` = the honored edge (matches gold-reputation Path A).

## Validated against live data (prod-copy branch)
11 signed NDAs / 9 pitches · **2 both-sides** · 7 investor-only · 0 production-only · 3 theses · 2 collabs · 0 deal-converted.

## Verification gates
- **G1 — degraded, not zeros:** `computeGraphDensity` self-wraps; a DB failure → Sentry `captureError` + `graphDensity:{degraded:true}` (the empty payload carries it too) → amber "metrics unavailable" banner in the UI, never misleading zeros. `catch-swallow-gate.mjs --include-worker --threshold 0` clean.
- **G2 — no new AE bindings:** `wrangler.toml` unchanged.
- **G3 — reachability:** served inside `AdminEndpointsHandler` (no `register('GET','/api/admin/graph…')`, which would 404 per the shadow gotcha); `worker-integrated.ts` not modified.
- **G4 — build/types/tests:** worker builds; `tsc -p tsconfig.app.json` clean; 155 admin vitest tests pass.
- **G5 — column correctness:** every referenced column confirmed live; `production_deals.pitch_id` linkage confirmed (no creator-level fallback); zero sub-metrics dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)