### PR TITLE
feat(pitches): human-readable slug URLs (/pitch/the-last-frontier)

### DIFF
--- a/frontend/src/components/ThesisMatchesSection.tsx
+++ b/frontend/src/components/ThesisMatchesSection.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { Sparkles } from 'lucide-react';
 import { InvestorThesisService, type ThesisMatch } from '../services/investor-thesis.service';
+import { pitchUrl } from '@/utils/pitchUrl';
 
 export default function ThesisMatchesSection() {
   const [matches, setMatches] = useState<ThesisMatch[]>([]);
@@ -44,7 +45,7 @@ export default function ThesisMatchesSection() {
           <button
             key={m.id}
             type="button"
-            onClick={() => { void navigate(`/pitch/${m.id}`); }}
+            onClick={() => { void navigate(pitchUrl(m)); }}
             className="text-left bg-white rounded-xl shadow-sm hover:shadow-md transition-shadow border border-gray-100 p-4"
           >
             <div className="flex items-start justify-between gap-2">

--- a/frontend/src/components/portfolio/PitchCard.tsx
+++ b/frontend/src/components/portfolio/PitchCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import GenrePlaceholder from '@shared/components/GenrePlaceholder';
+import { pitchUrl } from '@/utils/pitchUrl';
 
 interface Pitch {
   id: string;
@@ -85,8 +86,8 @@ const PitchCard: React.FC<PitchCardProps> = ({ pitch }) => {
           </span>
         </div>
         <div className="pt-4 border-t mt-auto">
-          <Link 
-            to={`/pitch/${pitch.id}`}
+          <Link
+            to={pitchUrl(pitch)}
             className="block w-full text-center px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors text-sm font-medium"
           >
             View Details

--- a/frontend/src/features/browse/components/BrowseTabsFixed.tsx
+++ b/frontend/src/features/browse/components/BrowseTabsFixed.tsx
@@ -6,6 +6,7 @@ import { PitchService } from '@features/pitches/services/pitch.service';
 import { motion } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import PortalTopNav from '@shared/components/layout/PortalTopNav';
+import { pitchUrl } from '@/utils/pitchUrl';
 
 interface Pitch {
   id: number;
@@ -447,7 +448,7 @@ const BrowseTabsFixed: React.FC = () => {
                     animate={{ opacity: 1, y: 0 }}
                     whileHover={{ y: -4 }}
                     className="bg-white rounded-lg shadow-sm hover:shadow-lg transition-all cursor-pointer overflow-hidden"
-                    onClick={() => navigate(`/pitch/${pitch.id}`)}
+                    onClick={() => navigate(pitchUrl(pitch))}
                   >
                     {/* Poster/Thumbnail */}
                     <div className="relative aspect-video bg-gradient-to-br from-purple-100 to-purple-200 flex items-center justify-center">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -160,6 +160,7 @@ export interface User {
 export interface Pitch {
   id: number;
   userId?: number;
+  slug?: string | null;
   title: string;
   logline: string;
   genre: string;

--- a/frontend/src/pages/AdvancedSearch.tsx
+++ b/frontend/src/pages/AdvancedSearch.tsx
@@ -14,6 +14,7 @@ import { Badge } from '@shared/components/ui/badge';
 import { toast } from 'react-hot-toast';
 import { API_URL } from '../config';
 import { getPortalPath } from '@/utils/navigation';
+import { pitchUrl } from '@/utils/pitchUrl';
 
 interface SearchFilters {
   query: string;
@@ -234,7 +235,7 @@ export default function AdvancedSearch() {
 
   const handleResultClick = (result: SearchResult) => {
     if (result.type === 'pitch') {
-      void navigate(`/pitch/${result.id}`);
+      void navigate(pitchUrl(result));
     } else if (result.type === 'creator') {
       void navigate(`/creator/${result.id}`);
     } else if (result.type === 'production') {

--- a/frontend/src/pages/BrowseGenres.tsx
+++ b/frontend/src/pages/BrowseGenres.tsx
@@ -10,6 +10,7 @@ import { configService } from '../services/config.service';
 import FormatDisplay from '../components/FormatDisplay';
 import { getApiUrl } from '../config';
 import PortalTopNav from '@shared/components/layout/PortalTopNav';
+import { pitchUrl } from '@/utils/pitchUrl';
 import {
   Eye,
   Heart,
@@ -440,7 +441,7 @@ export default function BrowseGenres() {
                     <div
                       key={pitch.id}
                       className="bg-white rounded-xl shadow-sm hover:shadow-xl transition-all duration-300 overflow-hidden cursor-pointer group"
-                      onClick={() => navigate(`/pitch/${pitch.id}`)}
+                      onClick={() => navigate(pitchUrl(pitch))}
                       data-testid={`genre-pitch-card-${pitch.id}`}
                     >
                       {/* Pitch Thumbnail */}

--- a/frontend/src/pages/BrowseTopRated.tsx
+++ b/frontend/src/pages/BrowseTopRated.tsx
@@ -9,6 +9,7 @@ import Pagination from '../components/Pagination';
 import { configService } from '../services/config.service';
 import FormatDisplay from '../components/FormatDisplay';
 import HeatBadge, { getHeatScore } from '../components/HeatBadge';
+import { pitchUrl } from '@/utils/pitchUrl';
 import { getApiUrl } from '../config';
 import PortalTopNav from '@shared/components/layout/PortalTopNav';
 import SortPillRow, { type SortPillOption } from '@shared/components/ui/SortPillRow';
@@ -522,7 +523,7 @@ export default function BrowseTopRated() {
                 <div
                   key={pitch.id}
                   className="bg-white rounded-xl shadow-sm hover:shadow-xl transition-all duration-300 overflow-hidden cursor-pointer group relative"
-                  onClick={() => navigate(`/pitch/${pitch.id}`)}
+                  onClick={() => navigate(pitchUrl(pitch))}
                   data-testid={`top-rated-pitch-card-${pitch.id}`}
                 >
                   {/* Ranking Badge */}

--- a/frontend/src/pages/CreatorPortfolio.tsx
+++ b/frontend/src/pages/CreatorPortfolio.tsx
@@ -5,6 +5,7 @@ import { apiClient } from '../lib/api-client';
 import { useBetterAuthStore } from '../store/betterAuthStore';
 import ShareLinksModal from '../components/portfolio/ShareLinksModal';
 import LogoLoader from '@/components/LogoLoader';
+import { pitchUrl } from '@/utils/pitchUrl';
 
 interface Pitch {
   id: string;
@@ -245,7 +246,7 @@ export default function CreatorPortfolio() {
               {pitches.map((pitch) => (
                 <Link
                   key={pitch.id}
-                  to={`/pitch/${pitch.id}`}
+                  to={pitchUrl(pitch)}
                   className="group block bg-white border rounded-xl overflow-hidden hover:shadow-lg transition-all"
                 >
                   {/* Thumbnail */}

--- a/frontend/src/pages/CreatorProfile.tsx
+++ b/frontend/src/pages/CreatorProfile.tsx
@@ -11,6 +11,7 @@ import FollowButton from '@features/browse/components/FollowButton';
 import { config } from '../config';
 import FormatDisplay from '../components/FormatDisplay';
 import { followService } from '@features/browse/services/follow.service';
+import { pitchUrl } from '@/utils/pitchUrl';
 
 interface CreatorData {
   id: number;
@@ -397,7 +398,7 @@ const CreatorProfile = () => {
                         </span>
                       </div>
                       <Link
-                        to={`/pitch/${pitch.id}`}
+                        to={pitchUrl(pitch)}
                         className="text-purple-600 hover:text-purple-700"
                       >
                         View →

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -3,10 +3,11 @@ import { Link } from 'react-router-dom';
 import { pitchAPI } from '../lib/api';
 import type { Pitch } from '../lib/api';
 import { useBetterAuthStore } from '../store/betterAuthStore';
-import { 
-  Plus, TrendingUp, Eye, Heart, Shield, Search, 
-  Film, Tv, Video, FileText, Grid, List 
+import {
+  Plus, TrendingUp, Eye, Heart, Shield, Search,
+  Film, Tv, Video, FileText, Grid, List
 } from 'lucide-react';
+import { pitchUrl } from '@/utils/pitchUrl';
 
 export default function Dashboard() {
   const { user } = useBetterAuthStore();
@@ -166,7 +167,7 @@ export default function Dashboard() {
                 {trending.map((pitch, index) => (
                   <Link
                     key={pitch.id}
-                    to={`/pitch/${pitch.id}`}
+                    to={pitchUrl(pitch)}
                     className="block hover:bg-gray-50 -mx-2 px-2 py-1 rounded"
                   >
                     <div className="flex items-start">
@@ -244,7 +245,7 @@ export default function Dashboard() {
                 {pitches.map((pitch) => (
                   <Link
                     key={pitch.id}
-                    to={`/pitch/${pitch.id}`}
+                    to={pitchUrl(pitch)}
                     className={`bg-white rounded-lg shadow hover:shadow-lg transition-shadow ${
                       viewMode === 'list' ? 'p-4' : 'overflow-hidden'
                     }`}

--- a/frontend/src/pages/Following.tsx
+++ b/frontend/src/pages/Following.tsx
@@ -7,6 +7,7 @@ import { useBetterAuthStore } from '../store/betterAuthStore';
 import { SocialService } from '@features/browse/services/social.service';
 import { SavedPitchesService, type SavedPitch } from '@features/pitches/services/saved-pitches.service';
 import { getPortalPath } from '@/utils/navigation';
+import { pitchUrl } from '@/utils/pitchUrl';
 
 interface Creator {
   id: number;
@@ -386,7 +387,7 @@ const Following: React.FC = () => {
                     {update.pitch && (
                       <div 
                         className="cursor-pointer group"
-                        onClick={() => navigate(`/pitch/${update.pitch!.id}`)}
+                        onClick={() => navigate(pitchUrl(update.pitch!))}
                       >
                         <h4 className="font-semibold text-gray-900 group-hover:text-blue-600 mb-1">
                           {update.pitch.title}
@@ -705,7 +706,7 @@ const Following: React.FC = () => {
               <div
                 key={sp.id || pitchId}
                 className="bg-white p-6 rounded-lg shadow-sm border hover:shadow-md transition-shadow cursor-pointer"
-                onClick={() => navigate(`/pitch/${pitchId}`)}
+                onClick={() => navigate(pitchUrl(pitchId))}
               >
                 <div className="flex items-start space-x-4">
                   <div className="flex-shrink-0">

--- a/frontend/src/pages/Homepage.tsx
+++ b/frontend/src/pages/Homepage.tsx
@@ -10,6 +10,7 @@ import GenrePlaceholder from '@shared/components/GenrePlaceholder';
 import { getHeatScore, getPitcheyScore } from '../components/HeatBadge';
 import PitcheyRating from '../components/PitcheyRating';
 import { getDashboardRoute } from '@/utils/navigation';
+import { pitchUrl } from '@/utils/pitchUrl';
 import PublicTopNav from '@shared/components/layout/PublicTopNav';
 
 
@@ -267,7 +268,7 @@ export default function Homepage() {
                 return (
                   <div
                     key={pitch.id}
-                    onClick={() => navigate(`/pitch/${pitch.id}`)}
+                    onClick={() => navigate(pitchUrl(pitch))}
                     className={`group relative bg-white rounded-2xl overflow-hidden cursor-pointer border transition-all duration-500 hover:-translate-y-1.5 ${
                       isTop
                         ? 'border-amber-200 ring-1 ring-amber-300/40 shadow-[0_16px_44px_-16px_rgba(217,119,6,0.35)] hover:shadow-[0_28px_60px_-18px_rgba(217,119,6,0.45)]'
@@ -384,7 +385,7 @@ export default function Homepage() {
                 return (
                   <div
                     key={pitch.id}
-                    onClick={() => navigate(`/pitch/${pitch.id}`)}
+                    onClick={() => navigate(pitchUrl(pitch))}
                     className="group bg-white rounded-2xl overflow-hidden border border-gray-200/70 shadow-sm transition-all duration-300 cursor-pointer hover:-translate-y-1 hover:shadow-xl hover:border-violet-200"
                   >
                     <div className="relative h-44 overflow-hidden bg-gray-900">
@@ -469,7 +470,7 @@ export default function Homepage() {
                 return (
                   <div
                     key={pitch.id}
-                    onClick={() => navigate(`/pitch/${pitch.id}`)}
+                    onClick={() => navigate(pitchUrl(pitch))}
                     className="group bg-white rounded-2xl overflow-hidden border border-gray-200/70 shadow-sm transition-all duration-300 cursor-pointer hover:-translate-y-1 hover:shadow-xl hover:border-violet-200"
                   >
                     <div className="relative h-44 overflow-hidden bg-gray-900">

--- a/frontend/src/pages/InvestorBrowse.tsx
+++ b/frontend/src/pages/InvestorBrowse.tsx
@@ -7,6 +7,7 @@ import { configService } from '../services/config.service';
 import FormatDisplay from '../components/FormatDisplay';
 import { useDebounce } from '@/shared/hooks/useDebounce';
 import { usePortalTheme } from '@shared/hooks/usePortalTheme';
+import { pitchUrl } from '@/utils/pitchUrl';
 
 interface Pitch {
   id: number;
@@ -634,7 +635,7 @@ export default function InvestorBrowse() {
 
                   <div className="flex space-x-2">
                     <button
-                      onClick={() => navigate(`/pitch/${pitch.id}`)}
+                      onClick={() => navigate(pitchUrl(pitch))}
                       className="flex-1 text-center py-2 bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200 transition text-sm"
                     >
                       View Details

--- a/frontend/src/pages/MarketplaceEnhanced.tsx
+++ b/frontend/src/pages/MarketplaceEnhanced.tsx
@@ -8,6 +8,7 @@ import EmptyState from '../components/EmptyState';
 import { useToast } from '@shared/components/feedback/ToastProvider';
 import Pagination from '../components/Pagination';
 import { useDebounce } from '@/shared/hooks/useDebounce';
+import { pitchUrl } from '@/utils/pitchUrl';
 import { useOnlineStatus } from '@/shared/hooks/useOnlineStatus';
 import { useResponsive } from '@/shared/hooks/useResponsive';
 import { configService } from '../services/config.service';
@@ -634,7 +635,7 @@ export default function MarketplaceEnhanced() {
 
   const handlePitchClick = (pitch: Pitch) => {
     if (!isAuthenticated) {
-      void navigate(`/pitch/${pitch.id}`);
+      void navigate(pitchUrl(pitch));
     } else if (user?.userType === 'investor') {
       void navigate(`/investor/pitch/${pitch.id}`);
     } else if (user?.userType === 'production') {
@@ -642,7 +643,7 @@ export default function MarketplaceEnhanced() {
     } else if (user?.userType === 'creator' && (pitch.creator?.id || pitch.userId) === user?.id) {
       void navigate(`/creator/pitch/${pitch.id}`);
     } else {
-      void navigate(`/pitch/${pitch.id}`);
+      void navigate(pitchUrl(pitch));
     }
   };
 

--- a/frontend/src/pages/OpportunitiesBoard.tsx
+++ b/frontend/src/pages/OpportunitiesBoard.tsx
@@ -15,6 +15,7 @@ import {
   callsService, type OpenCall, type CallInput,
   type CallSubmission, type SubmissionStatus,
 } from '../services/calls.service';
+import { pitchUrl } from '@/utils/pitchUrl';
 
 interface MyPitch { id: number; title: string; genre?: string }
 
@@ -509,7 +510,7 @@ function SubmissionsModal({ call, onClose }: { call: OpenCall; onClose: () => vo
                       aria-label="Select for comparison"
                     />
                     <div className="min-w-0 flex-1">
-                      <button onClick={() => navigate(`/pitch/${s.pitch_id}`)} className="text-sm font-bold text-gray-900 hover:text-purple-700 transition text-left">
+                      <button onClick={() => navigate(pitchUrl(s.pitch_id))} className="text-sm font-bold text-gray-900 hover:text-purple-700 transition text-left">
                         {s.pitch_title || `Pitch #${s.pitch_id}`}
                       </button>
                       <div className="text-xs text-gray-500">{s.creator_name || 'Unknown'}{s.pitch_genre ? ` · ${s.pitch_genre}` : ''}</div>
@@ -521,7 +522,7 @@ function SubmissionsModal({ call, onClose }: { call: OpenCall; onClose: () => vo
                     <button onClick={() => setStatus(s, 'shortlisted')} className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-medium bg-amber-50 text-amber-700 hover:bg-amber-100 transition"><Star className="w-3.5 h-3.5" /> Shortlist</button>
                     <button onClick={() => setStatus(s, 'accepted')} className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-medium bg-emerald-50 text-emerald-700 hover:bg-emerald-100 transition"><Check className="w-3.5 h-3.5" /> Accept</button>
                     <button onClick={() => setStatus(s, 'declined')} className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-medium bg-gray-50 text-gray-500 hover:bg-gray-100 transition">Decline</button>
-                    <button onClick={() => navigate(`/pitch/${s.pitch_id}`)} className="ml-auto inline-flex items-center gap-1 text-xs font-semibold text-purple-700 hover:text-purple-900 transition">View pitch <ArrowRight className="w-3.5 h-3.5" /></button>
+                    <button onClick={() => navigate(pitchUrl(s.pitch_id))} className="ml-auto inline-flex items-center gap-1 text-xs font-semibold text-purple-700 hover:text-purple-900 transition">View pitch <ArrowRight className="w-3.5 h-3.5" /></button>
                   </div>
                 </div>
               ))}

--- a/frontend/src/pages/ProductionDashboard.tsx
+++ b/frontend/src/pages/ProductionDashboard.tsx
@@ -28,6 +28,7 @@ import { CompanyJoinCodeCard } from '@features/teams/components/CompanyTeamCards
 import ProductionSlateBoard from '../portals/production/components/ProductionSlateBoard';
 import AudienceDemandRail from '../portals/production/components/AudienceDemandRail';
 import FormatDisplay from '../components/FormatDisplay';
+import { pitchUrl } from '@/utils/pitchUrl';
 import { EnhancedProductionAnalytics } from '@features/analytics/components/Analytics/EnhancedProductionAnalytics';
 import { withPortalErrorBoundary } from '../components/ErrorBoundary/PortalErrorBoundary';
 import { uploadService } from '@features/uploads/services/upload.service';
@@ -1515,7 +1516,7 @@ function ProductionDashboard() {
                               );
                             })()}
                             <Link
-                              to={`/pitch/${pitch.id}`}
+                              to={pitchUrl(pitch)}
                               onClick={(e) => e.stopPropagation()}
                               className="ml-auto flex items-center gap-1 px-3 py-1 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors"
                             >

--- a/frontend/src/pages/ProvenanceVerify.tsx
+++ b/frontend/src/pages/ProvenanceVerify.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { ShieldCheck, ShieldX, Loader2 } from 'lucide-react';
 import { API_URL } from '../config';
+import { pitchUrl } from '@/utils/pitchUrl';
 
 interface VerifyResult {
   sealed: boolean;
@@ -67,7 +68,7 @@ export default function ProvenanceVerify() {
                 <dt className="text-gray-400">Pitch</dt>
                 <dd className="font-medium text-gray-900">
                   {result.pitch_id
-                    ? <Link to={`/pitch/${result.pitch_id}`} className="text-indigo-600 hover:underline">{result.pitch_title}</Link>
+                    ? <Link to={pitchUrl(result.pitch_id)} className="text-indigo-600 hover:underline">{result.pitch_title}</Link>
                     : result.pitch_title}
                 </dd>
               </div>

--- a/frontend/src/pages/PublicSlate.tsx
+++ b/frontend/src/pages/PublicSlate.tsx
@@ -3,6 +3,7 @@ import { useParams, Link } from 'react-router-dom';
 import { Layers, Film, Eye, Heart, Sparkles, UserPlus } from 'lucide-react';
 import { API_URL } from '../config';
 import { useBetterAuthStore } from '../store/betterAuthStore';
+import { pitchUrl } from '@/utils/pitchUrl';
 
 // Role-aware conversion CTA on the public slate landing (moat #5). The whole point
 // of a tracked share is to convert the recipient — so we tailor the call to action
@@ -195,7 +196,7 @@ export default function PublicSlate() {
             {slate.pitches.map(pitch => (
               <Link
                 key={pitch.id}
-                to={`/pitch/${pitch.id}`}
+                to={pitchUrl(pitch)}
                 className="bg-white rounded-xl shadow-sm hover:shadow-md transition-shadow overflow-hidden group"
               >
                 {pitch.cover_image ? (

--- a/frontend/src/pages/SharedPortfolio.tsx
+++ b/frontend/src/pages/SharedPortfolio.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { BadgeCheck, Film, Eye, Heart, Calendar } from 'lucide-react';
 import { API_URL } from '../config';
+import { pitchUrl } from '@/utils/pitchUrl';
 
 interface Creator {
   id: number;
@@ -169,7 +170,7 @@ export default function SharedPortfolio() {
             {pitches.map(pitch => (
               <Link
                 key={pitch.id}
-                to={`/pitch/${pitch.id}`}
+                to={pitchUrl(pitch)}
                 className="bg-white rounded-xl shadow-sm hover:shadow-md transition-shadow overflow-hidden group"
               >
                 {pitch.cover_image ? (

--- a/frontend/src/portals/creator/pages/CreatorPitchesPublished.tsx
+++ b/frontend/src/portals/creator/pages/CreatorPitchesPublished.tsx
@@ -6,6 +6,7 @@ import {
   Download, Share2, BarChart3, Users, AlertCircle
 } from 'lucide-react';
 import { PitchService, type Pitch } from '@features/pitches/services/pitch.service';
+import { pitchUrl } from '@/utils/pitchUrl';
 
 interface PublishedPitch {
   id: string;
@@ -292,7 +293,7 @@ export default function CreatorPitchesPublished() {
               <div
                 key={pitch.id}
                 className="bg-white rounded-lg shadow-sm border hover:shadow-md transition cursor-pointer"
-                onClick={() => navigate(`/pitch/${pitch.id}`)}
+                onClick={() => navigate(pitchUrl(pitch))}
               >
                 {/* Thumbnail */}
                 <div className="h-48 rounded-t-lg relative overflow-hidden">
@@ -373,7 +374,7 @@ export default function CreatorPitchesPublished() {
                     <button
                       onClick={(e) => {
                         e.stopPropagation();
-                        void navigator.clipboard.writeText(`${window.location.origin}/pitch/${pitch.id}`);
+                        void navigator.clipboard.writeText(`${window.location.origin}${pitchUrl(pitch)}`);
                       }}
                       className="p-2 bg-gray-50 text-gray-600 rounded-lg hover:bg-gray-100 transition"
                     >

--- a/frontend/src/shared/types/index.ts
+++ b/frontend/src/shared/types/index.ts
@@ -58,6 +58,7 @@ export interface Pitch {
   id: number;
   userId: number;
   creatorId?: number;
+  slug?: string | null;
   title: string;
   logline: string;
   genre: PitchGenre;

--- a/frontend/src/utils/pitchUrl.ts
+++ b/frontend/src/utils/pitchUrl.ts
@@ -1,0 +1,18 @@
+// Canonical path to a pitch's public view. Prefers the human slug
+// (/pitch/the-last-frontier) and falls back to the numeric id (/pitch/213) when
+// the slug isn't present on the object — so this is always safe to use, and old
+// numeric links keep working because the backend resolves either form.
+type PitchLike = {
+  id?: number | string | null;
+  slug?: string | null;
+  pitch_id?: number | string | null;
+  pitchId?: number | string | null;
+};
+
+export function pitchUrl(pitch: PitchLike | number | string | null | undefined): string {
+  if (pitch != null && typeof pitch === 'object') {
+    const id = pitch.id ?? pitch.pitch_id ?? pitch.pitchId;
+    return `/pitch/${pitch.slug || id}`;
+  }
+  return `/pitch/${pitch ?? ''}`;
+}

--- a/src/db/migrations/118_pitch_slugs.sql
+++ b/src/db/migrations/118_pitch_slugs.sql
@@ -1,0 +1,66 @@
+-- Human-readable pitch URLs: /pitch/the-last-frontier instead of /pitch/213.
+-- Adds a unique `slug` column, backfills existing pitches from their titles, and
+-- installs a BEFORE INSERT/UPDATE trigger so every new/renamed pitch gets a slug
+-- automatically (no app-path change to the thinly-tested create/update handlers).
+-- The public getPitch handler resolves a slug OR a numeric id, so old /pitch/213
+-- links keep working.
+
+ALTER TABLE pitches ADD COLUMN IF NOT EXISTS slug TEXT;
+
+-- Backfill: slugify(title), dedupe collisions with a -N suffix (ordered by id so
+-- the oldest pitch keeps the clean slug). Empty/garbage titles fall back to
+-- pitch-<id>, which is always unique.
+WITH base AS (
+  SELECT id,
+         NULLIF(trim(both '-' FROM lower(regexp_replace(COALESCE(title, ''), '[^a-zA-Z0-9]+', '-', 'g'))), '') AS s
+  FROM pitches
+  WHERE slug IS NULL
+),
+ranked AS (
+  SELECT id, s, row_number() OVER (PARTITION BY s ORDER BY id) AS rn
+  FROM base
+)
+UPDATE pitches p
+SET slug = CASE
+             WHEN r.s IS NULL   THEN 'pitch-' || p.id
+             WHEN r.rn = 1      THEN left(r.s, 80)
+             ELSE left(r.s, 80) || '-' || r.rn
+           END
+FROM ranked r
+WHERE p.id = r.id AND p.slug IS NULL;
+
+-- Enforce uniqueness (partial: NULL slugs are allowed transiently before the
+-- trigger fills them, and never collide).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pitches_slug ON pitches(slug) WHERE slug IS NOT NULL;
+
+-- Auto-slug trigger. Fires BEFORE INSERT (NEW.id is already assigned from the
+-- SERIAL default at this point) and BEFORE UPDATE when the title changes or the
+-- slug is still empty. On a collision it appends the pitch id, which is always
+-- unique — no loop, concurrency-safe. Clean titles (the common case) keep a clean
+-- slug; only genuine title collisions get an id suffix.
+CREATE OR REPLACE FUNCTION pitches_set_slug() RETURNS trigger AS $$
+DECLARE
+  base text;
+BEGIN
+  IF TG_OP = 'INSERT'
+     OR NEW.title IS DISTINCT FROM OLD.title
+     OR NEW.slug IS NULL THEN
+    base := trim(both '-' FROM lower(regexp_replace(COALESCE(NEW.title, ''), '[^a-zA-Z0-9]+', '-', 'g')));
+    IF base IS NULL OR base = '' THEN
+      base := 'pitch';
+    END IF;
+    base := left(base, 80);
+    NEW.slug := base;
+    IF EXISTS (SELECT 1 FROM pitches WHERE slug = NEW.slug AND id <> NEW.id) THEN
+      NEW.slug := base || '-' || NEW.id;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_pitches_set_slug ON pitches;
+CREATE TRIGGER trg_pitches_set_slug
+  BEFORE INSERT OR UPDATE ON pitches
+  FOR EACH ROW
+  EXECUTE FUNCTION pitches_set_slug();

--- a/src/worker-integrated.ts
+++ b/src/worker-integrated.ts
@@ -6501,13 +6501,25 @@ pitchey_analytics_datapoints_per_minute 1250
     const builder = new ApiResponseBuilder(request);
     const params = (request as any).params;
     const sql = this.db.getSql() as any;
-    const pitchId = params.id;
+    let pitchId = params.id;
 
-    // Guard non-numeric ids (e.g. /api/pitches/NaN from a bad link): a string id
-    // hits an int column → Postgres "invalid input syntax for integer" → 500.
-    // Return 404 instead of crashing.
+    // The public URL now carries a human slug (/pitch/the-last-frontier). A
+    // non-numeric param is treated as a slug and resolved to the numeric id;
+    // numeric ids still work unchanged so old /pitch/213 links never break. A
+    // string id would otherwise hit an int column → Postgres "invalid input
+    // syntax for integer" → 500, so an unresolvable value returns 404 instead.
     if (!/^\d+$/.test(String(pitchId ?? ''))) {
-      return builder.error(ErrorCode.NOT_FOUND, 'Pitch not found');
+      try {
+        const slugRows = await sql`SELECT id FROM pitches WHERE slug = ${String(pitchId ?? '')} LIMIT 1`;
+        if (slugRows && slugRows.length > 0) {
+          pitchId = String(slugRows[0].id);
+        } else {
+          return builder.error(ErrorCode.NOT_FOUND, 'Pitch not found');
+        }
+      } catch {
+        // slug column missing (pre-migration) or lookup failed → 404, never 500.
+        return builder.error(ErrorCode.NOT_FOUND, 'Pitch not found');
+      }
     }
 
     try {


### PR DESCRIPTION
Replaces numeric pitch URLs (`/pitch/213`) with the pitch name (`/pitch/the-last-frontier`). **Already applied + verified live** on prod (worker `e6262045`, frontend `index-pC6MUKJe.js`); this PR tracks the change.

## Backend — migration 118 (applied to prod + recorded in `schema_migrations`)
- Unique `slug` column on `pitches`; backfilled from titles with `-N` dedupe (`Bob`→`bob`, `The Final Test`→`the-final-test`). Prod: **15/15 slugged, 0 dups**.
- **BEFORE INSERT/UPDATE trigger** auto-generates slugs from the title; collisions get an id suffix (concurrency-safe, no loop). Done in the DB so the thinly-tested create/update handlers are untouched — `RETURNING *`/`p.*` pick up the slug automatically.
- `getPitch` resolves a **slug OR numeric id** → old `/pitch/213` links keep working; unresolvable → 404 (never 500).

## Frontend
- `pitchUrl()` helper → `/pitch/${slug || id}` (always id-safe fallback).
- `slug` added to `Pitch` interfaces.
- 18 **public** link sites route via `pitchUrl` (marketplace, homepage, browse, dashboards, profiles, portfolios, slates, search, share-URL). Internal portal routes (`/creator|investor|production/pitch`, `/edit`, `/analytics`) intentionally left numeric.

## Verification (prod, live)
- `GET /api/pitches/bob` → id 4343 ✅
- `GET /api/pitches/4343` (numeric) → still works ✅
- `GET /api/pitches/<bad-slug>` → 404 (not 500) ✅
- `/pitch/bob` serves the SPA (200) ✅
- Migration trigger tested on a throwaway Neon branch: clean slug, collision→id-suffix, empty-title→`pitch`, title-change→regenerate, 0 dup slugs.

## Gates
- Worker type-check gate: **0 errors**.
- Frontend `tsc`: clean.
- Frontend ESLint ratchet: **7149 < 7151 baseline** (net −2).

## Not in scope (still functional via numeric fallback)
- Notification deep-links + internal portal views keep numeric ids (backend resolves either form). Can be upgraded later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)