### PR TITLE
ci(neon-preview): skip preview env for docs-only PRs

### DIFF
--- a/.github/workflows/neon-preview.yml
+++ b/.github/workflows/neon-preview.yml
@@ -2,6 +2,22 @@ name: Neon Database Preview Environments
 on:
   pull_request:
     types: [opened, reopened, synchronize, closed]
+    # Skip the whole preview environment (Neon branch + migrations + e2e + preview
+    # Worker) for docs-only PRs that never touch the DB or app — e.g. the rolling
+    # `audit-signals` harness PR (#389: only signals/prompts/*.md), or CLAUDE.md
+    # doc PRs. Those spun up (and, while open, permanently held) a Neon preview
+    # branch for zero benefit. GitHub skips the workflow only when EVERY changed
+    # file matches an ignore pattern, so mixed code+docs PRs still get a preview.
+    # Safe because setup-preview is NOT a required status check on main (required:
+    # Worker Tests / Frontend Tests / Code Coverage Quality Gate come from other
+    # workflows), so a skipped run can't block merges. The daily neon-preview-sweep
+    # remains the backstop for any branch left behind when such a PR closes.
+    paths-ignore:
+      - '**/*.md'
+      - 'signals/**'
+      - 'prompts/**'
+      - 'docs/**'
+      - '.claude/**'
 
 jobs:
   # Create or update preview branch


### PR DESCRIPTION
## What

Adds `paths-ignore` to `neon-preview.yml` so **docs-only PRs skip the preview environment** (Neon branch + migrations + e2e + preview Worker).

## Why

Investigating the leftover `preview/pr-389` Neon branch showed it wasn't a teardown bug — **PR #389 (`audit-signals`) is a rolling, always-open harness PR that changes only markdown** (14 `signals/`, 3 `prompts/`, 1 `work-log.md`). Both the per-PR teardown and the daily sweep correctly *keep* branches for OPEN PRs, so #389 held a permanent Neon branch and re-ran the full preview environment on every nightly `synchronize` — for a PR that never touches the DB or app.

Deleting the branch alone is futile (recreated on the next nightly update). The root-cause fix is a path filter.

## Safety

- GitHub skips the workflow only when **every** changed file matches an ignore pattern → **mixed code+docs PRs still get a full preview**.
- `setup-preview` is **not** a required status check on `main` (required: Worker Tests / Frontend Tests / Code Coverage Quality Gate, from other workflows) → a skipped run **cannot block merges**.
- `neon-preview-sweep.yml` (daily) remains the backstop for any branch left behind when a docs-only PR closes.
- This PR touches a workflow file (non-docs), so it still triggers `neon-preview.yml` normally — proving the path filter doesn't break code PRs.

Ignore patterns: `**/*.md`, `signals/**`, `prompts/**`, `docs/**`, `.claude/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)